### PR TITLE
fix: add missing step id to publish workflow

### DIFF
--- a/.github/workflows/_publish.yml
+++ b/.github/workflows/_publish.yml
@@ -44,6 +44,7 @@ jobs:
         id: meta
         run: echo "tgz=$(ls *.tgz | head -n1)" >> $GITHUB_OUTPUT
       - name: Publish
+        id: publish
         uses: JS-DevTools/npm-publish@v4
         with:
           access: public


### PR DESCRIPTION
## Summary

- The npm-publish step in `_publish.yml` was missing `id: publish`, so `steps.publish.outputs.version` always resolved to an empty string
- This caused the `pr-docs` and `pr-javascript-http` jobs in `publish.yml` to create branches named `seamapi/types/` (trailing slash) — an invalid git ref that fails with `fatal: 'seamapi/types/' is not a valid branch name`
- The fix is adding `id: publish` to the step so the version output propagates correctly

## What broke

Every `@seamapi/types` release since the `id` was lost has failed to open auto-bump PRs on `seamapi/docs` and `seamapi/javascript-http`. The docs repo's Dependabot is a fallback, but [PR #1107](https://github.com/seamapi/docs/pull/1107) on docs has been stuck open for 6+ weeks, blocking new Dependabot PRs.

## Fix

One line: `id: publish` on the npm-publish step in `_publish.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)