### PR TITLE
Add blueprint check and updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,24 @@
+---
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: '/'
+    schedule:
+      interval: daily
+    commit-message:
+      prefix: feat
+      include: scope
+    allow:
+      - dependency-name: '@seamapi/blueprint'
+    ignore:
+      - dependency-name: '*'
+        update-types:
+          - 'version-update:semver-major'
+    groups:
+      seam:
+        dependency-type: development
+        patterns:
+          - '@seamapi/blueprint'
+        update-types:
+          - patch
+          - minor

--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -1,0 +1,25 @@
+---
+name: Automerge
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  merge:
+    name: Merge
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    if: github.actor == 'dependabot[bot]'
+    steps:
+      - name: Approve pull request
+        run: gh pr review --approve "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+      - name: Merge pull request
+        run: gh pr merge --auto --merge "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -113,3 +113,16 @@ jobs:
         uses: ./.github/actions/setup
       - name: Build docs
         run: npm run docs:build
+  blueprint:
+    name: Blueprint
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup
+        uses: ./.github/actions/setup
+      - name: Generate blueprint
+        run: npm run blueprint
+      - name: Seam Connect Blueprint
+        run: cat ./tmp/connect-blueprint.json

--- a/blueprint.ts
+++ b/blueprint.ts
@@ -1,0 +1,19 @@
+import { writeFile } from 'node:fs/promises'
+import { join } from 'node:path'
+
+import { createBlueprint, TypesModuleSchema } from '@seamapi/blueprint'
+
+import * as types from '@seamapi/types/connect'
+
+const typesModule = TypesModuleSchema.parse(types)
+
+const blueprint = createBlueprint(typesModule)
+
+const content = JSON.stringify(blueprint, null, 2)
+
+const output = join('tmp', 'connect-blueprint.json')
+
+await writeFile(output, Buffer.from(content))
+
+// eslint-disable-next-line no-console
+console.log(`  Blueprint written to ${output}`)

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.210.0",
       "license": "MIT",
       "devDependencies": {
+        "@seamapi/blueprint": "^0.4.0",
         "@types/node": "^20.8.10",
         "concurrently": "^8.2.0",
         "del-cli": "^5.0.0",
@@ -19,6 +20,7 @@
         "eslint-plugin-node": "^11.1.0",
         "eslint-plugin-simple-import-sort": "^12.0.0",
         "eslint-plugin-unused-imports": "^3.0.0",
+        "mkdirp": "^3.0.1",
         "patch-package": "^8.0.0",
         "prettier": "^3.0.0",
         "tsc-alias": "^1.8.2",
@@ -1050,6 +1052,20 @@
         "win32"
       ]
     },
+    "node_modules/@seamapi/blueprint": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@seamapi/blueprint/-/blueprint-0.4.0.tgz",
+      "integrity": "sha512-js0pAHilLIvC885o7eH4wz1LofsgfwH7Ajs6FP7csH2Z4ZSve44t4OvVT6QhxM8PiJ+KOJzOilsYmB3F27TXUw==",
+      "dev": true,
+      "dependencies": {
+        "change-case": "^5.4.4",
+        "zod": "^3.23.8"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">= 9.0.0"
+      }
+    },
     "node_modules/@types/estree": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.5.tgz",
@@ -1757,6 +1773,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/change-case": {
+      "version": "5.4.4",
+      "resolved": "https://registry.npmjs.org/change-case/-/change-case-5.4.4.tgz",
+      "integrity": "sha512-HRQyTk2/YPEkt9TnUPbOpr64Uw3KOicFWPVBb+xiHvd6eBx/qPr9xqfBFDT8P2vWsvvz4jbEkfDe71W3VyNu2w==",
+      "dev": true
     },
     "node_modules/chokidar": {
       "version": "3.6.0",
@@ -4449,6 +4471,21 @@
         "node": ">=16 || 14 >=14.17"
       }
     },
+    "node_modules/mkdirp": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-3.0.1.tgz",
+      "integrity": "sha512-+NsyUUAZDmo6YVHzL/stxSu3t9YS1iljliy3BSDrXJ/dkn1KYdmtZODGGjLcc9XLgVVpH4KshHB8XmZgMhaBXg==",
+      "dev": true,
+      "bin": {
+        "mkdirp": "dist/cjs/src/bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
@@ -6337,9 +6374,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "3.22.4",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.22.4.tgz",
-      "integrity": "sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg==",
+      "version": "3.23.8",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.23.8.tgz",
+      "integrity": "sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==",
       "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/package.json
+++ b/package.json
@@ -75,6 +75,8 @@
     "postbuild:ts": "tsc-alias --replacer ./tsc-alias-replacer.cjs --project tsconfig.build.json",
     "typecheck": "tsc",
     "docs:build": "typedoc",
+    "blueprint": "tsx ./blueprint.ts",
+    "preblueprint": "mkdirp tmp",
     "lint": "eslint --ignore-path .gitignore .",
     "prelint": "prettier --check --ignore-path .gitignore .",
     "postversion": "git push --follow-tags",
@@ -90,6 +92,7 @@
     "zod": "^3.21.4"
   },
   "devDependencies": {
+    "@seamapi/blueprint": "^0.4.0",
     "@types/node": "^20.8.10",
     "concurrently": "^8.2.0",
     "del-cli": "^5.0.0",
@@ -100,6 +103,7 @@
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-simple-import-sort": "^12.0.0",
     "eslint-plugin-unused-imports": "^3.0.0",
+    "mkdirp": "^3.0.1",
     "patch-package": "^8.0.0",
     "prettier": "^3.0.0",
     "tsc-alias": "^1.8.2",

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -11,5 +11,5 @@
   },
   "files": ["src/index.ts", "src/connect.ts", "src/devicedb.ts"],
   "include": ["src/**/*"],
-  "exclude": ["tsup.config.ts"]
+  "exclude": ["tsup.config.ts", "blueprint.ts"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -31,5 +31,5 @@
     }
   },
   "files": ["src/index.ts", "src/connect.ts"],
-  "include": ["src/**/*", "tsup.config.ts"]
+  "include": ["src/**/*", "tsup.config.ts", "blueprint.ts"]
 }


### PR DESCRIPTION
- **Test blueprint generation**
- **Add dependabot support with automerge for blueprint**

This ensures that type updates are compatible with the latest blueprint version. By checking this here, we limit the chance that a type update will break code and doc generation in downstream repos.
