### PR TITLE
fix: Path alias for @seamapi/types/devicedb

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "postbuild:entrypoints": "tsup",
     "build:ts": "tsc --project tsconfig.build.json",
     "prebuild:ts": "del 'index.*' 'connect.*' 'devicedb.*' lib",
-    "postbuild:ts": "tsc-alias --project tsconfig.build.json",
+    "postbuild:ts": "tsc-alias --replacer ./tsc-alias-replacer.cjs --project tsconfig.build.json",
     "typecheck": "tsc",
     "docs:build": "typedoc",
     "lint": "eslint --ignore-path .gitignore .",

--- a/tsc-alias-replacer.cjs
+++ b/tsc-alias-replacer.cjs
@@ -1,4 +1,4 @@
-// UPSTREAM: tsc-alias does not replace paths with @
+// UPSTREAM: tsc-alias does not replace paths which start with @.
 
 const path = require('path')
 
@@ -17,6 +17,7 @@ module.exports.default = ({ orig, file }) => {
     const target = path
       .relative(file, tsPath)
       .replace('./src', '')
+      .replace('.././', '../')
       .replace('.ts', '.js')
     if (path != null) return `from '${target}'`
   }

--- a/tsc-alias-replacer.cjs
+++ b/tsc-alias-replacer.cjs
@@ -1,0 +1,24 @@
+// UPSTREAM: tsc-alias does not replace paths with @
+
+const path = require('path')
+
+const pkg = require('./package.json')
+const tsconfig = require('./tsconfig.json')
+
+const {
+  compilerOptions: { paths = {} },
+} = tsconfig
+
+module.exports.default = ({ orig, file }) => {
+  if (orig.startsWith(`from '${pkg.name}`)) {
+    const key = orig.split("from '")[1].slice(0, -1)
+    const tsPath = paths[key]?.[0]
+    if (tsPath == null) return orig
+    const target = path
+      .relative(file, tsPath)
+      .replace('./src', '')
+      .replace('.ts', '.js')
+    if (path != null) return `from '${target}'`
+  }
+  return orig
+}

--- a/tsc-alias-replacer.cjs
+++ b/tsc-alias-replacer.cjs
@@ -1,4 +1,5 @@
 // UPSTREAM: tsc-alias does not replace paths which start with @.
+// https://github.com/justkey007/tsc-alias/issues/212
 
 const path = require('path')
 


### PR DESCRIPTION
tsc-alias should be replacing references to `@seamapi/types/devicedb`, but this is not working. This replacer handles the replacement.

Reported here https://github.com/justkey007/tsc-alias/issues/212