### PR TITLE
fix: Reference types per-entrypoint

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,19 +7,34 @@
   "types": "index.d.ts",
   "exports": {
     ".": {
-      "import": "./index.js",
-      "require": "./dist/index.cjs",
-      "types": "./index.d.ts"
+      "import": {
+        "types": "./index.d.ts",
+        "default": "./index.js"
+      },
+      "require": {
+        "types": "./dist/index.d.cts",
+        "default": "./dist/index.cjs"
+      }
     },
     "./connect": {
-      "import": "./connect.js",
-      "require": "./dist/connect.cjs",
-      "types": "./connect.d.ts"
+      "import": {
+        "types": "./connect.d.ts",
+        "default": "./connect.js"
+      },
+      "require": {
+        "types": "./dist/connect.d.cts",
+        "default": "./dist/connect.cjs"
+      }
     },
     "./devicedb": {
-      "import": "./devicedb.js",
-      "require": "./dist/devicedb.cjs",
-      "types": "./devicedb.d.ts"
+      "import": {
+        "types": "./devicedb.d.ts",
+        "default": "./devicedb.js"
+      },
+      "require": {
+        "types": "./dist/devicedb.d.cts",
+        "default": "./dist/devicedb.cjs"
+      }
     }
   },
   "module": "index.js",


### PR DESCRIPTION
See https://github.com/seamapi/javascript-http/pull/24 and https://github.com/seamapi/javascript-http/pull/26 