### PR TITLE
fix: drop legacy /latest segment from docs links in descriptions

### DIFF
--- a/src/lib/seam/connect/models/access-codes/managed-access-code.ts
+++ b/src/lib/seam/connect/models/access-codes/managed-access-code.ts
@@ -365,7 +365,7 @@ const access_code_error = z
     replaced_by_newer_access_code,
   ])
   .describe(
-    'Errors associated with the [access code](https://docs.seam.co/latest/capability-guides/smart-locks/access-codes).',
+    'Errors associated with the [access code](https://docs.seam.co/capability-guides/smart-locks/access-codes).',
   )
 
 export type AccessCodeError = z.infer<typeof access_code_error>
@@ -645,7 +645,7 @@ const access_code_warning = z
     being_deleted,
   ])
   .describe(
-    'Warnings associated with the [access code](https://docs.seam.co/latest/capability-guides/smart-locks/access-codes).',
+    'Warnings associated with the [access code](https://docs.seam.co/capability-guides/smart-locks/access-codes).',
   )
 
 export type AccessCodeWarning = z.infer<typeof access_code_warning>
@@ -814,7 +814,7 @@ export const access_code = z.object({
           provider_metadata:
             name: Provider Metadata
         ---
-        Errors associated with the [access code](https://docs.seam.co/latest/capability-guides/smart-locks/access-codes).
+        Errors associated with the [access code](https://docs.seam.co/capability-guides/smart-locks/access-codes).
       `),
   warnings: z.array(access_code_warning).describe(`
         ---
@@ -834,7 +834,7 @@ export const access_code = z.object({
           provider_metadata:
             name: Provider Metadata
         ---
-        Warnings associated with the [access code](https://docs.seam.co/latest/capability-guides/smart-locks/access-codes).
+        Warnings associated with the [access code](https://docs.seam.co/capability-guides/smart-locks/access-codes).
       `),
   is_managed: z
     .literal(true)
@@ -858,7 +858,7 @@ export const access_code = z.object({
   status: z
     .enum(['setting', 'set', 'unset', 'removing', 'unknown'])
     .describe(
-      'Current status of the access code within the operational lifecycle. Values are `setting`, a transitional phase that indicates that the code is being configured or activated; `set`, which indicates that the code is active and operational; `unset`, which indicates a deactivated or unused state, either before activation or after deliberate deactivation; `removing`, which indicates a transitional period in which the code is being deleted or made inactive; and `unknown`, which indicates an indeterminate state, due to reasons such as system errors or incomplete data, that highlights a potential need for system review or troubleshooting. See also [Lifecycle of Access Codes](https://docs.seam.co/latest/capability-guides/smart-locks/access-codes/lifecycle-of-access-codes).',
+      'Current status of the access code within the operational lifecycle. Values are `setting`, a transitional phase that indicates that the code is being configured or activated; `set`, which indicates that the code is active and operational; `unset`, which indicates a deactivated or unused state, either before activation or after deliberate deactivation; `removing`, which indicates a transitional period in which the code is being deleted or made inactive; and `unknown`, which indicates an indeterminate state, due to reasons such as system errors or incomplete data, that highlights a potential need for system review or troubleshooting. See also [Lifecycle of Access Codes](https://docs.seam.co/capability-guides/smart-locks/access-codes/lifecycle-of-access-codes).',
     ),
   is_backup_access_code_available: z
     .boolean()
@@ -907,13 +907,13 @@ export const access_code = z.object({
   ---
   route_path: /access_codes
   ---
-  Represents a smart lock [access code](https://docs.seam.co/latest/capability-guides/smart-locks/access-codes).
+  Represents a smart lock [access code](https://docs.seam.co/capability-guides/smart-locks/access-codes).
 
   An access code is a code used for a keypad or pinpad device. Unlike physical keys, which can easily be lost or duplicated, PIN codes can be customized, tracked, and altered on the fly. Using the Seam Access Code API, you can easily generate access codes on the hundreds of door lock models with which we integrate.
 
-  Seam supports programming two types of access codes: [ongoing](https://docs.seam.co/latest/capability-guides/smart-locks/access-codes#ongoing-access-codes) and [time-bound](https://docs.seam.co/latest/capability-guides/smart-locks/access-codes#time-bound-access-codes). To differentiate between the two, refer to the \`type\` property of the access code. Ongoing codes display as \`ongoing\`, whereas time-bound codes are labeled \`time_bound\`. An ongoing access code is active, until it has been removed from the device. To specify an ongoing access code, leave both \`starts_at\` and \`ends_at\` empty. A time-bound access code will be programmed at the \`starts_at\` time and removed at the \`ends_at\` time.
+  Seam supports programming two types of access codes: [ongoing](https://docs.seam.co/capability-guides/smart-locks/access-codes#ongoing-access-codes) and [time-bound](https://docs.seam.co/capability-guides/smart-locks/access-codes#time-bound-access-codes). To differentiate between the two, refer to the \`type\` property of the access code. Ongoing codes display as \`ongoing\`, whereas time-bound codes are labeled \`time_bound\`. An ongoing access code is active, until it has been removed from the device. To specify an ongoing access code, leave both \`starts_at\` and \`ends_at\` empty. A time-bound access code will be programmed at the \`starts_at\` time and removed at the \`ends_at\` time.
 
-  In addition, for certain devices, Seam also supports [offline access codes](https://docs.seam.co/latest/capability-guides/smart-locks/access-codes#offline-access-codes). Offline access (PIN) codes are designed for door locks that might not always maintain an internet connection. For this type of access code, the device manufacturer uses encryption keys (tokens) to create server-based registries of algorithmically-generated offline PIN codes. Because the tokens remain synchronized with the managed devices, the locks do not require an active internet connection—and you do not need to be near the locks—to create an offline access code. Then, owners or managers can share these offline codes with users through a variety of mechanisms, such as messaging applications. That is, lock users do not need to install a smartphone application to receive an offline access code.
+  In addition, for certain devices, Seam also supports [offline access codes](https://docs.seam.co/capability-guides/smart-locks/access-codes#offline-access-codes). Offline access (PIN) codes are designed for door locks that might not always maintain an internet connection. For this type of access code, the device manufacturer uses encryption keys (tokens) to create server-based registries of algorithmically-generated offline PIN codes. Because the tokens remain synchronized with the managed devices, the locks do not require an active internet connection—and you do not need to be near the locks—to create an offline access code. Then, owners or managers can share these offline codes with users through a variety of mechanisms, such as messaging applications. That is, lock users do not need to install a smartphone application to receive an offline access code.
 `)
 
 export type AccessCode = z.infer<typeof access_code>

--- a/src/lib/seam/connect/models/access-codes/unmanaged-access-code.ts
+++ b/src/lib/seam/connect/models/access-codes/unmanaged-access-code.ts
@@ -51,7 +51,7 @@ export const unmanaged_access_code = access_code
     ---
     route_path: /access_codes/unmanaged
     ---
-    Represents an [unmanaged smart lock access code](https://docs.seam.co/latest/capability-guides/smart-locks/access-codes/migrating-existing-access-codes).
+    Represents an [unmanaged smart lock access code](https://docs.seam.co/capability-guides/smart-locks/access-codes/migrating-existing-access-codes).
 
     An access code is a code used for a keypad or pinpad device. Unlike physical keys, which can easily be lost or duplicated, PIN codes can be customized, tracked, and altered on the fly.
 
@@ -61,7 +61,7 @@ export const unmanaged_access_code = access_code
 
     Not all providers support unmanaged access codes. The following providers do not support unmanaged access codes:
 
-    - [Kwikset](https://docs.seam.co/latest/device-and-system-integration-guides/kwikset-locks)
+    - [Kwikset](https://docs.seam.co/device-and-system-integration-guides/kwikset-locks)
   `)
 
 export type UnmanagedAccessCode = z.infer<typeof unmanaged_access_code>

--- a/src/lib/seam/connect/models/access-grants/access-grant.ts
+++ b/src/lib/seam/connect/models/access-grants/access-grant.ts
@@ -64,7 +64,7 @@ const being_deleted = common_access_grant_warning
     warning_code: z.literal('being_deleted').describe(warning_code_description),
   })
   .describe(
-    'Indicates that the [access grant](https://docs.seam.co/latest/capability-guides/access-grants) is being deleted.',
+    'Indicates that the [access grant](https://docs.seam.co/capability-guides/access-grants) is being deleted.',
   )
 
 const underprovisioned_access = common_access_grant_warning
@@ -118,7 +118,7 @@ const updating_access_times = common_access_grant_warning
       .describe('IDs of the access methods being updated.'),
   })
   .describe(
-    'Indicates that the access times for this [access grant](https://docs.seam.co/latest/capability-guides/access-grants) are being updated.',
+    'Indicates that the access times for this [access grant](https://docs.seam.co/capability-guides/access-grants) are being updated.',
   )
 
 const requested_code_unavailable = common_access_grant_warning
@@ -191,7 +191,7 @@ const access_grant_warning = z
     device_time_constraints_violated,
   ])
   .describe(
-    'Warning associated with the [access grant](https://docs.seam.co/latest/capability-guides/access-grants).',
+    'Warning associated with the [access grant](https://docs.seam.co/capability-guides/access-grants).',
   )
 
 const _access_grant_warning_map = z.object({
@@ -283,12 +283,12 @@ export const access_grant = z.object({
   warnings: z
     .array(access_grant_warning)
     .describe(
-      'Warnings associated with the [access grant](https://docs.seam.co/latest/capability-guides/access-grants).',
+      'Warnings associated with the [access grant](https://docs.seam.co/capability-guides/access-grants).',
     ),
   errors: z
     .array(access_grant_error)
     .describe(
-      'Errors associated with the [access grant](https://docs.seam.co/latest/capability-guides/access-grants).',
+      'Errors associated with the [access grant](https://docs.seam.co/capability-guides/access-grants).',
     ),
   customization_profile_id: z
     .string()

--- a/src/lib/seam/connect/models/access-grants/access-method.ts
+++ b/src/lib/seam/connect/models/access-grants/access-method.ts
@@ -20,7 +20,7 @@ const being_deleted = common_access_method_warning
     warning_code: z.literal('being_deleted').describe(warning_code_description),
   })
   .describe(
-    'Indicates that the [access method](https://docs.seam.co/latest/capability-guides/access-grants/delivering-access-methods) is being deleted.',
+    'Indicates that the [access method](https://docs.seam.co/capability-guides/access-grants/delivering-access-methods) is being deleted.',
   )
 
 const updating_access_times_warning = common_access_method_warning
@@ -30,7 +30,7 @@ const updating_access_times_warning = common_access_method_warning
       .describe(warning_code_description),
   })
   .describe(
-    'Indicates that the access times for this [access method](https://docs.seam.co/latest/capability-guides/access-grants/delivering-access-methods) are being updated.',
+    'Indicates that the access times for this [access method](https://docs.seam.co/capability-guides/access-grants/delivering-access-methods) are being updated.',
   )
 
 const pulled_backup_access_code_warning = common_access_method_warning
@@ -57,7 +57,7 @@ const access_method_warning = z
     pulled_backup_access_code_warning,
   ])
   .describe(
-    'Warning associated with the [access method](https://docs.seam.co/latest/capability-guides/access-grants/delivering-access-methods).',
+    'Warning associated with the [access method](https://docs.seam.co/capability-guides/access-grants/delivering-access-methods).',
   )
 
 const _access_method_warning_map = z.object({
@@ -277,12 +277,12 @@ export const access_method = z.object({
   warnings: z
     .array(access_method_warning)
     .describe(
-      'Warnings associated with the [access method](https://docs.seam.co/latest/capability-guides/access-grants/delivering-access-methods).',
+      'Warnings associated with the [access method](https://docs.seam.co/capability-guides/access-grants/delivering-access-methods).',
     ),
   pending_mutations: z
     .array(access_method_pending_mutations)
     .describe(
-      'Pending mutations for the [access method](https://docs.seam.co/latest/capability-guides/access-grants/delivering-access-methods). Indicates operations that are in progress.',
+      'Pending mutations for the [access method](https://docs.seam.co/capability-guides/access-grants/delivering-access-methods). Indicates operations that are in progress.',
     ),
   customization_profile_id: z
     .string()

--- a/src/lib/seam/connect/models/acs/acs-access-group.ts
+++ b/src/lib/seam/connect/models/acs/acs-access-group.ts
@@ -42,7 +42,7 @@ const acs_access_groups_failed_to_create_on_acs_system =
         .describe(error_code_description),
     })
     .describe(
-      `Indicates that the [access group](https://docs.seam.co/latest/capability-guides/access-systems/user-management/assigning-users-to-access-groups) was not created on the [access system](https://docs.seam.co/latest/capability-guides/access-systems). This is likely due to an internal unexpected error. Contact Seam [support](mailto:support@seam.co).`,
+      `Indicates that the [access group](https://docs.seam.co/capability-guides/access-systems/user-management/assigning-users-to-access-groups) was not created on the [access system](https://docs.seam.co/capability-guides/access-systems). This is likely due to an internal unexpected error. Contact Seam [support](mailto:support@seam.co).`,
     )
 
 const acs_access_group_errors = z
@@ -119,13 +119,13 @@ const common_acs_access_group = z.object({
     .string()
     .uuid()
     .describe(
-      'ID of the [workspace](https://docs.seam.co/latest/core-concepts/workspaces) that contains the access group.',
+      'ID of the [workspace](https://docs.seam.co/core-concepts/workspaces) that contains the access group.',
     ),
   connected_account_id: z
     .string()
     .uuid()
     .describe(
-      'ID of the [connected account](https://docs.seam.co/latest/core-concepts/connected-accounts) that contains the access group.',
+      'ID of the [connected account](https://docs.seam.co/core-concepts/connected-accounts) that contains the access group.',
     ),
   name: z.string().describe('Name of the access group.'),
   access_group_type: acs_access_group_external_type.describe(`
@@ -177,9 +177,9 @@ export const acs_access_group = common_acs_access_group.extend({
     ---
     Group that defines the entrances to which a set of users has access and, in some cases, the access schedule for these entrances and users.
 
-    Some access control systems use [access group](https://docs.seam.co/latest/capability-guides/access-systems/user-management/assigning-users-to-access-groups), which are sets of users, combined with sets of permissions. These permissions include both the set of areas or assets that the users can access and the schedule during which the users can access these areas or assets. Instead of assigning access rights individually to each access control system user, which can be time-consuming and error-prone, administrators can assign users to an access group, thereby ensuring that the users inherit all the permissions associated with the access group. Using access groups streamlines the process of managing large numbers of access control system users, especially in bigger organizations or complexes.
+    Some access control systems use [access group](https://docs.seam.co/capability-guides/access-systems/user-management/assigning-users-to-access-groups), which are sets of users, combined with sets of permissions. These permissions include both the set of areas or assets that the users can access and the schedule during which the users can access these areas or assets. Instead of assigning access rights individually to each access control system user, which can be time-consuming and error-prone, administrators can assign users to an access group, thereby ensuring that the users inherit all the permissions associated with the access group. Using access groups streamlines the process of managing large numbers of access control system users, especially in bigger organizations or complexes.
 
-    To learn whether your access control system supports access groups, see the corresponding [system integration guide](https://docs.seam.co/latest/device-and-system-integration-guides#access-control-systems).
+    To learn whether your access control system supports access groups, see the corresponding [system integration guide](https://docs.seam.co/device-and-system-integration-guides#access-control-systems).
   `)
 export const unmanaged_acs_access_group = common_acs_access_group.extend({
   is_managed: z.literal(false),

--- a/src/lib/seam/connect/models/acs/acs-credential-provisioning-automation.ts
+++ b/src/lib/seam/connect/models/acs/acs-credential-provisioning-automation.ts
@@ -23,13 +23,13 @@ export const enrollment_automation = z.object({
     .string()
     .uuid()
     .describe(
-      'ID of the associated [ACS system](https://docs.seam.co/latest/capability-guides/access-systems) that serves as the credential manager.',
+      'ID of the associated [ACS system](https://docs.seam.co/capability-guides/access-systems) that serves as the credential manager.',
     ),
   user_identity_id: z
     .string()
     .uuid()
     .describe(
-      'ID of the associated [user identity](https://docs.seam.co/latest/capability-guides/mobile-access/managing-mobile-app-user-accounts-with-user-identities#what-is-a-user-identity).',
+      'ID of the associated [user identity](https://docs.seam.co/capability-guides/mobile-access/managing-mobile-app-user-accounts-with-user-identities#what-is-a-user-identity).',
     ),
   created_at: z
     .string()
@@ -39,14 +39,14 @@ export const enrollment_automation = z.object({
     .string()
     .uuid()
     .describe(
-      'ID of the [workspace](https://docs.seam.co/latest/core-concepts/workspaces) that contains the enrollment automation.',
+      'ID of the [workspace](https://docs.seam.co/core-concepts/workspaces) that contains the enrollment automation.',
     ),
 }).describe(`
   ---
   route_path: /user_identities/enrollment_automations
   undocumented: Will be removed.
   ---
-  Represents an [enrollment automation](https://docs.seam.co/latest/capability-guides/mobile-access/issuing-mobile-credentials-from-an-access-control-system) within the [Seam mobile access solution](https://docs.seam.co/latest/capability-guides/mobile-access/).
+  Represents an [enrollment automation](https://docs.seam.co/capability-guides/mobile-access/issuing-mobile-credentials-from-an-access-control-system) within the [Seam mobile access solution](https://docs.seam.co/capability-guides/mobile-access/).
 `)
 
 export type EnrollmentAutomation = z.output<typeof enrollment_automation>

--- a/src/lib/seam/connect/models/acs/acs-credential.ts
+++ b/src/lib/seam/connect/models/acs/acs-credential.ts
@@ -54,7 +54,7 @@ const waiting_to_be_issued = common_acs_credential_warning
       .describe(warning_code_description),
   })
   .describe(
-    'Indicates that the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials) is waiting to be issued.',
+    'Indicates that the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials) is waiting to be issued.',
   )
 
 const schedule_externally_modified = common_acs_credential_warning
@@ -64,7 +64,7 @@ const schedule_externally_modified = common_acs_credential_warning
       .describe(warning_code_description),
   })
   .describe(
-    "Indicates that the schedule of one of the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials)'s children was modified externally.",
+    "Indicates that the schedule of one of the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials)'s children was modified externally.",
   )
 
 const schedule_modified = common_acs_credential_warning
@@ -74,7 +74,7 @@ const schedule_modified = common_acs_credential_warning
       .describe(warning_code_description),
   })
   .describe(
-    'Indicates that the schedule of the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials) was modified to avoid creating a credential with a start date in the past.',
+    'Indicates that the schedule of the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials) was modified to avoid creating a credential with a start date in the past.',
   )
 
 const being_deleted = common_acs_credential_warning
@@ -82,7 +82,7 @@ const being_deleted = common_acs_credential_warning
     warning_code: z.literal('being_deleted').describe(warning_code_description),
   })
   .describe(
-    'Indicates that the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials) is being deleted.',
+    'Indicates that the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials) is being deleted.',
   )
 
 export const unknown_issue_with_acs_credential = common_acs_credential_warning
@@ -92,7 +92,7 @@ export const unknown_issue_with_acs_credential = common_acs_credential_warning
       .describe(warning_code_description),
   })
   .describe(
-    'An unknown issue occurred while syncing the state of the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials) with the provider. This issue may affect the proper functioning of the credential.',
+    'An unknown issue occurred while syncing the state of the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials) with the provider. This issue may affect the proper functioning of the credential.',
   )
 
 const needs_to_be_reissued = common_acs_credential_warning
@@ -102,7 +102,7 @@ const needs_to_be_reissued = common_acs_credential_warning
       .describe(warning_code_description),
   })
   .describe(
-    'Access permissions for the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials) have changed. [Reissue](https://docs.seam.co/latest/capability-guides/access-systems/working-with-card-encoders-and-scanners/creating-and-encoding-card-based-credentials) (re-encode) the credential. This issue may affect the proper functioning of the credential.',
+    'Access permissions for the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials) have changed. [Reissue](https://docs.seam.co/capability-guides/access-systems/working-with-card-encoders-and-scanners/creating-and-encoding-card-based-credentials) (re-encode) the credential. This issue may affect the proper functioning of the credential.',
   )
 
 const acs_credential_warning = z
@@ -115,7 +115,7 @@ const acs_credential_warning = z
     needs_to_be_reissued,
   ])
   .describe(
-    'Warning associated with the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials).',
+    'Warning associated with the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials).',
   )
 
 const _acs_credential_warning_map = z.object({
@@ -140,73 +140,73 @@ const common_acs_credential = z.object({
     .string()
     .uuid()
     .describe(
-      'ID of the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials).',
+      'ID of the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials).',
     ),
   acs_user_id: z
     .string()
     .uuid()
     .optional()
     .describe(
-      'ID of the [ACS user](https://docs.seam.co/latest/capability-guides/access-systems/user-management) to whom the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials) belongs.',
+      'ID of the [ACS user](https://docs.seam.co/capability-guides/access-systems/user-management) to whom the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials) belongs.',
     ),
   user_identity_id: z
     .string()
     .uuid()
     .optional()
     .describe(
-      'ID of the [user identity](https://docs.seam.co/latest/api/user_identities) to whom the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials) belongs.',
+      'ID of the [user identity](https://docs.seam.co/api/user_identities) to whom the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials) belongs.',
     ),
   connected_account_id: z
     .string()
     .uuid()
     .describe(
-      'ID of the [connected account](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials#connected-accounts) to which the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials) belongs.',
+      'ID of the [connected account](https://docs.seam.co/capability-guides/access-systems/managing-credentials#connected-accounts) to which the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials) belongs.',
     ),
   acs_credential_pool_id: z.string().uuid().optional(),
   acs_system_id: z
     .string()
     .uuid()
     .describe(
-      'ID of the [access control system](https://docs.seam.co/latest/capability-guides/access-systems) that contains the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials).',
+      'ID of the [access control system](https://docs.seam.co/capability-guides/access-systems) that contains the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials).',
     ),
   parent_acs_credential_id: z
     .string()
     .uuid()
     .optional()
     .describe(
-      'ID of the parent [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials).',
+      'ID of the parent [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials).',
     ),
   display_name: z
     .string()
     .min(1)
     .describe(
-      'Display name that corresponds to the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials) type.',
+      'Display name that corresponds to the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials) type.',
     ),
   code: z
     .string()
     .optional()
     .nullable()
     .describe(
-      'Access (PIN) code for the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials).',
+      'Access (PIN) code for the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials).',
     ),
   is_one_time_use: z
     .boolean()
     .optional()
     .describe(
-      'Indicates whether the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials) can only be used once. If `true`, the code becomes invalid after the first use.',
+      'Indicates whether the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials) can only be used once. If `true`, the code becomes invalid after the first use.',
     ),
   card_number: z
     .string()
     .optional()
     .nullable()
     .describe(
-      'Number of the card associated with the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials).',
+      'Number of the card associated with the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials).',
     ),
   is_issued: z
     .boolean()
     .optional()
     .describe(
-      'Indicates whether the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials) has been encoded onto a card.',
+      'Indicates whether the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials) has been encoded onto a card.',
     ),
   issued_at: z
     .string()
@@ -214,45 +214,45 @@ const common_acs_credential = z.object({
     .optional()
     .nullable()
     .describe(
-      'Date and time at which the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials) was encoded onto a card.',
+      'Date and time at which the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials) was encoded onto a card.',
     ),
   access_method: acs_credential_access_method_type.describe(
-    'Access method for the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials). Supported values: `code`, `card`, `mobile_key`, `cloud_key`.',
+    'Access method for the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials). Supported values: `code`, `card`, `mobile_key`, `cloud_key`.',
   ),
   external_type: acs_credential_external_type
     .optional()
     .describe(
-      'Brand-specific terminology for the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials) type. Supported values: `pti_card`, `brivo_credential`, `hid_credential`, `visionline_card`.',
+      'Brand-specific terminology for the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials) type. Supported values: `pti_card`, `brivo_credential`, `hid_credential`, `visionline_card`.',
     ),
   external_type_display_name: z
     .string()
     .optional()
     .describe(
-      'Display name that corresponds to the brand-specific terminology for the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials) type.',
+      'Display name that corresponds to the brand-specific terminology for the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials) type.',
     ),
   created_at: z
     .string()
     .datetime()
     .describe(
-      'Date and time at which the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials) was created.',
+      'Date and time at which the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials) was created.',
     ),
   workspace_id: z
     .string()
     .uuid()
     .describe(
-      'ID of the [workspace](https://docs.seam.co/latest/core-concepts/workspaces) that contains the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials).',
+      'ID of the [workspace](https://docs.seam.co/core-concepts/workspaces) that contains the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials).',
     ),
   starts_at: z
     .string()
     .optional()
     .describe(
-      'Date and time at which the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials) validity starts, in [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) format.',
+      'Date and time at which the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials) validity starts, in [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) format.',
     ),
   ends_at: z
     .string()
     .optional()
     .describe(
-      'Date and time at which the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials) validity ends, in [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) format. Must be a time in the future and after `starts_at`.',
+      'Date and time at which the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials) validity ends, in [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) format. Must be a time in the future and after `starts_at`.',
     ),
   errors: z
     .array(
@@ -262,25 +262,25 @@ const common_acs_credential = z.object({
       }),
     )
     .describe(
-      'Errors associated with the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials).',
+      'Errors associated with the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials).',
     ),
   warnings: z
     .array(acs_credential_warning)
     .describe(
-      'Warnings associated with the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials).',
+      'Warnings associated with the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials).',
     ),
   is_multi_phone_sync_credential: z
     .boolean()
     .optional()
     .describe(
-      'Indicates whether the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials) is a [multi-phone sync credential](https://docs.seam.co/latest/capability-guides/mobile-access/issuing-mobile-credentials-from-an-access-control-system#what-are-multi-phone-sync-credentials).',
+      'Indicates whether the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials) is a [multi-phone sync credential](https://docs.seam.co/capability-guides/mobile-access/issuing-mobile-credentials-from-an-access-control-system#what-are-multi-phone-sync-credentials).',
     ),
   is_latest_desired_state_synced_with_provider: z
     .boolean()
     .nullable()
     .optional()
     .describe(
-      'Indicates whether the latest state of the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials) has been synced from Seam to the provider.',
+      'Indicates whether the latest state of the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials) has been synced from Seam to the provider.',
     ),
   latest_desired_state_synced_with_provider_at: z
     .string()
@@ -288,17 +288,17 @@ const common_acs_credential = z.object({
     .nullable()
     .optional()
     .describe(
-      'Date and time at which the state of the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials) was most recently synced from Seam to the provider.',
+      'Date and time at which the state of the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials) was most recently synced from Seam to the provider.',
     ),
   visionline_metadata: acs_credential_visionline_metadata
     .optional()
     .describe(
-      'Visionline-specific metadata for the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials).',
+      'Visionline-specific metadata for the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials).',
     ),
   assa_abloy_vostio_metadata: acs_credential_vostio_metadata
     .optional()
     .describe(
-      'Vostio-specific metadata for the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials).',
+      'Vostio-specific metadata for the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials).',
     ),
 })
 
@@ -310,7 +310,7 @@ export const acs_credential = common_acs_credential.merge(
   ---
   route_path: /acs/credentials
   ---
-  Means by which an [access control system user](https://docs.seam.co/latest/capability-guides/access-systems/user-management) gains access at an [entrance](https://docs.seam.co/latest/capability-guides/access-systems/retrieving-entrance-details). The \`acs_credential\` object represents a [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials) that provides an ACS user access within an [access control system](https://docs.seam.co/latest/capability-guides/access-systems).
+  Means by which an [access control system user](https://docs.seam.co/capability-guides/access-systems/user-management) gains access at an [entrance](https://docs.seam.co/capability-guides/access-systems/retrieving-entrance-details). The \`acs_credential\` object represents a [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials) that provides an ACS user access within an [access control system](https://docs.seam.co/capability-guides/access-systems).
 
   An access control system generally uses digital means of access to authorize a user trying to get through a specific entrance. Examples of credentials include plastic key cards, mobile keys, biometric identifiers, and PIN codes. The electronic nature of these credentials, as well as the fact that access is centralized, enables both the rapid provisioning and rescinding of access and the ability to compile access audit logs.
 
@@ -326,7 +326,7 @@ export const unmanaged_acs_credential = common_acs_credential.merge(
   route_path: /acs/credentials/unmanaged
   undocumented: Unreleased.
   ---
-  Means by which an [ACS user](https://docs.seam.co/latest/capability-guides/access-systems/user-management) gains access at an [entrance](https://docs.seam.co/latest/capability-guides/access-systems/retrieving-entrance-details). The \`unmanaged_acs_credential\` object, which is not managed by Seam, represents a [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials) that provides an ACS user access within an [access control system](https://docs.seam.co/latest/capability-guides/access-systems). For each \`acs_credential\` object, you define the access method. You can also specify additional properties, such as a PIN code.
+  Means by which an [ACS user](https://docs.seam.co/capability-guides/access-systems/user-management) gains access at an [entrance](https://docs.seam.co/capability-guides/access-systems/retrieving-entrance-details). The \`unmanaged_acs_credential\` object, which is not managed by Seam, represents a [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials) that provides an ACS user access within an [access control system](https://docs.seam.co/capability-guides/access-systems). For each \`acs_credential\` object, you define the access method. You can also specify additional properties, such as a PIN code.
 `)
 
 export const acs_credential_on_encoder = z.object({
@@ -335,7 +335,7 @@ export const acs_credential_on_encoder = z.object({
     .datetime()
     .nullable()
     .describe(
-      'Date and time at which the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials) was created.',
+      'Date and time at which the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials) was created.',
     ),
 
   is_issued: z.boolean().nullable(),
@@ -345,21 +345,21 @@ export const acs_credential_on_encoder = z.object({
     .datetime()
     .nullable()
     .describe(
-      'Date and time at which the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials) becomes usable.',
+      'Date and time at which the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials) becomes usable.',
     ),
   ends_at: z
     .string()
     .datetime()
     .nullable()
     .describe(
-      'Date and time at which the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials) will stop being usable.',
+      'Date and time at which the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials) will stop being usable.',
     ),
 
   card_number: z
     .string()
     .nullable()
     .describe(
-      'A number or string that physically identifies the card associated with the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials).',
+      'A number or string that physically identifies the card associated with the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials).',
     ),
 
   visionline_metadata: z
@@ -367,76 +367,76 @@ export const acs_credential_on_encoder = z.object({
       card_id: z
         .string()
         .describe(
-          'Card ID for the Visionline card associated with the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials).',
+          'Card ID for the Visionline card associated with the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials).',
         ),
       // TODO card_function_type: z.enum(["guest", "staff"]), // computed, looks at door ops, and checks is guest op is present.
 
       cancelled: z
         .boolean()
         .describe(
-          'Indicates whether the card associated with the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials) is cancelled.',
+          'Indicates whether the card associated with the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials) is cancelled.',
         ),
       discarded: z
         .boolean()
         .describe(
-          'Indicates whether the card associated with the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials) is discarded.',
+          'Indicates whether the card associated with the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials) is discarded.',
         ),
       expired: z
         .boolean()
         .describe(
-          'Indicates whether the card associated with the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials) is expired.',
+          'Indicates whether the card associated with the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials) is expired.',
         ),
       overwritten: z
         .boolean()
         .describe(
-          'Indicates whether the card associated with the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials) is overwritten.',
+          'Indicates whether the card associated with the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials) is overwritten.',
         ),
       overridden: z
         .boolean()
         .optional()
         .describe(
-          'Indicates whether the card associated with the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials) is overridden.',
+          'Indicates whether the card associated with the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials) is overridden.',
         ),
       pending_auto_update: z
         .boolean()
         .describe(
-          'Indicates whether the card associated with the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials) is pending auto-update.',
+          'Indicates whether the card associated with the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials) is pending auto-update.',
         ),
 
       card_format: z
         .enum(['TLCode', 'rfid48'])
         .describe(
-          'Format of the card associated with the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials).',
+          'Format of the card associated with the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials).',
         ),
       card_holder: z
         .string()
         .optional()
         .describe(
-          'Holder of the card associated with the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials).',
+          'Holder of the card associated with the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials).',
         ),
 
       number_of_issued_cards: z
         .number()
         .describe(
-          'Number of issued cards associated with the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials).',
+          'Number of issued cards associated with the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials).',
         ),
 
       guest_acs_entrance_ids: z
         .array(z.string().uuid())
         .optional()
         .describe(
-          'IDs of the guest [entrances](https://docs.seam.co/latest/capability-guides/access-systems/retrieving-entrance-details) for the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials).',
+          'IDs of the guest [entrances](https://docs.seam.co/capability-guides/access-systems/retrieving-entrance-details) for the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials).',
         ),
       common_acs_entrance_ids: z
         .array(z.string().uuid())
         .optional()
         .describe(
-          'IDs of the common [entrances](https://docs.seam.co/latest/capability-guides/access-systems/retrieving-entrance-details) for the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials).',
+          'IDs of the common [entrances](https://docs.seam.co/capability-guides/access-systems/retrieving-entrance-details) for the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials).',
         ),
     })
     .optional()
     .describe(
-      'Visionline-specific metadata for the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials).',
+      'Visionline-specific metadata for the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials).',
     ),
 })
 

--- a/src/lib/seam/connect/models/acs/acs-encoder.ts
+++ b/src/lib/seam/connect/models/acs/acs-encoder.ts
@@ -24,7 +24,7 @@ const acs_encoder_error =
   acs_encoder_removed
     // ])
     .describe(
-      'Error associated with the [encoder](https://docs.seam.co/latest/capability-guides/access-systems/working-with-card-encoders-and-scanners).',
+      'Error associated with the [encoder](https://docs.seam.co/capability-guides/access-systems/working-with-card-encoders-and-scanners).',
     )
 
 const _acs_encoder_error_map = z.object({
@@ -38,47 +38,47 @@ export const acs_encoder = z.object({
     .string()
     .uuid()
     .describe(
-      'ID of the [encoder](https://docs.seam.co/latest/capability-guides/access-systems/working-with-card-encoders-and-scanners.',
+      'ID of the [encoder](https://docs.seam.co/capability-guides/access-systems/working-with-card-encoders-and-scanners.',
     ),
   acs_system_id: z
     .string()
     .uuid()
     .describe(
-      'ID of the [access control system](https://docs.seam.co/latest/capability-guides/access-systems) that contains the [encoder](https://docs.seam.co/latest/capability-guides/access-systems/working-with-card-encoders-and-scanners).',
+      'ID of the [access control system](https://docs.seam.co/capability-guides/access-systems) that contains the [encoder](https://docs.seam.co/capability-guides/access-systems/working-with-card-encoders-and-scanners).',
     ),
   connected_account_id: z
     .string()
     .uuid()
     .describe(
-      'ID of the [connected account](https://docs.seam.co/latest/core-concepts/connected-accounts) that contains the [encoder](https://docs.seam.co/latest/capability-guides/access-systems/working-with-card-encoders-and-scanners).',
+      'ID of the [connected account](https://docs.seam.co/core-concepts/connected-accounts) that contains the [encoder](https://docs.seam.co/capability-guides/access-systems/working-with-card-encoders-and-scanners).',
     ),
   workspace_id: z
     .string()
     .uuid()
     .describe(
-      'ID of the [workspace](https://docs.seam.co/latest/core-concepts/workspaces) that contains the [encoder](https://docs.seam.co/latest/capability-guides/access-systems/working-with-card-encoders-and-scanners).',
+      'ID of the [workspace](https://docs.seam.co/core-concepts/workspaces) that contains the [encoder](https://docs.seam.co/capability-guides/access-systems/working-with-card-encoders-and-scanners).',
     ),
   errors: z
     .array(acs_encoder_error)
     .describe(
-      'Errors associated with the [encoder](https://docs.seam.co/latest/capability-guides/access-systems/working-with-card-encoders-and-scanners).',
+      'Errors associated with the [encoder](https://docs.seam.co/capability-guides/access-systems/working-with-card-encoders-and-scanners).',
     ),
   created_at: z
     .string()
     .datetime()
     .describe(
-      'Date and time at which the [encoder](https://docs.seam.co/latest/capability-guides/access-systems/working-with-card-encoders-and-scanners) was created.',
+      'Date and time at which the [encoder](https://docs.seam.co/capability-guides/access-systems/working-with-card-encoders-and-scanners) was created.',
     ),
   display_name: z
     .string()
     .describe(
-      'Display name for the [encoder](https://docs.seam.co/latest/capability-guides/access-systems/working-with-card-encoders-and-scanners).',
+      'Display name for the [encoder](https://docs.seam.co/capability-guides/access-systems/working-with-card-encoders-and-scanners).',
     ),
 }).describe(`
   ---
   route_path: /acs/encoders
   ---
-  Represents a hardware device that encodes [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials) data onto physical cards within an [access control system](https://docs.seam.co/latest/capability-guides/access-systems).
+  Represents a hardware device that encodes [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials) data onto physical cards within an [access control system](https://docs.seam.co/capability-guides/access-systems).
 
   Some access control systems require credentials to be encoded onto plastic key cards using a card encoder. This process involves the following two key steps:
 
@@ -89,9 +89,9 @@ export const acs_encoder = z.object({
 
   Separately, the Seam API also supports card scanning, which enables you to scan and read the encoded data on a card. You can use this action to confirm consistency with access control system records or diagnose discrepancies if needed.
 
-   See [Working with Card Encoders and Scanners](https://docs.seam.co/latest/capability-guides/access-systems/working-with-card-encoders-and-scanners).
+   See [Working with Card Encoders and Scanners](https://docs.seam.co/capability-guides/access-systems/working-with-card-encoders-and-scanners).
 
-  To verify if your access control system requires a card encoder, see the corresponding [system integration guide](https://docs.seam.co/latest/device-and-system-integration-guides#access-control-systems).
+  To verify if your access control system requires a card encoder, see the corresponding [system integration guide](https://docs.seam.co/device-and-system-integration-guides#access-control-systems).
 `)
 
 export type AcsEncoder = z.infer<typeof acs_encoder>

--- a/src/lib/seam/connect/models/acs/acs-entrance.ts
+++ b/src/lib/seam/connect/models/acs/acs-entrance.ts
@@ -77,7 +77,7 @@ const acs_entrance_warning = z
     salto_ks_privacy_mode,
   ])
   .describe(
-    'Warning associated with the [entrance](https://docs.seam.co/latest/capability-guides/access-systems/retrieving-entrance-details).',
+    'Warning associated with the [entrance](https://docs.seam.co/capability-guides/access-systems/retrieving-entrance-details).',
   )
 
 const _acs_entrance_warning_map = z.object({
@@ -129,13 +129,13 @@ export const acs_entrance = z
       .string()
       .uuid()
       .describe(
-        'ID of the [access control system](https://docs.seam.co/latest/capability-guides/access-systems) that contains the [entrance](https://docs.seam.co/latest/capability-guides/access-systems/retrieving-entrance-details).',
+        'ID of the [access control system](https://docs.seam.co/capability-guides/access-systems) that contains the [entrance](https://docs.seam.co/capability-guides/access-systems/retrieving-entrance-details).',
       ),
     acs_entrance_id: z
       .string()
       .uuid()
       .describe(
-        'ID of the [entrance](https://docs.seam.co/latest/capability-guides/access-systems/retrieving-entrance-details).',
+        'ID of the [entrance](https://docs.seam.co/capability-guides/access-systems/retrieving-entrance-details).',
       ),
     space_ids: z
       .array(z.string().uuid())
@@ -144,18 +144,18 @@ export const acs_entrance = z
       .string()
       .datetime()
       .describe(
-        'Date and time at which the [entrance](https://docs.seam.co/latest/capability-guides/access-systems/retrieving-entrance-details) was created.',
+        'Date and time at which the [entrance](https://docs.seam.co/capability-guides/access-systems/retrieving-entrance-details) was created.',
       ),
     display_name: z
       .string()
       .describe(
-        'Display name for the [entrance](https://docs.seam.co/latest/capability-guides/access-systems/retrieving-entrance-details).',
+        'Display name for the [entrance](https://docs.seam.co/capability-guides/access-systems/retrieving-entrance-details).',
       ),
     connected_account_id: z
       .string()
       .uuid()
       .describe(
-        'ID of the [connected account](https://docs.seam.co/latest/capability-guides/access-systems/retrieving-entrance-details) associated with the [entrance](https://docs.seam.co/latest/capability-guides/access-systems/retrieving-entrance-details).',
+        'ID of the [connected account](https://docs.seam.co/capability-guides/access-systems/retrieving-entrance-details) associated with the [entrance](https://docs.seam.co/capability-guides/access-systems/retrieving-entrance-details).',
       ),
     errors: z
       .array(
@@ -173,75 +173,75 @@ export const acs_entrance = z
         }),
       )
       .describe(
-        'Errors associated with the [entrance](https://docs.seam.co/latest/capability-guides/access-systems/retrieving-entrance-details).',
+        'Errors associated with the [entrance](https://docs.seam.co/capability-guides/access-systems/retrieving-entrance-details).',
       ),
     warnings: z
       .array(acs_entrance_warning)
       .describe(
-        'Warnings associated with the [entrance](https://docs.seam.co/latest/capability-guides/access-systems/retrieving-entrance-details).',
+        'Warnings associated with the [entrance](https://docs.seam.co/capability-guides/access-systems/retrieving-entrance-details).',
       ),
     latch_metadata: acs_entrance_latch_metadata
       .optional()
       .describe(
-        'Latch-specific metadata associated with the [entrance](https://docs.seam.co/latest/capability-guides/access-systems/retrieving-entrance-details).',
+        'Latch-specific metadata associated with the [entrance](https://docs.seam.co/capability-guides/access-systems/retrieving-entrance-details).',
       ),
     hotek_metadata: acs_entrance_hotek_metadata
       .optional()
       .describe(
-        'Hotek-specific metadata associated with the [entrance](https://docs.seam.co/latest/capability-guides/access-systems/retrieving-entrance-details).',
+        'Hotek-specific metadata associated with the [entrance](https://docs.seam.co/capability-guides/access-systems/retrieving-entrance-details).',
       ),
     visionline_metadata: acs_entrance_visionline_metadata
       .optional()
       .describe(
-        'Visionline-specific metadata associated with the [entrance](https://docs.seam.co/latest/capability-guides/access-systems/retrieving-entrance-details).',
+        'Visionline-specific metadata associated with the [entrance](https://docs.seam.co/capability-guides/access-systems/retrieving-entrance-details).',
       ),
     salto_ks_metadata: acs_entrance_salto_ks_metadata
       .optional()
       .describe(
-        'Salto KS-specific metadata associated with the [entrance](https://docs.seam.co/latest/capability-guides/access-systems/retrieving-entrance-details).',
+        'Salto KS-specific metadata associated with the [entrance](https://docs.seam.co/capability-guides/access-systems/retrieving-entrance-details).',
       ),
     dormakaba_community_metadata: acs_entrance_dormakaba_community_metadata
       .optional()
       .describe(
-        'dormakaba Community-specific metadata associated with the [entrance](https://docs.seam.co/latest/capability-guides/access-systems/retrieving-entrance-details).',
+        'dormakaba Community-specific metadata associated with the [entrance](https://docs.seam.co/capability-guides/access-systems/retrieving-entrance-details).',
       ),
     assa_abloy_vostio_metadata: acs_entrance_assa_abloy_vostio_metadata
       .optional()
       .describe(
-        'ASSA ABLOY Vostio-specific metadata associated with the [entrance](https://docs.seam.co/latest/capability-guides/access-systems/retrieving-entrance-details).',
+        'ASSA ABLOY Vostio-specific metadata associated with the [entrance](https://docs.seam.co/capability-guides/access-systems/retrieving-entrance-details).',
       ),
     salto_space_metadata: acs_entrance_salto_space_metadata
       .optional()
       .describe(
-        'Salto Space-specific metadata associated with the [entrance](https://docs.seam.co/latest/capability-guides/access-systems/retrieving-entrance-details).',
+        'Salto Space-specific metadata associated with the [entrance](https://docs.seam.co/capability-guides/access-systems/retrieving-entrance-details).',
       ),
     dormakaba_ambiance_metadata: acs_entrance_dormakaba_ambiance_metadata
       .optional()
       .describe(
-        'dormakaba Ambiance-specific metadata associated with the [entrance](https://docs.seam.co/latest/capability-guides/access-systems/retrieving-entrance-details).',
+        'dormakaba Ambiance-specific metadata associated with the [entrance](https://docs.seam.co/capability-guides/access-systems/retrieving-entrance-details).',
       ),
     brivo_metadata: acs_entrance_brivo_metadata
       .optional()
       .describe(
-        'Brivo-specific metadata associated with the [entrance](https://docs.seam.co/latest/capability-guides/access-systems/retrieving-entrance-details).',
+        'Brivo-specific metadata associated with the [entrance](https://docs.seam.co/capability-guides/access-systems/retrieving-entrance-details).',
       ),
     avigilon_alta_metadata: acs_entrance_avigilon_alta_metadata
       .optional()
       .describe(
-        'Avigilon Alta-specific metadata associated with the [entrance](https://docs.seam.co/latest/capability-guides/access-systems/retrieving-entrance-details).',
+        'Avigilon Alta-specific metadata associated with the [entrance](https://docs.seam.co/capability-guides/access-systems/retrieving-entrance-details).',
       ),
     is_locked: z
       .boolean()
       .optional()
       .describe(
-        'Indicates whether the [entrance](https://docs.seam.co/latest/capability-guides/access-systems/retrieving-entrance-details) is currently locked.',
+        'Indicates whether the [entrance](https://docs.seam.co/capability-guides/access-systems/retrieving-entrance-details) is currently locked.',
       ),
   })
   .merge(acs_entrance_capability_flags).describe(`
   ---
   route_path: /acs/entrances
   ---
-  Represents an [entrance](https://docs.seam.co/latest/capability-guides/access-systems/retrieving-entrance-details) within an [access control system](https://docs.seam.co/latest/capability-guides/access-systems).
+  Represents an [entrance](https://docs.seam.co/capability-guides/access-systems/retrieving-entrance-details) within an [access control system](https://docs.seam.co/capability-guides/access-systems).
 
   In an access control system, an entrance is a secured door, gate, zone, or other method of entry. You can list details for all the \`acs_entrance\` resources in your workspace or get these details for a specific \`acs_entrance\`. You can also list all entrances associated with a specific credential, and you can list all credentials associated with a specific entrance.
 `)

--- a/src/lib/seam/connect/models/acs/acs-system.ts
+++ b/src/lib/seam/connect/models/acs/acs-system.ts
@@ -10,7 +10,7 @@ export const acs_location = z.object({
     .string()
     .nullable()
     .describe(
-      'Time zone in which the [access control system](https://docs.seam.co/latest/capability-guides/access-systems) is located.',
+      'Time zone in which the [access control system](https://docs.seam.co/capability-guides/access-systems) is located.',
     ),
 })
 
@@ -57,25 +57,25 @@ const seam_bridge_disconnected = common_acs_system_error.extend({
     .literal('seam_bridge_disconnected')
     .describe(error_code_description),
 })
-  .describe(`Indicates that the Seam API cannot communicate with [Seam Bridge](https://docs.seam.co/latest/capability-guides/seam-bridge), for example, if Seam Bridge executable has stopped or if the computer running the Seam Bridge executable is offline.
-  This error might also occur if Seam Bridge is connected to the wrong [workspace](https://docs.seam.co/latest/core-concepts/workspaces).
-  See also [Troubleshooting Your Access Control System](https://docs.seam.co/latest/capability-guides/access-systems/troubleshooting-your-access-control-system#acs_system.errors.seam_bridge_disconnected).`)
+  .describe(`Indicates that the Seam API cannot communicate with [Seam Bridge](https://docs.seam.co/capability-guides/seam-bridge), for example, if Seam Bridge executable has stopped or if the computer running the Seam Bridge executable is offline.
+  This error might also occur if Seam Bridge is connected to the wrong [workspace](https://docs.seam.co/core-concepts/workspaces).
+  See also [Troubleshooting Your Access Control System](https://docs.seam.co/capability-guides/access-systems/troubleshooting-your-access-control-system#acs_system.errors.seam_bridge_disconnected).`)
 
 const bridge_disconnected = common_acs_system_error.extend({
   error_code: z.literal('bridge_disconnected').describe(error_code_description),
   is_bridge_error: z.boolean().optional(),
 })
-  .describe(`Indicates that the Seam API cannot communicate with [Seam Bridge](https://docs.seam.co/latest/capability-guides/seam-bridge), for example, if Seam Bridge executable has stopped or if the computer running the Seam Bridge executable is offline.
-    See also [Troubleshooting Your Access Control System](https://docs.seam.co/latest/capability-guides/access-systems/troubleshooting-your-access-control-system#acs_system.errors.seam_bridge_disconnected).`)
+  .describe(`Indicates that the Seam API cannot communicate with [Seam Bridge](https://docs.seam.co/capability-guides/seam-bridge), for example, if Seam Bridge executable has stopped or if the computer running the Seam Bridge executable is offline.
+    See also [Troubleshooting Your Access Control System](https://docs.seam.co/capability-guides/access-systems/troubleshooting-your-access-control-system#acs_system.errors.seam_bridge_disconnected).`)
 
 const visionline_instance_unreachable = common_acs_system_error.extend({
   error_code: z
     .literal('visionline_instance_unreachable')
     .describe(error_code_description),
 })
-  .describe(`Indicates that [Seam Bridge](https://docs.seam.co/latest/capability-guides/seam-bridge) is functioning correctly and the Seam API can communicate with Seam Bridge, but the Seam API cannot connect to the on-premises [Visionline access control system](https://docs.seam.co/latest/device-and-system-integration-guides/assa-abloy-visionline-access-control-system).
-  For example, the IP address of the on-premises access control system may be set incorrectly within the Seam [workspace](https://docs.seam.co/latest/core-concepts/workspaces).
-  See also [Troubleshooting Your Access Control System](https://docs.seam.co/latest/capability-guides/access-systems/troubleshooting-your-access-control-system#acs_system.errors.visionline_instance_unreachable).`)
+  .describe(`Indicates that [Seam Bridge](https://docs.seam.co/capability-guides/seam-bridge) is functioning correctly and the Seam API can communicate with Seam Bridge, but the Seam API cannot connect to the on-premises [Visionline access control system](https://docs.seam.co/device-and-system-integration-guides/assa-abloy-visionline-access-control-system).
+  For example, the IP address of the on-premises access control system may be set incorrectly within the Seam [workspace](https://docs.seam.co/core-concepts/workspaces).
+  See also [Troubleshooting Your Access Control System](https://docs.seam.co/capability-guides/access-systems/troubleshooting-your-access-control-system#acs_system.errors.visionline_instance_unreachable).`)
 
 const salto_ks_subscription_limit_exceeded = common_acs_system_error
   .extend({
@@ -94,7 +94,7 @@ const acs_system_disconnected = common_acs_system_error
       .describe(error_code_description),
   })
   .describe(
-    'Indicates that the [access control system](https://docs.seam.co/latest/capability-guides/access-systems) has been disconnected. See [Troubleshooting Your Access Control System](https://docs.seam.co/latest/capability-guides/access-systems/troubleshooting-your-access-control-system) to resolve the issue.',
+    'Indicates that the [access control system](https://docs.seam.co/capability-guides/access-systems) has been disconnected. See [Troubleshooting Your Access Control System](https://docs.seam.co/capability-guides/access-systems/troubleshooting-your-access-control-system) to resolve the issue.',
   )
 
 const account_disconnected = common_acs_system_error
@@ -104,7 +104,7 @@ const account_disconnected = common_acs_system_error
       .describe(error_code_description),
   })
   .describe(
-    'Indicates that the login credentials are invalid. Reconnect the account using a [Connect Webview](https://docs.seam.co/latest/core-concepts/connect-webviews) to restore access.',
+    'Indicates that the login credentials are invalid. Reconnect the account using a [Connect Webview](https://docs.seam.co/core-concepts/connect-webviews) to restore access.',
   )
 
 const salto_ks_certification_expired = common_acs_system_error
@@ -114,7 +114,7 @@ const salto_ks_certification_expired = common_acs_system_error
       .describe(error_code_description),
   })
   .describe(
-    'Indicates that the [access control system](https://docs.seam.co/latest/capability-guides/access-systems) has lost its Salto KS certification. Contact [support](mailto:support@seam.co) to regain access.',
+    'Indicates that the [access control system](https://docs.seam.co/capability-guides/access-systems) has lost its Salto KS certification. Contact [support](mailto:support@seam.co) to regain access.',
   )
 const provider_service_unavailable = common_acs_system_error
   .extend({
@@ -138,7 +138,7 @@ const acs_system_error = z
     provider_service_unavailable,
   ])
   .describe(
-    'Error associated with the [access control system](https://docs.seam.co/latest/capability-guides/access-systems).',
+    'Error associated with the [access control system](https://docs.seam.co/capability-guides/access-systems).',
   )
 
 const _acs_system_error_map = z.object({
@@ -201,7 +201,7 @@ const time_zone_does_not_match_location = common_acs_system_warning
       ),
   })
   .describe(
-    'Indicates the [access control system](https://docs.seam.co/latest/capability-guides/access-systems) time zone could not be determined because the reported physical location does not match the time zone configured on the physical [ACS entrances](https://docs.seam.co/latest/capability-guides/access-systems/retrieving-entrance-details).',
+    'Indicates the [access control system](https://docs.seam.co/capability-guides/access-systems) time zone could not be determined because the reported physical location does not match the time zone configured on the physical [ACS entrances](https://docs.seam.co/capability-guides/access-systems/retrieving-entrance-details).',
   )
 
 const acs_system_warning = z
@@ -210,7 +210,7 @@ const acs_system_warning = z
     time_zone_does_not_match_location,
   ])
   .describe(
-    'Warning associated with the [access control system](https://docs.seam.co/latest/capability-guides/access-systems).',
+    'Warning associated with the [access control system](https://docs.seam.co/capability-guides/access-systems).',
   )
 
 const _acs_system_warning_map = z.object({
@@ -231,25 +231,25 @@ export const acs_system = z
       .nullable()
       .optional()
       .describe(
-        'ID of the default credential manager `acs_system` for this [access control system](https://docs.seam.co/latest/capability-guides/access-systems).',
+        'ID of the default credential manager `acs_system` for this [access control system](https://docs.seam.co/capability-guides/access-systems).',
       ),
     acs_system_id: z
       .string()
       .uuid()
       .describe(
-        'ID of the [access control system](https://docs.seam.co/latest/capability-guides/access-systems).',
+        'ID of the [access control system](https://docs.seam.co/capability-guides/access-systems).',
       ),
     acs_user_count: z.number().optional(),
     acs_access_group_count: z.number().optional(),
     external_type: acs_system_external_type
       .describe(
-        'Brand-specific terminology for the [access control system](https://docs.seam.co/latest/capability-guides/access-systems) type.',
+        'Brand-specific terminology for the [access control system](https://docs.seam.co/capability-guides/access-systems) type.',
       )
       .optional(),
     external_type_display_name: z
       .string()
       .describe(
-        'Display name that corresponds to the brand-specific terminology for the [access control system](https://docs.seam.co/latest/capability-guides/access-systems) type.',
+        'Display name that corresponds to the brand-specific terminology for the [access control system](https://docs.seam.co/capability-guides/access-systems) type.',
       )
       .optional(),
     is_credential_manager: z
@@ -270,7 +270,7 @@ export const acs_system = z
         lan_address: z
           .string()
           .describe(
-            'IP address or hostname of the main Visionline server relative to [Seam Bridge](https://docs.seam.co/latest/capability-guides/seam-bridge) on the local network.',
+            'IP address or hostname of the main Visionline server relative to [Seam Bridge](https://docs.seam.co/capability-guides/seam-bridge) on the local network.',
           ),
       })
       .optional(),
@@ -292,62 +292,62 @@ export const acs_system = z
     name: z
       .string()
       .describe(
-        'Name of the [access control system](https://docs.seam.co/latest/capability-guides/access-systems).',
+        'Name of the [access control system](https://docs.seam.co/capability-guides/access-systems).',
       ),
     created_at: z
       .string()
       .datetime()
       .describe(
-        'Date and time at which the [access control system](https://docs.seam.co/latest/capability-guides/access-systems) was created.',
+        'Date and time at which the [access control system](https://docs.seam.co/capability-guides/access-systems) was created.',
       ),
     workspace_id: z
       .string()
       .uuid()
       .describe(
-        'ID of the [workspace](https://docs.seam.co/latest/core-concepts/workspaces) that contains the [access control system](https://docs.seam.co/latest/capability-guides/access-systems).',
+        'ID of the [workspace](https://docs.seam.co/core-concepts/workspaces) that contains the [access control system](https://docs.seam.co/capability-guides/access-systems).',
       ),
     connected_account_ids: z.array(z.string().uuid()).describe(`
       ---
       deprecated: Use \`connected_account_id\`.
       ---
-      IDs of the [connected accounts](https://docs.seam.co/latest/core-concepts/connected-accounts) associated with the [access control system](https://docs.seam.co/latest/capability-guides/access-systems).
+      IDs of the [connected accounts](https://docs.seam.co/core-concepts/connected-accounts) associated with the [access control system](https://docs.seam.co/capability-guides/access-systems).
       `),
     connected_account_id: z
       .string()
       .uuid()
       .describe(
-        'ID of the [connected account](https://docs.seam.co/latest/core-concepts/connected-accounts) associated with the [access control system](https://docs.seam.co/latest/capability-guides/access-systems).',
+        'ID of the [connected account](https://docs.seam.co/core-concepts/connected-accounts) associated with the [access control system](https://docs.seam.co/capability-guides/access-systems).',
       ),
     image_url: z
       .string()
       .describe(
-        'URL for the image that represents the [access control system](https://docs.seam.co/latest/capability-guides/access-systems).',
+        'URL for the image that represents the [access control system](https://docs.seam.co/capability-guides/access-systems).',
       ),
     image_alt_text: z
       .string()
       .describe(
-        'Alternative text for the [access control system](https://docs.seam.co/latest/capability-guides/access-systems) image.',
+        'Alternative text for the [access control system](https://docs.seam.co/capability-guides/access-systems) image.',
       ),
     errors: z
       .array(acs_system_error)
       .describe(
-        'Errors associated with the [access control system](https://docs.seam.co/latest/capability-guides/access-systems).',
+        'Errors associated with the [access control system](https://docs.seam.co/capability-guides/access-systems).',
       ),
     warnings: z
       .array(acs_system_warning)
       .describe(
-        'Warnings associated with the [access control system](https://docs.seam.co/latest/capability-guides/access-systems).',
+        'Warnings associated with the [access control system](https://docs.seam.co/capability-guides/access-systems).',
       ),
   })
   .merge(acs_system_capability_flags).describe(`
     ---
     route_path: /acs/systems
     ---
-    Represents an [access control system](https://docs.seam.co/latest/capability-guides/access-systems).
+    Represents an [access control system](https://docs.seam.co/capability-guides/access-systems).
 
-    Within an \`acs_system\`, create [\`acs_user\`s](https://docs.seam.co/latest/api/acs/users#acs_user) and [\`acs_credential\`s](https://docs.seam.co/latest/api/acs/credentials#acs_credential) to grant access to the \`acs_user\`s.
+    Within an \`acs_system\`, create [\`acs_user\`s](https://docs.seam.co/api/acs/users#acs_user) and [\`acs_credential\`s](https://docs.seam.co/api/acs/credentials#acs_credential) to grant access to the \`acs_user\`s.
 
-    For details about the resources associated with an access control system, see the [access control systems namespace](https://docs.seam.co/latest/api/acs).
+    For details about the resources associated with an access control system, see the [access control systems namespace](https://docs.seam.co/api/acs).
   `)
 
 export type AcsSystem = z.output<typeof acs_system>

--- a/src/lib/seam/connect/models/acs/acs-users/acs-user.ts
+++ b/src/lib/seam/connect/models/acs/acs-users/acs-user.ts
@@ -35,7 +35,7 @@ const acs_users_deleted_externally = common_acs_user_error
     error_code: z.literal('deleted_externally'),
   })
   .describe(
-    `Indicates that the [access system user](https://docs.seam.co/latest/capability-guides/access-systems/user-management) was deleted from the [access system](https://docs.seam.co/latest/capability-guides/access-systems) outside of Seam.`,
+    `Indicates that the [access system user](https://docs.seam.co/capability-guides/access-systems/user-management) was deleted from the [access system](https://docs.seam.co/capability-guides/access-systems) outside of Seam.`,
   )
 
 const acs_users_salto_ks_subscription_limit_exceeded = common_acs_user_error
@@ -43,7 +43,7 @@ const acs_users_salto_ks_subscription_limit_exceeded = common_acs_user_error
     error_code: z.literal('salto_ks_subscription_limit_exceeded'),
   })
   .describe(
-    `Indicates that the [access system user](https://docs.seam.co/latest/capability-guides/access-systems/user-management) could not be subscribed on Salto KS because the subscription limit has been exceeded.`,
+    `Indicates that the [access system user](https://docs.seam.co/capability-guides/access-systems/user-management) could not be subscribed on Salto KS because the subscription limit has been exceeded.`,
   )
 
 const acs_users_failed_to_create_on_acs_system = common_acs_user_error
@@ -51,7 +51,7 @@ const acs_users_failed_to_create_on_acs_system = common_acs_user_error
     error_code: z.literal('failed_to_create_on_acs_system'),
   })
   .describe(
-    `Indicates that the [access system user](https://docs.seam.co/latest/capability-guides/access-systems/user-management) was not created on the [access system](https://docs.seam.co/latest/capability-guides/access-systems). This is likely due to an internal unexpected error. Contact Seam [support](mailto:support@seam.co).`,
+    `Indicates that the [access system user](https://docs.seam.co/capability-guides/access-systems/user-management) was not created on the [access system](https://docs.seam.co/capability-guides/access-systems). This is likely due to an internal unexpected error. Contact Seam [support](mailto:support@seam.co).`,
   )
 
 const acs_users_failed_to_update_on_acs_system = common_acs_user_error
@@ -59,7 +59,7 @@ const acs_users_failed_to_update_on_acs_system = common_acs_user_error
     error_code: z.literal('failed_to_update_on_acs_system'),
   })
   .describe(
-    `Indicates that the [access system user](https://docs.seam.co/latest/capability-guides/access-systems/user-management) was not updated on the [access system](https://docs.seam.co/latest/capability-guides/access-systems). This is likely due to an internal unexpected error. Contact Seam [support](mailto:support@seam.co).`,
+    `Indicates that the [access system user](https://docs.seam.co/capability-guides/access-systems/user-management) was not updated on the [access system](https://docs.seam.co/capability-guides/access-systems). This is likely due to an internal unexpected error. Contact Seam [support](mailto:support@seam.co).`,
   )
 
 const acs_users_failed_to_delete_on_acs_system = common_acs_user_error
@@ -67,7 +67,7 @@ const acs_users_failed_to_delete_on_acs_system = common_acs_user_error
     error_code: z.literal('failed_to_delete_on_acs_system'),
   })
   .describe(
-    `Indicates that the [access system user](https://docs.seam.co/latest/capability-guides/access-systems/user-management) was not deleted on the [access system](https://docs.seam.co/latest/capability-guides/access-systems). This is likely due to an internal unexpected error. Contact Seam [support](mailto:support@seam.co).`,
+    `Indicates that the [access system user](https://docs.seam.co/capability-guides/access-systems/user-management) was not deleted on the [access system](https://docs.seam.co/capability-guides/access-systems). This is likely due to an internal unexpected error. Contact Seam [support](mailto:support@seam.co).`,
   )
 
 const acs_users_latch_conflict_with_resident_user = common_acs_user_error
@@ -75,7 +75,7 @@ const acs_users_latch_conflict_with_resident_user = common_acs_user_error
     error_code: z.literal('latch_conflict_with_resident_user'),
   })
   .describe(
-    `Indicates that the [access system user](https://docs.seam.co/latest/capability-guides/access-systems/user-management) was created from the Seam API but also exists on Mission Control. This is unsupported. Contact Seam [support](mailto:support@seam.co).`,
+    `Indicates that the [access system user](https://docs.seam.co/capability-guides/access-systems/user-management) was created from the Seam API but also exists on Mission Control. This is unsupported. Contact Seam [support](mailto:support@seam.co).`,
   )
 
 const acs_user_errors = z
@@ -88,7 +88,7 @@ const acs_user_errors = z
     acs_users_latch_conflict_with_resident_user,
   ])
   .describe(
-    'Errors associated with the [access system user](https://docs.seam.co/latest/capability-guides/access-systems/user-management).',
+    'Errors associated with the [access system user](https://docs.seam.co/capability-guides/access-systems/user-management).',
   )
 
 const _acs_users_error_map = z.object({
@@ -128,7 +128,7 @@ const acs_users_being_deleted = common_acs_user_warning
     warning_code: z.literal('being_deleted'),
   })
   .describe(
-    'Indicates that the [access system user](https://docs.seam.co/latest/capability-guides/access-systems/user-management) is being deleted from the [access system](https://docs.seam.co/latest/capability-guides/access-systems). This is a temporary state, and the access system user will be deleted shortly.',
+    'Indicates that the [access system user](https://docs.seam.co/capability-guides/access-systems/user-management) is being deleted from the [access system](https://docs.seam.co/capability-guides/access-systems). This is a temporary state, and the access system user will be deleted shortly.',
   )
 
 const acs_users_salto_ks_user_not_subscribed = common_acs_user_warning
@@ -136,7 +136,7 @@ const acs_users_salto_ks_user_not_subscribed = common_acs_user_warning
     warning_code: z.literal('salto_ks_user_not_subscribed'),
   })
   .describe(
-    'Indicates that the [access system user](https://docs.seam.co/latest/capability-guides/access-systems/user-management) is not subscribed on Salto KS, so they cannot unlock doors or perform any actions. This occurs when the their access schedule hasn’t started yet, if their access schedule has ended, if the site has reached its limit for active users (subscription slots), or if they have been manually unsubscribed.',
+    'Indicates that the [access system user](https://docs.seam.co/capability-guides/access-systems/user-management) is not subscribed on Salto KS, so they cannot unlock doors or perform any actions. This occurs when the their access schedule hasn’t started yet, if their access schedule has ended, if the site has reached its limit for active users (subscription slots), or if they have been manually unsubscribed.',
   )
 
 export const unknown_issue_with_acs_user = common_acs_user_warning
@@ -144,7 +144,7 @@ export const unknown_issue_with_acs_user = common_acs_user_warning
     warning_code: z.literal('unknown_issue_with_acs_user'),
   })
   .describe(
-    'An unknown issue occurred while syncing the state of this [access system user](https://docs.seam.co/latest/capability-guides/access-systems/user-management) with the provider. This issue may affect the proper functioning of this user.',
+    'An unknown issue occurred while syncing the state of this [access system user](https://docs.seam.co/capability-guides/access-systems/user-management) with the provider. This issue may affect the proper functioning of this user.',
   )
 
 export const latch_resident_user = common_acs_user_warning
@@ -152,7 +152,7 @@ export const latch_resident_user = common_acs_user_warning
     warning_code: z.literal('latch_resident_user'),
   })
   .describe(
-    'Indicates that the [access system user](https://docs.seam.co/latest/capability-guides/access-systems/user-management) was created on Latch Mission Control. Please use the Latch Mission Control to manage this user.',
+    'Indicates that the [access system user](https://docs.seam.co/capability-guides/access-systems/user-management) was created on Latch Mission Control. Please use the Latch Mission Control to manage this user.',
   )
 
 const _acs_users_warning_map = z.object({
@@ -174,7 +174,7 @@ export const acs_users_warnings = z
     latch_resident_user,
   ])
   .describe(
-    'Warnings associated with the [access system user](https://docs.seam.co/latest/capability-guides/access-systems/user-management).',
+    'Warnings associated with the [access system user](https://docs.seam.co/capability-guides/access-systems/user-management).',
   )
 
 export type AcsUsersWarningMap = z.infer<typeof _acs_users_warning_map>
@@ -186,7 +186,7 @@ const user_fields = z.object({
     .min(1)
     .optional()
     .describe(
-      'Full name of the [access system user](https://docs.seam.co/latest/capability-guides/access-systems/user-management).',
+      'Full name of the [access system user](https://docs.seam.co/capability-guides/access-systems/user-management).',
     ),
   email: z.string().email().optional().describe(`
     ---
@@ -198,12 +198,12 @@ const user_fields = z.object({
     .email()
     .optional()
     .describe(
-      'Email address of the [access system user](https://docs.seam.co/latest/capability-guides/access-systems/user-management).',
+      'Email address of the [access system user](https://docs.seam.co/capability-guides/access-systems/user-management).',
     ),
   phone_number: phone_number
     .optional()
     .describe(
-      'Phone number of the [access system user](https://docs.seam.co/latest/capability-guides/access-systems/user-management) in E.164 format (for example, `+15555550100`).',
+      'Phone number of the [access system user](https://docs.seam.co/capability-guides/access-systems/user-management) in E.164 format (for example, `+15555550100`).',
     ),
 })
 
@@ -213,96 +213,96 @@ const common_acs_user = z
       .string()
       .uuid()
       .describe(
-        'ID of the [access system user](https://docs.seam.co/latest/capability-guides/access-systems/user-management).',
+        'ID of the [access system user](https://docs.seam.co/capability-guides/access-systems/user-management).',
       ),
     acs_system_id: z
       .string()
       .uuid()
       .describe(
-        'ID of the [access system](https://docs.seam.co/latest/capability-guides/access-systems) that contains the [access system user](https://docs.seam.co/latest/capability-guides/access-systems/user-management).',
+        'ID of the [access system](https://docs.seam.co/capability-guides/access-systems) that contains the [access system user](https://docs.seam.co/capability-guides/access-systems/user-management).',
       ),
     hid_acs_system_id: z.string().uuid().optional(),
     workspace_id: z
       .string()
       .uuid()
       .describe(
-        'ID of the [workspace](https://docs.seam.co/latest/core-concepts/workspaces) that contains the [access system user](https://docs.seam.co/latest/capability-guides/access-systems/user-management).',
+        'ID of the [workspace](https://docs.seam.co/core-concepts/workspaces) that contains the [access system user](https://docs.seam.co/capability-guides/access-systems/user-management).',
       ),
     created_at: z
       .string()
       .datetime()
       .describe(
-        'Date and time at which the [access system user](https://docs.seam.co/latest/capability-guides/access-systems/user-management) was created.',
+        'Date and time at which the [access system user](https://docs.seam.co/capability-guides/access-systems/user-management) was created.',
       ),
     display_name: z
       .string()
       .describe(
-        'Display name for the [access system user](https://docs.seam.co/latest/capability-guides/access-systems/user-management).',
+        'Display name for the [access system user](https://docs.seam.co/capability-guides/access-systems/user-management).',
       ),
     external_type: acs_user_external_type
       .optional()
       .describe(
-        'Brand-specific terminology for the [access system user](https://docs.seam.co/latest/capability-guides/access-systems/user-management) type.',
+        'Brand-specific terminology for the [access system user](https://docs.seam.co/capability-guides/access-systems/user-management) type.',
       ),
     external_type_display_name: z
       .string()
       .optional()
       .describe(
-        'Display name that corresponds to the brand-specific terminology for the [access system user](https://docs.seam.co/latest/capability-guides/access-systems/user-management) type.',
+        'Display name that corresponds to the brand-specific terminology for the [access system user](https://docs.seam.co/capability-guides/access-systems/user-management) type.',
       ),
     is_suspended: z
       .boolean()
       .optional()
       .describe(
-        'Indicates whether the [access system user](https://docs.seam.co/latest/capability-guides/access-systems/user-management) is currently [suspended](https://docs.seam.co/latest/capability-guides/access-systems/user-management/suspending-and-unsuspending-users).',
+        'Indicates whether the [access system user](https://docs.seam.co/capability-guides/access-systems/user-management) is currently [suspended](https://docs.seam.co/capability-guides/access-systems/user-management/suspending-and-unsuspending-users).',
       ),
     access_schedule: schedule
       .optional()
       .describe(
-        "`starts_at` and `ends_at` timestamps for the [access system user's](https://docs.seam.co/latest/capability-guides/access-systems/user-management) access.",
+        "`starts_at` and `ends_at` timestamps for the [access system user's](https://docs.seam.co/capability-guides/access-systems/user-management) access.",
       ),
     user_identity_id: z
       .string()
       .optional()
       .describe(
-        'ID of the user identity associated with the [access system user](https://docs.seam.co/latest/capability-guides/access-systems/user-management).',
+        'ID of the user identity associated with the [access system user](https://docs.seam.co/capability-guides/access-systems/user-management).',
       ),
     user_identity_full_name: z
       .string()
       .nullable()
       .optional()
       .describe(
-        'Full name of the user identity associated with the [access system user](https://docs.seam.co/latest/capability-guides/access-systems/user-management).',
+        'Full name of the user identity associated with the [access system user](https://docs.seam.co/capability-guides/access-systems/user-management).',
       ),
     user_identity_email_address: z
       .string()
       .nullable()
       .optional()
       .describe(
-        'Email address of the user identity associated with the [access system user](https://docs.seam.co/latest/capability-guides/access-systems/user-management).',
+        'Email address of the user identity associated with the [access system user](https://docs.seam.co/capability-guides/access-systems/user-management).',
       ),
     user_identity_phone_number: z
       .string()
       .nullable()
       .optional()
       .describe(
-        'Phone number of the user identity associated with the [access system user](https://docs.seam.co/latest/capability-guides/access-systems/user-management) in E.164 format (for example, `+15555550100`).',
+        'Phone number of the user identity associated with the [access system user](https://docs.seam.co/capability-guides/access-systems/user-management) in E.164 format (for example, `+15555550100`).',
       ),
     warnings: z
       .array(acs_users_warnings)
       .describe(
-        'Warnings associated with the [access system user](https://docs.seam.co/latest/capability-guides/access-systems/user-management).',
+        'Warnings associated with the [access system user](https://docs.seam.co/capability-guides/access-systems/user-management).',
       ),
     errors: z
       .array(acs_user_errors)
       .describe(
-        'Errors associated with the [access system user](https://docs.seam.co/latest/capability-guides/access-systems/user-management).',
+        'Errors associated with the [access system user](https://docs.seam.co/capability-guides/access-systems/user-management).',
       ),
     pending_mutations: z
       .array(acs_user_pending_mutations)
       .optional()
       .describe(
-        'Pending mutations associated with the [access system user](https://docs.seam.co/latest/capability-guides/access-systems/user-management). Seam is in the process of pushing these mutations to the integrated access system.',
+        'Pending mutations associated with the [access system user](https://docs.seam.co/capability-guides/access-systems/user-management). Seam is in the process of pushing these mutations to the integrated access system.',
       ),
     last_successful_sync_at: z.string().datetime().nullable().describe(`
         ---
@@ -311,12 +311,12 @@ const common_acs_user = z
         The last time an internal sync job completed for this access system user.
       `),
     connected_account_id: z.string().uuid().describe(`
-      The ID of the [connected account](https://docs.seam.co/latest/core-concepts/connected-accounts) that is associated with the [access system user](https://docs.seam.co/latest/capability-guides/access-systems/user-management).
+      The ID of the [connected account](https://docs.seam.co/core-concepts/connected-accounts) that is associated with the [access system user](https://docs.seam.co/capability-guides/access-systems/user-management).
     `),
     salto_space_metadata: acs_user_salto_space_metadata
       .optional()
       .describe(
-        'Salto Space-specific metadata associated with the [access system user](https://docs.seam.co/latest/capability-guides/access-systems/user-management).',
+        'Salto Space-specific metadata associated with the [access system user](https://docs.seam.co/capability-guides/access-systems/user-management).',
       ),
   })
   .merge(user_fields)
@@ -329,11 +329,11 @@ export const acs_user = common_acs_user.merge(
   ---
   route_path: /acs/users
   ---
-  Represents a [user](https://docs.seam.co/latest/capability-guides/access-systems/user-management) in an [access system](https://docs.seam.co/latest/capability-guides/access-systems).
+  Represents a [user](https://docs.seam.co/capability-guides/access-systems/user-management) in an [access system](https://docs.seam.co/capability-guides/access-systems).
 
   An access system user typically refers to an individual who requires access, like an employee or resident. Each user can possess multiple credentials that serve as their keys or identifiers for access. The type of credential can vary widely. For example, in the Salto system, a user can have a PIN code, a mobile app account, and a fob. In other platforms, it is not uncommon for a user to have more than one of the same credential type, such as multiple key cards. Additionally, these credentials can have a schedule or validity period.
 
-  For details about how to configure users in your access system, see the corresponding [system integration guide](https://docs.seam.co/latest/device-and-system-integration-guides#access-control-systems).
+  For details about how to configure users in your access system, see the corresponding [system integration guide](https://docs.seam.co/device-and-system-integration-guides#access-control-systems).
 `)
 
 export const unmanaged_acs_user = common_acs_user.merge(
@@ -345,7 +345,7 @@ export const unmanaged_acs_user = common_acs_user.merge(
   route_path: /acs/users/unmanaged
   undocumented: Unreleased.
   ---
-  Represents an unmanaged [user](https://docs.seam.co/latest/capability-guides/access-systems/user-management) in an [access system](https://docs.seam.co/latest/capability-guides/access-systems).
+  Represents an unmanaged [user](https://docs.seam.co/capability-guides/access-systems/user-management) in an [access system](https://docs.seam.co/capability-guides/access-systems).
 `)
 
 export type AcsUser = z.output<typeof acs_user>

--- a/src/lib/seam/connect/models/action-attempts/action-attempt.ts
+++ b/src/lib/seam/connect/models/action-attempts/action-attempt.ts
@@ -38,7 +38,7 @@ export const action_attempt = z.union([
 
   When you request for a device to perform an action, the Seam API immediately returns an action attempt object. In the background, the Seam API performs the action.
 
-  See also [Action Attempts](https://docs.seam.co/latest/core-concepts/action-attempts).
+  See also [Action Attempts](https://docs.seam.co/core-concepts/action-attempts).
 `)
 
 export type ActionAttempt = z.infer<typeof action_attempt>

--- a/src/lib/seam/connect/models/bridges/bridge-client-session.ts
+++ b/src/lib/seam/connect/models/bridges/bridge-client-session.ts
@@ -144,7 +144,7 @@ export const bridge_client_session = z.object({
   route_path: /seam/bridge/v1/bridge_client_sessions
   undocumented: Seam Bridge client only.
   ---
-  Represents a [Seam Bridge](https://docs.seam.co/latest/capability-guides/seam-bridge) client session.
+  Represents a [Seam Bridge](https://docs.seam.co/capability-guides/seam-bridge) client session.
 `)
 
 export type BridgeClientSession = z.infer<typeof bridge_client_session>

--- a/src/lib/seam/connect/models/bridges/bridge-connected-system.ts
+++ b/src/lib/seam/connect/models/bridges/bridge-connected-system.ts
@@ -23,30 +23,30 @@ export const bridge_connected_system = z.object({
     .string()
     .uuid()
     .describe(
-      'ID of the [access system](https://docs.seam.co/latest/capability-guides/access-systems) associated with Seam Bridge.',
+      'ID of the [access system](https://docs.seam.co/capability-guides/access-systems) associated with Seam Bridge.',
     ),
   acs_system_display_name: z
     .string()
     .describe(
-      'Display name for the [access system](https://docs.seam.co/latest/capability-guides/access-systems) associated with Seam Bridge.',
+      'Display name for the [access system](https://docs.seam.co/capability-guides/access-systems) associated with Seam Bridge.',
     ),
   workspace_id: z
     .string()
     .uuid()
     .describe(
-      'ID of the [workspace](https://docs.seam.co/latest/core-concepts/workspaces) with which Seam Bridge is paired.',
+      'ID of the [workspace](https://docs.seam.co/core-concepts/workspaces) with which Seam Bridge is paired.',
     ),
   workspace_display_name: z
     .string()
     .describe(
-      'Display name for the [workspace](https://docs.seam.co/latest/core-concepts/workspaces) with which Seam Bridge is paired.',
+      'Display name for the [workspace](https://docs.seam.co/core-concepts/workspaces) with which Seam Bridge is paired.',
     ),
 }).describe(`
   ---
   route_path: /seam/bridge/v1/bridge_connected_systems
   undocumented: Seam Bridge client only.
   ---
-  Represents an access system connected to [Seam Bridge](https://docs.seam.co/latest/capability-guides/seam-bridge).
+  Represents an access system connected to [Seam Bridge](https://docs.seam.co/capability-guides/seam-bridge).
 `)
 
 export type BridgeConnectedSystem = z.infer<typeof bridge_connected_system>

--- a/src/lib/seam/connect/models/bridges/bridge.ts
+++ b/src/lib/seam/connect/models/bridges/bridge.ts
@@ -6,7 +6,7 @@ export const bridge = z.object({
     .string()
     .uuid()
     .describe(
-      'ID of the [workspace](https://docs.seam.co/latest/core-concepts/workspaces) that contains Seam Bridge.',
+      'ID of the [workspace](https://docs.seam.co/core-concepts/workspaces) that contains Seam Bridge.',
     ),
   created_at: z
     .string()
@@ -17,6 +17,6 @@ export const bridge = z.object({
 undocumented: Unreleased.
 route_path: /bridges
 ---
-Represents [Seam Bridge](https://docs.seam.co/latest/capability-guides/seam-bridge).
+Represents [Seam Bridge](https://docs.seam.co/capability-guides/seam-bridge).
 `)
 export type Bridge = z.infer<typeof bridge>

--- a/src/lib/seam/connect/models/client-sessions/client-session.ts
+++ b/src/lib/seam/connect/models/client-sessions/client-session.ts
@@ -5,76 +5,76 @@ export const client_session = z.object({
     .string()
     .uuid()
     .describe(
-      'ID of the [client session](https://docs.seam.co/latest/core-concepts/authentication/client-session-tokens).',
+      'ID of the [client session](https://docs.seam.co/core-concepts/authentication/client-session-tokens).',
     ),
   workspace_id: z
     .string()
     .uuid()
     .describe(
-      'ID of the [workspace](https://docs.seam.co/latest/core-concepts/workspaces) associated with the [client session](https://docs.seam.co/latest/core-concepts/authentication/client-session-tokens).',
+      'ID of the [workspace](https://docs.seam.co/core-concepts/workspaces) associated with the [client session](https://docs.seam.co/core-concepts/authentication/client-session-tokens).',
     ),
   created_at: z
     .string()
     .datetime()
     .describe(
-      'Date and time at which the [client session](https://docs.seam.co/latest/core-concepts/authentication/client-session-tokens) was created.',
+      'Date and time at which the [client session](https://docs.seam.co/core-concepts/authentication/client-session-tokens) was created.',
     ),
   expires_at: z
     .string()
     .datetime()
     .describe(
-      'Date and time at which the [client session](https://docs.seam.co/latest/core-concepts/authentication/client-session-tokens) expires.',
+      'Date and time at which the [client session](https://docs.seam.co/core-concepts/authentication/client-session-tokens) expires.',
     ),
   token: z
     .string()
     .describe(
-      'Client session token associated with the [client session](https://docs.seam.co/latest/core-concepts/authentication/client-session-tokens).',
+      'Client session token associated with the [client session](https://docs.seam.co/core-concepts/authentication/client-session-tokens).',
     ),
   user_identifier_key: z
     .string()
     .nullable()
     .describe(
-      'Your user ID for the user associated with the [client session](https://docs.seam.co/latest/core-concepts/authentication/client-session-tokens).',
+      'Your user ID for the user associated with the [client session](https://docs.seam.co/core-concepts/authentication/client-session-tokens).',
     ),
   device_count: z
     .number()
     .describe(
-      'Number of devices associated with the [client session](https://docs.seam.co/latest/core-concepts/authentication/client-session-tokens).',
+      'Number of devices associated with the [client session](https://docs.seam.co/core-concepts/authentication/client-session-tokens).',
     ),
   customer_key: z
     .string()
     .optional()
     .describe(
-      'Customer key associated with the [client session](https://docs.seam.co/latest/core-concepts/authentication/client-session-tokens).',
+      'Customer key associated with the [client session](https://docs.seam.co/core-concepts/authentication/client-session-tokens).',
     ),
   connected_account_ids: z
     .array(z.string().uuid())
     .describe(
-      'IDs of the [connected accounts](https://docs.seam.co/latest/core-concepts/connected-accounts) associated with the [client session](https://docs.seam.co/latest/core-concepts/authentication/client-session-tokens).',
+      'IDs of the [connected accounts](https://docs.seam.co/core-concepts/connected-accounts) associated with the [client session](https://docs.seam.co/core-concepts/authentication/client-session-tokens).',
     ),
   connect_webview_ids: z
     .array(z.string().uuid())
     .describe(
-      'IDs of the [Connect Webviews](https://docs.seam.co/latest/core-concepts/connect-webviews) associated with the [client session](https://docs.seam.co/latest/core-concepts/authentication/client-session-tokens).',
+      'IDs of the [Connect Webviews](https://docs.seam.co/core-concepts/connect-webviews) associated with the [client session](https://docs.seam.co/core-concepts/authentication/client-session-tokens).',
     ),
   user_identity_ids: z.array(z.string().uuid()).describe(`
     ---
     deprecated: Use \`user_identity_id\` instead.
     ---
-    IDs of the [user identities](https://docs.seam.co/latest/capability-guides/mobile-access/managing-mobile-app-user-accounts-with-user-identities#what-is-a-user-identity) associated with the client session.
+    IDs of the [user identities](https://docs.seam.co/capability-guides/mobile-access/managing-mobile-app-user-accounts-with-user-identities#what-is-a-user-identity) associated with the client session.
   `),
   user_identity_id: z
     .string()
     .uuid()
     .optional()
     .describe(
-      'ID of the [user identity](https://docs.seam.co/latest/capability-guides/mobile-access/managing-mobile-app-user-accounts-with-user-identities#what-is-a-user-identity) associated with the client session.',
+      'ID of the [user identity](https://docs.seam.co/capability-guides/mobile-access/managing-mobile-app-user-accounts-with-user-identities#what-is-a-user-identity) associated with the client session.',
     ),
 }).describe(`
   ---
   route_path: /client_sessions
   ---
-  Represents a [client session](https://docs.seam.co/latest/core-concepts/authentication/client-session-tokens). If you want to restrict your users' access to their own devices, use client sessions.
+  Represents a [client session](https://docs.seam.co/core-concepts/authentication/client-session-tokens). If you want to restrict your users' access to their own devices, use client sessions.
 
   You create each client session with a custom \`user_identifier_key\`. Normally, the \`user_identifier_key\` is a user ID that your application provides.
 
@@ -82,7 +82,7 @@ export const client_session = z.object({
 
   A client session has a token that you can use with the Seam JavaScript SDK to make requests from the client (browser) directly to the Seam API. The token restricts the user's access to only the devices that they own.
 
-  See also [Get Started with React](https://docs.seam.co/latest/ui-components/overview/getting-started-with-seam-components/get-started-with-react-components-and-client-session-tokens).
+  See also [Get Started with React](https://docs.seam.co/ui-components/overview/getting-started-with-seam-components/get-started-with-react-components-and-client-session-tokens).
 `)
 
 export type ClientSession = z.infer<typeof client_session>

--- a/src/lib/seam/connect/models/connect-webviews/connect-webview.ts
+++ b/src/lib/seam/connect/models/connect-webviews/connect-webview.ts
@@ -15,7 +15,7 @@ export const connect_webview = z.object({
     .string()
     .uuid()
     .describe(
-      'ID of the [workspace](https://docs.seam.co/latest/core-concepts/workspaces) that contains the Connect Webview.',
+      'ID of the [workspace](https://docs.seam.co/core-concepts/workspaces) that contains the Connect Webview.',
     ),
   created_at: z
     .string()
@@ -26,7 +26,7 @@ export const connect_webview = z.object({
     .uuid()
     .nullable()
     .describe(
-      'ID of the [connected account](https://docs.seam.co/latest/core-concepts/connected-accounts) associated with the Connect Webview.',
+      'ID of the [connected account](https://docs.seam.co/core-concepts/connected-accounts) associated with the Connect Webview.',
     ),
   url: z
     .string()
@@ -40,7 +40,7 @@ export const connect_webview = z.object({
   accepted_providers: z
     .array(z.string())
     .describe(
-      'List of accepted [provider keys](https://docs.seam.co/latest/core-concepts/connect-webviews/customizing-connect-webviews#customize-the-brands-to-display-in-your-connect-webviews).',
+      'List of accepted [provider keys](https://docs.seam.co/core-concepts/connect-webviews/customizing-connect-webviews#customize-the-brands-to-display-in-your-connect-webviews).',
     ),
 
   accepted_capabilities: z
@@ -97,12 +97,12 @@ export const connect_webview = z.object({
   automatically_manage_new_devices: z
     .boolean()
     .describe(
-      'Indicates whether Seam should [import all new devices](https://docs.seam.co/latest/core-concepts/connect-webviews/customizing-connect-webviews#automatically_manage_new_devices) for the connected account to make these devices available for use and management by the Seam API.',
+      'Indicates whether Seam should [import all new devices](https://docs.seam.co/core-concepts/connect-webviews/customizing-connect-webviews#automatically_manage_new_devices) for the connected account to make these devices available for use and management by the Seam API.',
     ),
   wait_for_device_creation: z
     .boolean()
     .describe(
-      'Indicates whether Seam should [finish syncing all devices](https://docs.seam.co/latest/core-concepts/connect-webviews/customizing-connect-webviews#wait_for_device_creation) in a newly-connected account before completing the associated Connect Webview.',
+      'Indicates whether Seam should [finish syncing all devices](https://docs.seam.co/core-concepts/connect-webviews/customizing-connect-webviews#wait_for_device_creation) in a newly-connected account before completing the associated Connect Webview.',
     ),
   authorized_at: z
     .string()
@@ -115,7 +115,7 @@ export const connect_webview = z.object({
     .string()
     .nullable()
     .describe(
-      'Selected provider of the Connect Webview, one of the [provider keys](https://docs.seam.co/latest/core-concepts/connect-webviews/customizing-connect-webviews#customize-the-brands-to-display-in-your-connect-webviews).',
+      'Selected provider of the Connect Webview, one of the [provider keys](https://docs.seam.co/core-concepts/connect-webviews/customizing-connect-webviews#customize-the-brands-to-display-in-your-connect-webviews).',
     ),
   customer_key: z
     .string()
@@ -125,7 +125,7 @@ export const connect_webview = z.object({
   ---
   route_path: /connect_webviews
   ---
-  Represents a [Connect Webview](https://docs.seam.co/latest/core-concepts/connect-webviews).
+  Represents a [Connect Webview](https://docs.seam.co/core-concepts/connect-webviews).
 
   Connect Webviews are fully-embedded client-side components that you add to your app. Your users interact with your embedded Connect Webviews to link their IoT device or system accounts to Seam. That is, Connect Webviews walk your users through the process of logging in to their device or system accounts. Seam handles all the authentication steps, and—once your user has completed the authorization through your app—you can access and control their devices or systems using the Seam API.
   

--- a/src/lib/seam/connect/models/connected-accounts/connected-account.ts
+++ b/src/lib/seam/connect/models/connected-accounts/connected-account.ts
@@ -23,7 +23,7 @@ const common_connected_account_error = z.object({
     .boolean()
     .optional()
     .describe(
-      'Indicates whether the error is related to [Seam Bridge](https://docs.seam.co/latest/capability-guides/seam-bridge).',
+      'Indicates whether the error is related to [Seam Bridge](https://docs.seam.co/capability-guides/seam-bridge).',
     ),
 })
 
@@ -60,7 +60,7 @@ export const bridge_disconnected = common_connected_account_error
       .describe(error_code_description),
   })
   .describe(
-    'Indicates that the Seam API cannot communicate with [Seam Bridge](https://docs.seam.co/latest/capability-guides/seam-bridge), for example, if the Seam Bridge executable has stopped or if the computer running the Seam Bridge executable is offline. See also [Troubleshooting Your Access Control System](https://docs.seam.co/latest/capability-guides/access-systems/troubleshooting-your-access-control-system#acs_system.errors.seam_bridge_disconnected).',
+    'Indicates that the Seam API cannot communicate with [Seam Bridge](https://docs.seam.co/capability-guides/seam-bridge), for example, if the Seam Bridge executable has stopped or if the computer running the Seam Bridge executable is offline. See also [Troubleshooting Your Access Control System](https://docs.seam.co/capability-guides/access-systems/troubleshooting-your-access-control-system#acs_system.errors.seam_bridge_disconnected).',
   )
 
 export const salto_ks_subscription_limit_exceeded =
@@ -342,7 +342,7 @@ export const connected_account = z.object({
   automatically_manage_new_devices: z
     .boolean()
     .describe(
-      'Indicates whether Seam should [import all new devices](https://docs.seam.co/latest/core-concepts/connect-webviews/customizing-connect-webviews#automatically_manage_new_devices) for the connected account to make these devices available for management by the Seam API.',
+      'Indicates whether Seam should [import all new devices](https://docs.seam.co/core-concepts/connect-webviews/customizing-connect-webviews#automatically_manage_new_devices) for the connected account to make these devices available for management by the Seam API.',
     ),
   customer_key: z
     .string()
@@ -389,7 +389,7 @@ export const connected_account = z.object({
   ---
   route_path: /connected_accounts
   ---
-  Represents a [connected account](https://docs.seam.co/latest/core-concepts/connected-accounts). A connected account is an external third-party account to which your user has authorized Seam to get access, for example, an August account with a list of door locks.
+  Represents a [connected account](https://docs.seam.co/core-concepts/connected-accounts). A connected account is an external third-party account to which your user has authorized Seam to get access, for example, an August account with a list of door locks.
 `)
 
 export type ConnectedAccount = z.infer<typeof connected_account>

--- a/src/lib/seam/connect/models/custom-metadata.ts
+++ b/src/lib/seam/connect/models/custom-metadata.ts
@@ -9,13 +9,13 @@ export const custom_metadata_input = z
     message: 'Custom metadata is limited to a maximum of 50 keys',
   })
   .describe(
-    'Set of up to 50 key:value pairs, with key names up to 40 characters long. Accepts string or Boolean values. Strings are limited to 500 characters. Adding custom metadata to a resource, such as a [Connect Webview](https://docs.seam.co/latest/core-concepts/connect-webviews/attaching-custom-data-to-the-connect-webview), [connected account](https://docs.seam.co/latest/core-concepts/connected-accounts/adding-custom-metadata-to-a-connected-account), or [device](https://docs.seam.co/latest/core-concepts/devices/adding-custom-metadata-to-a-device), enables you to store custom information, like customer details or internal IDs from your application.',
+    'Set of up to 50 key:value pairs, with key names up to 40 characters long. Accepts string or Boolean values. Strings are limited to 500 characters. Adding custom metadata to a resource, such as a [Connect Webview](https://docs.seam.co/core-concepts/connect-webviews/attaching-custom-data-to-the-connect-webview), [connected account](https://docs.seam.co/core-concepts/connected-accounts/adding-custom-metadata-to-a-connected-account), or [device](https://docs.seam.co/core-concepts/devices/adding-custom-metadata-to-a-device), enables you to store custom information, like customer details or internal IDs from your application.',
   )
 
 export const custom_metadata = z
   .record(z.string(), z.union([z.string(), z.boolean()]))
   .describe(
-    'Set of key:value pairs. Adding custom metadata to a resource, such as a [Connect Webview](https://docs.seam.co/latest/core-concepts/connect-webviews/attaching-custom-data-to-the-connect-webview), [connected account](https://docs.seam.co/latest/core-concepts/connected-accounts/adding-custom-metadata-to-a-connected-account), or [device](https://docs.seam.co/latest/core-concepts/devices/adding-custom-metadata-to-a-device), enables you to store custom information, like customer details or internal IDs from your application.',
+    'Set of key:value pairs. Adding custom metadata to a resource, such as a [Connect Webview](https://docs.seam.co/core-concepts/connect-webviews/attaching-custom-data-to-the-connect-webview), [connected account](https://docs.seam.co/core-concepts/connected-accounts/adding-custom-metadata-to-a-connected-account), or [device](https://docs.seam.co/core-concepts/devices/adding-custom-metadata-to-a-device), enables you to store custom information, like customer details or internal IDs from your application.',
   )
 
 export type CustomMetadata = z.output<typeof custom_metadata>

--- a/src/lib/seam/connect/models/customer/customer.ts
+++ b/src/lib/seam/connect/models/customer/customer.ts
@@ -8,7 +8,7 @@ export const customer = z.object({
     .string()
     .uuid()
     .describe(
-      'ID of the [workspace](https://docs.seam.co/latest/core-concepts/workspaces) associated with the customer.',
+      'ID of the [workspace](https://docs.seam.co/core-concepts/workspaces) associated with the customer.',
     ),
   created_at: z
     .string()

--- a/src/lib/seam/connect/models/devices/capabilities-supported.ts
+++ b/src/lib/seam/connect/models/devices/capabilities-supported.ts
@@ -8,7 +8,7 @@ export const capabilities = z.enum([
   'battery',
   'phone',
 ]).describe(`
-        Collection of capabilities that the device supports when connected to Seam. **Important:** Superseded by [capability flags](https://docs.seam.co/latest/capability-guides/device-and-system-capabilities#capability-flags).
+        Collection of capabilities that the device supports when connected to Seam. **Important:** Superseded by [capability flags](https://docs.seam.co/capability-guides/device-and-system-capabilities#capability-flags).
         `)
 
 export type Capabilities = z.infer<typeof capabilities>

--- a/src/lib/seam/connect/models/devices/capability-properties/access-code.ts
+++ b/src/lib/seam/connect/models/devices/capability-properties/access-code.ts
@@ -68,7 +68,7 @@ export const access_code_capability_properties = z.object({
           ---
           property_group_key: access_codes
           ---
-          Indicates whether the device supports a [backup access code pool](https://docs.seam.co/latest/capability-guides/smart-locks/access-codes/backup-access-codes).`),
+          Indicates whether the device supports a [backup access code pool](https://docs.seam.co/capability-guides/smart-locks/access-codes/backup-access-codes).`),
   has_native_entry_events: z.boolean().optional().describe(`
           ---
           property_group_key: access_codes

--- a/src/lib/seam/connect/models/devices/capability-properties/thermostat.ts
+++ b/src/lib/seam/connect/models/devices/capability-properties/thermostat.ts
@@ -104,121 +104,121 @@ export const thermostat_capability_properties = z
           ---
           property_group_key: thermostats
           ---
-          Available [climate presets](https://docs.seam.co/latest/capability-guides/thermostats/creating-and-managing-climate-presets) for the thermostat.
+          Available [climate presets](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-climate-presets) for the thermostat.
           `),
     fallback_climate_preset_key: z.string().min(1).nullable().describe(`
           ---
           property_group_key: thermostats
           ---
-          Key of the [fallback climate preset](https://docs.seam.co/latest/capability-guides/thermostats/creating-and-managing-climate-presets/setting-the-fallback-climate-preset) for the thermostat.
+          Key of the [fallback climate preset](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-climate-presets/setting-the-fallback-climate-preset) for the thermostat.
           `),
     active_thermostat_schedule: thermostat_schedule.nullable().describe(`
           ---
           property_group_key: thermostats
           deprecated: Use \`active_thermostat_schedule_id\` with \`/thermostats/schedules/get\` instead.
           ---
-          Active [thermostat schedule](https://docs.seam.co/latest/capability-guides/thermostats/creating-and-managing-thermostat-schedules).
+          Active [thermostat schedule](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-thermostat-schedules).
           `),
     active_thermostat_schedule_id: z.string().uuid().nullable().describe(`
           ---
           property_group_key: thermostats
           ---
-          ID of the active [thermostat schedule](https://docs.seam.co/latest/capability-guides/thermostats/creating-and-managing-thermostat-schedules).
+          ID of the active [thermostat schedule](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-thermostat-schedules).
           `),
     thermostat_daily_programs: z.array(thermostat_daily_program).optional()
       .describe(`
           ---
           property_group_key: thermostats
           ---
-          Configured [daily programs](https://docs.seam.co/latest/capability-guides/thermostats/creating-and-managing-thermostat-programs) for the thermostat.
+          Configured [daily programs](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-thermostat-programs) for the thermostat.
           `),
     thermostat_weekly_program: thermostat_weekly_program.nullable().optional()
       .describe(`
           ---
           property_group_key: thermostats
           ---
-          Current [weekly program](https://docs.seam.co/latest/capability-guides/thermostats/creating-and-managing-thermostat-programs) for the thermostat.
+          Current [weekly program](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-thermostat-programs) for the thermostat.
           `),
     min_cooling_set_point_celsius: z.number().describe(`
           ---
           property_group_key: thermostats
           ---
-          Minimum [cooling set point](https://docs.seam.co/latest/capability-guides/thermostats/understanding-thermostat-concepts/set-points#cooling-set-point) in °C.
+          Minimum [cooling set point](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/set-points#cooling-set-point) in °C.
           `),
     min_cooling_set_point_fahrenheit: z.number().describe(`
           ---
           property_group_key: thermostats
           ---
-          Minimum [cooling set point](https://docs.seam.co/latest/capability-guides/thermostats/understanding-thermostat-concepts/set-points#cooling-set-point) in °F.
+          Minimum [cooling set point](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/set-points#cooling-set-point) in °F.
           `),
     max_cooling_set_point_celsius: z.number().describe(`
           ---
           property_group_key: thermostats
           ---
-          Maximum [cooling set point](https://docs.seam.co/latest/capability-guides/thermostats/understanding-thermostat-concepts/set-points#cooling-set-point) in °C.
+          Maximum [cooling set point](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/set-points#cooling-set-point) in °C.
           `),
     max_cooling_set_point_fahrenheit: z.number().describe(`
           ---
           property_group_key: thermostats
           ---
-          Maximum [cooling set point](https://docs.seam.co/latest/capability-guides/thermostats/understanding-thermostat-concepts/set-points#cooling-set-point) in °F.
+          Maximum [cooling set point](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/set-points#cooling-set-point) in °F.
           `),
     min_heating_set_point_celsius: z.number().describe(`
           ---
           property_group_key: thermostats
           ---
-          Minimum [heating set point](https://docs.seam.co/latest/capability-guides/thermostats/understanding-thermostat-concepts/set-points#heating-set-point) in °C.
+          Minimum [heating set point](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/set-points#heating-set-point) in °C.
           `),
     min_heating_set_point_fahrenheit: z.number().describe(`
           ---
           property_group_key: thermostats
           ---
-          Minimum [heating set point](https://docs.seam.co/latest/capability-guides/thermostats/understanding-thermostat-concepts/set-points#heating-set-point) in °F.
+          Minimum [heating set point](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/set-points#heating-set-point) in °F.
           `),
     max_heating_set_point_celsius: z.number().describe(`
           ---
           property_group_key: thermostats
           ---
-          Maximum [heating set point](https://docs.seam.co/latest/capability-guides/thermostats/understanding-thermostat-concepts/set-points#heating-set-point) in °C.
+          Maximum [heating set point](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/set-points#heating-set-point) in °C.
           `),
     max_heating_set_point_fahrenheit: z.number().describe(`
           ---
           property_group_key: thermostats
           ---
-          Maximum [heating set point](https://docs.seam.co/latest/capability-guides/thermostats/understanding-thermostat-concepts/set-points#heating-set-point) in °F.
+          Maximum [heating set point](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/set-points#heating-set-point) in °F.
           `),
     min_heating_cooling_delta_celsius: z.number().describe(`
           ---
           property_group_key: thermostats
           ---
-          Minimum [temperature difference](https://docs.seam.co/latest/capability-guides/thermostats/understanding-thermostat-concepts/set-points#minimum-heating-cooling-temperature-delta) in °C between the cooling and heating set points when in heat-cool (auto) mode.
+          Minimum [temperature difference](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/set-points#minimum-heating-cooling-temperature-delta) in °C between the cooling and heating set points when in heat-cool (auto) mode.
           `),
     min_heating_cooling_delta_fahrenheit: z.number().describe(`
           ---
           property_group_key: thermostats
           ---
-          Minimum [temperature difference](https://docs.seam.co/latest/capability-guides/thermostats/understanding-thermostat-concepts/set-points#minimum-heating-cooling-temperature-delta) in °F between the cooling and heating set points when in heat-cool (auto) mode.
+          Minimum [temperature difference](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/set-points#minimum-heating-cooling-temperature-delta) in °F between the cooling and heating set points when in heat-cool (auto) mode.
           `),
     temperature_threshold: z
       .object({
         lower_limit_celsius: z.number().nullable()
-          .describe(`Lower limit in °C within the current [temperature threshold](https://docs.seam.co/latest/capability-guides/thermostats/setting-and-monitoring-temperature-thresholds) set for the thermostat.
+          .describe(`Lower limit in °C within the current [temperature threshold](https://docs.seam.co/capability-guides/thermostats/setting-and-monitoring-temperature-thresholds) set for the thermostat.
           `),
         lower_limit_fahrenheit: z.number().nullable()
-          .describe(`Lower limit in °F within the current [temperature threshold](https://docs.seam.co/latest/capability-guides/thermostats/setting-and-monitoring-temperature-thresholds) set for the thermostat.
+          .describe(`Lower limit in °F within the current [temperature threshold](https://docs.seam.co/capability-guides/thermostats/setting-and-monitoring-temperature-thresholds) set for the thermostat.
           `),
         upper_limit_celsius: z.number().nullable()
-          .describe(`Upper limit in °C within the current [temperature threshold](https://docs.seam.co/latest/capability-guides/thermostats/setting-and-monitoring-temperature-thresholds) set for the thermostat.
+          .describe(`Upper limit in °C within the current [temperature threshold](https://docs.seam.co/capability-guides/thermostats/setting-and-monitoring-temperature-thresholds) set for the thermostat.
           `),
         upper_limit_fahrenheit: z.number().nullable()
-          .describe(`Upper limit in °F within the current [temperature threshold](https://docs.seam.co/latest/capability-guides/thermostats/setting-and-monitoring-temperature-thresholds) set for the thermostat.
+          .describe(`Upper limit in °F within the current [temperature threshold](https://docs.seam.co/capability-guides/thermostats/setting-and-monitoring-temperature-thresholds) set for the thermostat.
           `),
       })
       .optional().describe(`
           ---
           property_group_key: thermostats
           ---
-          Current [temperature threshold](https://docs.seam.co/latest/capability-guides/thermostats/setting-and-monitoring-temperature-thresholds) set for the thermostat.
+          Current [temperature threshold](https://docs.seam.co/capability-guides/thermostats/setting-and-monitoring-temperature-thresholds) set for the thermostat.
           `),
     thermostat_daily_program_period_precision_minutes: z.number().optional()
       .describe(`

--- a/src/lib/seam/connect/models/devices/device.ts
+++ b/src/lib/seam/connect/models/devices/device.ts
@@ -98,7 +98,7 @@ const account_disconnected = common_device_error
     is_connected_account_error: z
       .literal(true)
       .describe(
-        'Indicates that the error is a [connected account](https://docs.seam.co/latest/api/connected_accounts) error.',
+        'Indicates that the error is a [connected account](https://docs.seam.co/api/connected_accounts) error.',
       ),
     is_device_error: z
       .literal(false)
@@ -114,7 +114,7 @@ const empty_backup_access_code_pool = common_device_error.extend({
     ---
     variant_group_key: access_codes
     ---
-    Indicates that the [backup access code pool](https://docs.seam.co/latest/capability-guides/smart-locks/access-codes/backup-access-codes) is empty.
+    Indicates that the [backup access code pool](https://docs.seam.co/capability-guides/smart-locks/access-codes/backup-access-codes) is empty.
     `)
 
 const august_lock_not_authorized = common_device_error.extend({
@@ -147,7 +147,7 @@ const salto_ks_subscription_limit_exceeded = common_device_error.extend({
   is_connected_account_error: z
     .literal(true)
     .describe(
-      'Indicates that the error is a [connected account](https://docs.seam.co/latest/api/connected_accounts) error.',
+      'Indicates that the error is a [connected account](https://docs.seam.co/api/connected_accounts) error.',
     ),
   is_device_error: z
     .literal(false)
@@ -897,7 +897,7 @@ export const device = z
         'Display name of the device, defaults to nickname (if it is set) or `properties.appearance.name`, otherwise. Enables administrators and users to identify the device easily, especially when there are numerous devices.',
       ),
     capabilities_supported: z.array(capabilities).describe(`
-        Collection of capabilities that the device supports when connected to Seam. Values are \`access_code\`, which indicates that the device can manage and utilize digital PIN codes for secure access; \`lock\`, which indicates that the device controls a door locking mechanism, enabling the remote opening and closing of doors and other entry points; \`noise_detection\`, which indicates that the device supports monitoring and responding to ambient noise levels; \`thermostat\`, which indicates that the device can regulate and adjust indoor temperatures; \`battery\`, which indicates that the device can manage battery life and health; and \`phone\`, which indicates that the device is a mobile device, such as a smartphone. **Important:** Superseded by [capability flags](https://docs.seam.co/latest/capability-guides/device-and-system-capabilities#capability-flags).
+        Collection of capabilities that the device supports when connected to Seam. Values are \`access_code\`, which indicates that the device can manage and utilize digital PIN codes for secure access; \`lock\`, which indicates that the device controls a door locking mechanism, enabling the remote opening and closing of doors and other entry points; \`noise_detection\`, which indicates that the device supports monitoring and responding to ambient noise levels; \`thermostat\`, which indicates that the device can regulate and adjust indoor temperatures; \`battery\`, which indicates that the device can manage battery life and health; and \`phone\`, which indicates that the device is a mobile device, such as a smartphone. **Important:** Superseded by [capability flags](https://docs.seam.co/capability-guides/device-and-system-capabilities#capability-flags).
         `),
     properties: common_device_properties
       .and(phone_specific_properties.partial())
@@ -1014,7 +1014,7 @@ export const device = z
     is_managed: z
       .literal(true)
       .describe(
-        'Indicates whether Seam manages the device. See also [Managed and Unmanaged Devices](https://docs.seam.co/latest/core-concepts/devices/managed-and-unmanaged-devices).',
+        'Indicates whether Seam manages the device. See also [Managed and Unmanaged Devices](https://docs.seam.co/core-concepts/devices/managed-and-unmanaged-devices).',
       ),
     custom_metadata,
     device_provider: device_provider_info.optional().describe(`
@@ -1049,7 +1049,7 @@ export const device = z
       provider_metadata:
         name: Provider Metadata
     ---
-    Represents a [device](https://docs.seam.co/latest/core-concepts/devices) that has been connected to Seam.
+    Represents a [device](https://docs.seam.co/core-concepts/devices) that has been connected to Seam.
   `)
 
 export type Device = z.infer<typeof device>

--- a/src/lib/seam/connect/models/devices/phone.ts
+++ b/src/lib/seam/connect/models/devices/phone.ts
@@ -25,13 +25,13 @@ export const phone = z.object({
     .describe(`Display name of the phone. Defaults to \`nickname\` (if it is set) or \`properties.appearance.name\`, otherwise. Enables administrators and users to identify the phone easily, especially when there are numerous phones.
   `),
   workspace_id: basePhoneDeviceSchema.shape.workspace_id
-    .describe(`ID of the [workspace](https://docs.seam.co/latest/core-concepts/workspaces) that contains the phone.
+    .describe(`ID of the [workspace](https://docs.seam.co/core-concepts/workspaces) that contains the phone.
   `),
   created_at: basePhoneDeviceSchema.shape.created_at
     .describe(`Date and time at which the phone was created.
   `),
   custom_metadata: basePhoneDeviceSchema.shape.custom_metadata
-    .describe(`Optional [custom metadata](https://docs.seam.co/latest/core-concepts/devices/adding-custom-metadata-to-a-device) for the phone.
+    .describe(`Optional [custom metadata](https://docs.seam.co/core-concepts/devices/adding-custom-metadata-to-a-device) for the phone.
   `),
 
   errors: z

--- a/src/lib/seam/connect/models/devices/unmanaged-device.ts
+++ b/src/lib/seam/connect/models/devices/unmanaged-device.ts
@@ -73,7 +73,7 @@ export const unmanaged_device = device
       provider_metadata:
         name: Provider Metadata
     ---
-    Represents an [unmanaged device](https://docs.seam.co/latest/core-concepts/devices/managed-and-unmanaged-devices). An unmanaged device has a limited set of visible properties and a subset of supported events. You cannot control an unmanaged device. Any [access codes](https://docs.seam.co/latest/capability-guides/smart-locks/access-codes/migrating-existing-access-codes) on an unmanaged device are unmanaged. To control an unmanaged device with Seam, [convert it to a managed device](https://docs.seam.co/latest/core-concepts/devices/managed-and-unmanaged-devices#convert-an-unmanaged-device-to-managed).
+    Represents an [unmanaged device](https://docs.seam.co/core-concepts/devices/managed-and-unmanaged-devices). An unmanaged device has a limited set of visible properties and a subset of supported events. You cannot control an unmanaged device. Any [access codes](https://docs.seam.co/capability-guides/smart-locks/access-codes/migrating-existing-access-codes) on an unmanaged device are unmanaged. To control an unmanaged device with Seam, [convert it to a managed device](https://docs.seam.co/core-concepts/devices/managed-and-unmanaged-devices#convert-an-unmanaged-device-to-managed).
   `)
 
 export type UnmanagedDevice = z.infer<typeof unmanaged_device>

--- a/src/lib/seam/connect/models/events/access-codes.ts
+++ b/src/lib/seam/connect/models/events/access-codes.ts
@@ -17,7 +17,7 @@ const access_code_event = common_event.extend({
     .string()
     .uuid()
     .describe(
-      'ID of the [connected account](https://docs.seam.co/latest/core-concepts/connected-accounts) associated with the affected access code.',
+      'ID of the [connected account](https://docs.seam.co/core-concepts/connected-accounts) associated with the affected access code.',
     ),
   device_custom_metadata: custom_metadata
     .optional()
@@ -60,7 +60,7 @@ export const access_code_created_event = access_code_event.extend({
     ---
     route_path: /access_codes
     ---
-    An [access code](https://docs.seam.co/latest/capability-guides/smart-locks/access-codes) was created.
+    An [access code](https://docs.seam.co/capability-guides/smart-locks/access-codes) was created.
   `)
 
 export type AccessCodeCreatedEvent = z.infer<typeof access_code_created_event>
@@ -71,7 +71,7 @@ export const access_code_changed_event = access_code_event.extend({
     ---
     route_path: /access_codes
     ---
-    An [access code](https://docs.seam.co/latest/capability-guides/smart-locks/access-codes) was changed.
+    An [access code](https://docs.seam.co/capability-guides/smart-locks/access-codes) was changed.
   `)
 
 export type AccessCodeChangedEvent = z.infer<typeof access_code_changed_event>
@@ -83,7 +83,7 @@ export const access_code_scheduled_on_device_event = access_code_event.extend({
     ---
     route_path: /access_codes
     ---
-    An [access code](https://docs.seam.co/latest/capability-guides/smart-locks/access-codes) was [scheduled natively](https://docs.seam.co/latest/capability-guides/smart-locks/access-codes#native-scheduling) on a device.
+    An [access code](https://docs.seam.co/capability-guides/smart-locks/access-codes) was [scheduled natively](https://docs.seam.co/capability-guides/smart-locks/access-codes#native-scheduling) on a device.
   `)
 
 export type AccessCodeScheduledOnDeviceEvent = z.infer<
@@ -97,7 +97,7 @@ export const access_code_set_on_device_event = access_code_event.extend({
     ---
     route_path: /access_codes
     ---
-    An [access code](https://docs.seam.co/latest/capability-guides/smart-locks/access-codes) was set on a device.
+    An [access code](https://docs.seam.co/capability-guides/smart-locks/access-codes) was set on a device.
   `)
 
 export type AccessCodeSetOnDeviceEvent = z.infer<
@@ -110,7 +110,7 @@ export const access_code_removed_from_device_event = access_code_event.extend({
     ---
     route_path: /access_codes
     ---
-    An [access code](https://docs.seam.co/latest/capability-guides/smart-locks/access-codes) was removed from a device.
+    An [access code](https://docs.seam.co/capability-guides/smart-locks/access-codes) was removed from a device.
   `)
 
 export type AccessCodeRemovedFromDeviceEvent = z.infer<
@@ -125,7 +125,7 @@ export const access_code_delay_in_setting_on_device_event = access_code_event
     ---
     route_path: /access_codes
     ---
-    There was an unusually long delay in setting an [access code](https://docs.seam.co/latest/capability-guides/smart-locks/access-codes) on a device.
+    There was an unusually long delay in setting an [access code](https://docs.seam.co/capability-guides/smart-locks/access-codes) on a device.
   `)
 
 export type AccessCodeDelayInSettingOnDeviceEvent = z.infer<
@@ -140,7 +140,7 @@ export const access_code_failed_to_set_on_device_event = access_code_event
     ---
     route_path: /access_codes
     ---
-    An [access code](https://docs.seam.co/latest/capability-guides/smart-locks/access-codes) failed to be set on a device.
+    An [access code](https://docs.seam.co/capability-guides/smart-locks/access-codes) failed to be set on a device.
   `)
 
 export type AccessCodeFailedToSetOnDeviceEvent = z.infer<
@@ -154,7 +154,7 @@ export const access_code_deleted_event = access_code_event.extend({
     ---
     route_path: /access_codes
     ---
-    An [access code](https://docs.seam.co/latest/capability-guides/smart-locks/access-codes) was deleted.
+    An [access code](https://docs.seam.co/capability-guides/smart-locks/access-codes) was deleted.
   `)
 
 export type AccessCodeDeletedEvent = z.infer<typeof access_code_deleted_event>
@@ -167,7 +167,7 @@ export const access_code_delay_in_removing_from_device_event = access_code_event
     ---
     route_path: /access_codes
     ---
-    There was an unusually long delay in removing an [access code](https://docs.seam.co/latest/capability-guides/smart-locks/access-codes) from a device.
+    There was an unusually long delay in removing an [access code](https://docs.seam.co/capability-guides/smart-locks/access-codes) from a device.
   `)
 
 export type AccessCodeDelayInRemovingFromDeviceEvent = z.infer<
@@ -182,7 +182,7 @@ export const access_code_failed_to_remove_from_device_event = access_code_event
     ---
     route_path: /access_codes
     ---
-    An [access code](https://docs.seam.co/latest/capability-guides/smart-locks/access-codes) failed to be removed from a device.
+    An [access code](https://docs.seam.co/capability-guides/smart-locks/access-codes) failed to be removed from a device.
   `)
 
 export type AccessCodeFailedToRemoveFromDeviceEvent = z.infer<
@@ -196,7 +196,7 @@ export const access_code_modified_external_to_seam_event =
     ---
     route_path: /access_codes
     ---
-    An [access code](https://docs.seam.co/latest/capability-guides/smart-locks/access-codes) was modified outside of Seam.
+    An [access code](https://docs.seam.co/capability-guides/smart-locks/access-codes) was modified outside of Seam.
   `)
 
 export type AccessCodeModifiedExternalToSeamEvent = z.infer<
@@ -210,7 +210,7 @@ export const access_code_deleted_external_to_seam_event =
     ---
     route_path: /access_codes
     ---
-    An [access code](https://docs.seam.co/latest/capability-guides/smart-locks/access-codes) was deleted outside of Seam.
+    An [access code](https://docs.seam.co/capability-guides/smart-locks/access-codes) was deleted outside of Seam.
   `)
 
 export type AccessCodeDeletedExternalToSeamEvent = z.infer<
@@ -225,7 +225,7 @@ export const access_code_backup_access_code_pulled_event =
     ---
     route_path: /access_codes
     ---
-    A [backup access code](https://docs.seam.co/latest/capability-guides/smart-locks/access-codes/backup-access-codes) was pulled from the backup access code pool and set on a device.
+    A [backup access code](https://docs.seam.co/capability-guides/smart-locks/access-codes/backup-access-codes) was pulled from the backup access code pool and set on a device.
   `)
 
 export type AccessCodeBackupAccessCodePulledEvent = z.infer<
@@ -239,7 +239,7 @@ export const unmanaged_access_code_converted_to_managed_event =
       ---
       route_path: /access_codes/unmanaged
       ---
-      An [unmanaged access code](https://docs.seam.co/latest/capability-guides/smart-locks/access-codes/migrating-existing-access-codes) was converted successfully to a managed access code.
+      An [unmanaged access code](https://docs.seam.co/capability-guides/smart-locks/access-codes/migrating-existing-access-codes) was converted successfully to a managed access code.
     `)
 
 export type UnmanagedAccessCodeConvertedToManagedEvent = z.infer<
@@ -257,7 +257,7 @@ export const unmanaged_access_code_failed_to_convert_to_managed_event =
       ---
       route_path: /access_codes/unmanaged
       ---
-      An [unmanaged access code](https://docs.seam.co/latest/capability-guides/smart-locks/access-codes/migrating-existing-access-codes) failed to be converted to a managed access code.
+      An [unmanaged access code](https://docs.seam.co/capability-guides/smart-locks/access-codes/migrating-existing-access-codes) failed to be converted to a managed access code.
     `)
 
 export type UnmanagedAccessCodeFailedToConvertToManagedEvent = z.infer<
@@ -270,7 +270,7 @@ export const unmanaged_access_code_created_event = access_code_event.extend({
     ---
     route_path: /access_codes/unmanaged
     ---
-    An [unmanaged access code](https://docs.seam.co/latest/capability-guides/smart-locks/access-codes/migrating-existing-access-codes) was created on a device.
+    An [unmanaged access code](https://docs.seam.co/capability-guides/smart-locks/access-codes/migrating-existing-access-codes) was created on a device.
   `)
 
 export type UnmanagedAccessCodeCreatedEvent = z.infer<
@@ -283,7 +283,7 @@ export const unmanaged_access_code_removed_event = access_code_event.extend({
     ---
     route_path: /access_codes/unmanaged
     ---
-    An [unmanaged access code](https://docs.seam.co/latest/capability-guides/smart-locks/access-codes/migrating-existing-access-codes) was removed from a device.
+    An [unmanaged access code](https://docs.seam.co/capability-guides/smart-locks/access-codes/migrating-existing-access-codes) was removed from a device.
   `)
 
 export type UnmanagedAccessCodeRemovedEvent = z.infer<

--- a/src/lib/seam/connect/models/events/access-grants.ts
+++ b/src/lib/seam/connect/models/events/access-grants.ts
@@ -45,7 +45,7 @@ const acs_entrance_id = z
   .string()
   .uuid()
   .describe(
-    'ID of the affected [entrance](https://docs.seam.co/latest/capability-guides/access-systems/retrieving-entrance-details).',
+    'ID of the affected [entrance](https://docs.seam.co/capability-guides/access-systems/retrieving-entrance-details).',
   )
 
 export const access_grant_access_granted_to_door_event =

--- a/src/lib/seam/connect/models/events/acs/credentials.ts
+++ b/src/lib/seam/connect/models/events/acs/credentials.ts
@@ -15,7 +15,7 @@ export const acs_credential_deleted_event = acs_credential_event.extend({
     ---
     route_path: /acs/credentials
     ---
-    An [access system credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials) was deleted.
+    An [access system credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials) was deleted.
   `)
 
 export type AcsCredentialDeletedEvent = z.infer<
@@ -28,7 +28,7 @@ export const acs_credential_issued = acs_credential_event.extend({
     ---
     route_path: /acs/credentials
     ---
-    An [access system credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials) was issued.
+    An [access system credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials) was issued.
   `)
 
 export const acs_credential_reissued = acs_credential_event.extend({
@@ -37,7 +37,7 @@ export const acs_credential_reissued = acs_credential_event.extend({
   ---
   route_path: /acs/credentials
   ---
-  An [access system credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials) was reissued.
+  An [access system credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials) was reissued.
 `)
 
 export const acs_credential_invalidated = acs_credential_event.extend({
@@ -46,7 +46,7 @@ export const acs_credential_invalidated = acs_credential_event.extend({
   ---
   route_path: /acs/credentials
   ---
-  An [access system credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials) was invalidated. That is, the credential cannot be used anymore.
+  An [access system credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials) was invalidated. That is, the credential cannot be used anymore.
 
 `)
 

--- a/src/lib/seam/connect/models/events/acs/encoders.ts
+++ b/src/lib/seam/connect/models/events/acs/encoders.ts
@@ -12,7 +12,7 @@ export const acs_encoder_added_event = acs_encoder_event.extend({
     ---
     route_path: /acs/encoders
     ---
-    An [access system encoder](https://docs.seam.co/latest/capability-guides/access-systems/working-with-card-encoders-and-scanners) was added.
+    An [access system encoder](https://docs.seam.co/capability-guides/access-systems/working-with-card-encoders-and-scanners) was added.
   `)
 
 export type AcsEncoderAddedEvent = z.infer<typeof acs_encoder_added_event>
@@ -23,7 +23,7 @@ export const acs_encoder_removed_event = acs_encoder_event.extend({
     ---
     route_path: /acs/encoders
     ---
-    An [access system encoder](https://docs.seam.co/latest/capability-guides/access-systems/working-with-card-encoders-and-scanners) was removed.
+    An [access system encoder](https://docs.seam.co/capability-guides/access-systems/working-with-card-encoders-and-scanners) was removed.
   `)
 
 export type AcsEncoderRemovedEvent = z.infer<typeof acs_encoder_removed_event>

--- a/src/lib/seam/connect/models/events/acs/entrances.ts
+++ b/src/lib/seam/connect/models/events/acs/entrances.ts
@@ -14,7 +14,7 @@ export const acs_entrance_added_event = acs_entrance_event.extend({
     ---
     route_path: /acs/entrances
     ---
-    An [access system entrance](https://docs.seam.co/latest/capability-guides/access-systems/retrieving-entrance-details) was added.
+    An [access system entrance](https://docs.seam.co/capability-guides/access-systems/retrieving-entrance-details) was added.
   `)
 
 export const acs_entrance_removed_event = acs_entrance_event.extend({
@@ -23,7 +23,7 @@ export const acs_entrance_removed_event = acs_entrance_event.extend({
     ---
     route_path: /acs/entrances
     ---
-    An [access system entrance](https://docs.seam.co/latest/capability-guides/access-systems/retrieving-entrance-details) was removed.
+    An [access system entrance](https://docs.seam.co/capability-guides/access-systems/retrieving-entrance-details) was removed.
   `)
 
 export type AcsUserDeletedEvent = z.infer<typeof acs_entrance_removed_event>

--- a/src/lib/seam/connect/models/events/acs/systems.ts
+++ b/src/lib/seam/connect/models/events/acs/systems.ts
@@ -26,7 +26,7 @@ export const acs_system_connected_event = acs_system_event.extend({
     ---
     route_path: /acs/systems
     ---
-    An [access system](https://docs.seam.co/latest/capability-guides/access-systems) was connected.
+    An [access system](https://docs.seam.co/capability-guides/access-systems) was connected.
   `)
 
 export type AcsSystemConnectedEvent = z.infer<typeof acs_system_connected_event>
@@ -39,7 +39,7 @@ export const acs_system_disconnected_event = acs_system_event
     ---
     route_path: /acs/systems
     ---
-    An [access system](https://docs.seam.co/latest/capability-guides/access-systems) was disconnected.
+    An [access system](https://docs.seam.co/capability-guides/access-systems) was disconnected.
   `)
 
 export type AcsSystemDisconnectedEvent = z.infer<
@@ -52,7 +52,7 @@ export const acs_system_added_event = acs_system_event.extend({
     ---
     route_path: /acs/systems
     ---
-    An [access system](https://docs.seam.co/latest/capability-guides/access-systems) was added.
+    An [access system](https://docs.seam.co/capability-guides/access-systems) was added.
   `)
 
 export type AcsSystemAddedEvent = z.infer<typeof acs_system_added_event>

--- a/src/lib/seam/connect/models/events/acs/users.ts
+++ b/src/lib/seam/connect/models/events/acs/users.ts
@@ -14,7 +14,7 @@ export const acs_user_deleted_event = acs_user_event.extend({
     ---
     route_path: /acs/users
     ---
-    An [access system user](https://docs.seam.co/latest/capability-guides/access-systems/user-management) was deleted.
+    An [access system user](https://docs.seam.co/capability-guides/access-systems/user-management) was deleted.
   `)
 
 export type AcsUserDeletedEvent = z.infer<typeof acs_user_deleted_event>
@@ -25,7 +25,7 @@ export const acs_user_created_event = acs_user_event.extend({
     ---
     route_path: /acs/users
     ---
-    An [access system user](https://docs.seam.co/latest/capability-guides/access-systems/user-management) was created.
+    An [access system user](https://docs.seam.co/capability-guides/access-systems/user-management) was created.
   `)
 
 export type AcsUserCreatedEvent = z.infer<typeof acs_user_created_event>

--- a/src/lib/seam/connect/models/events/action-attempts.ts
+++ b/src/lib/seam/connect/models/events/action-attempts.ts
@@ -32,7 +32,7 @@ export const action_attempt_lock_door_succeeded_event =
     ---
     route_path: /action_attempts
     ---
-    A lock door [action attempt](https://docs.seam.co/latest/core-concepts/action-attempts) succeeded.
+    A lock door [action attempt](https://docs.seam.co/core-concepts/action-attempts) succeeded.
   `)
 
 export const action_attempt_lock_door_failed_event =
@@ -42,7 +42,7 @@ export const action_attempt_lock_door_failed_event =
     ---
     route_path: /action_attempts
     ---
-    A lock door [action attempt](https://docs.seam.co/latest/core-concepts/action-attempts) failed.
+    A lock door [action attempt](https://docs.seam.co/core-concepts/action-attempts) failed.
   `)
 
 export const action_attempt_unlock_door_succeeded_event =
@@ -52,7 +52,7 @@ export const action_attempt_unlock_door_succeeded_event =
     ---
     route_path: /action_attempts
     ---
-    An unlock door [action attempt](https://docs.seam.co/latest/core-concepts/action-attempts) succeeded.
+    An unlock door [action attempt](https://docs.seam.co/core-concepts/action-attempts) succeeded.
   `)
 
 export const action_attempt_unlock_door_failed_event =
@@ -62,7 +62,7 @@ export const action_attempt_unlock_door_failed_event =
     ---
     route_path: /action_attempts
     ---
-    An unlock door [action attempt](https://docs.seam.co/latest/core-concepts/action-attempts) failed.
+    An unlock door [action attempt](https://docs.seam.co/core-concepts/action-attempts) failed.
   `)
 
 export const action_attempt_simulate_keypad_code_entry_succeeded_event =
@@ -74,7 +74,7 @@ export const action_attempt_simulate_keypad_code_entry_succeeded_event =
     ---
     route_path: /action_attempts
     ---
-    A simulate keypad code entry [action attempt](https://docs.seam.co/latest/core-concepts/action-attempts) succeeded.
+    A simulate keypad code entry [action attempt](https://docs.seam.co/core-concepts/action-attempts) succeeded.
   `)
 
 export const action_attempt_simulate_keypad_code_entry_failed_event =
@@ -84,7 +84,7 @@ export const action_attempt_simulate_keypad_code_entry_failed_event =
     ---
     route_path: /action_attempts
     ---
-    A simulate keypad code entry [action attempt](https://docs.seam.co/latest/core-concepts/action-attempts) failed.
+    A simulate keypad code entry [action attempt](https://docs.seam.co/core-concepts/action-attempts) failed.
   `)
 
 export const action_attempt_simulate_manual_lock_via_keypad_succeeded_event =
@@ -96,7 +96,7 @@ export const action_attempt_simulate_manual_lock_via_keypad_succeeded_event =
     ---
     route_path: /action_attempts
     ---
-    A simulate manual lock via keypad [action attempt](https://docs.seam.co/latest/core-concepts/action-attempts) succeeded.
+    A simulate manual lock via keypad [action attempt](https://docs.seam.co/core-concepts/action-attempts) succeeded.
   `)
 
 export const action_attempt_simulate_manual_lock_via_keypad_failed_event =
@@ -108,7 +108,7 @@ export const action_attempt_simulate_manual_lock_via_keypad_failed_event =
     ---
     route_path: /action_attempts
     ---
-    A simulate manual lock via keypad [action attempt](https://docs.seam.co/latest/core-concepts/action-attempts) failed.
+    A simulate manual lock via keypad [action attempt](https://docs.seam.co/core-concepts/action-attempts) failed.
   `)
 
 export const action_attempt_events = [

--- a/src/lib/seam/connect/models/events/client-sessions.ts
+++ b/src/lib/seam/connect/models/events/client-sessions.ts
@@ -15,7 +15,7 @@ export const client_session_deleted_event = client_session_event.extend({
     ---
     route_path: /client_sessions
     ---
-    A [client session](https://docs.seam.co/latest/core-concepts/authentication/client-session-tokens) was deleted.
+    A [client session](https://docs.seam.co/core-concepts/authentication/client-session-tokens) was deleted.
   `)
 
 export type ClientSessionDeletedEvent = z.infer<

--- a/src/lib/seam/connect/models/events/common.ts
+++ b/src/lib/seam/connect/models/events/common.ts
@@ -6,7 +6,7 @@ export const common_event = z.object({
     .string()
     .uuid()
     .describe(
-      'ID of the [workspace](https://docs.seam.co/latest/core-concepts/workspaces) associated with the event.',
+      'ID of the [workspace](https://docs.seam.co/core-concepts/workspaces) associated with the event.',
     ),
   created_at: z
     .string()

--- a/src/lib/seam/connect/models/events/connect-webviews.ts
+++ b/src/lib/seam/connect/models/events/connect-webviews.ts
@@ -8,7 +8,7 @@ const connect_webview_event = common_event.extend({
     .string()
     .uuid()
     .describe(
-      'ID of the affected [Connect Webview](https://docs.seam.co/latest/core-concepts/connect-webviews).',
+      'ID of the affected [Connect Webview](https://docs.seam.co/core-concepts/connect-webviews).',
     ),
 })
 
@@ -16,7 +16,7 @@ const connected_account_id = z
   .string()
   .uuid()
   .describe(
-    'ID of the [connected account](https://docs.seam.co/latest/core-concepts/connected-accounts) associated with the event.',
+    'ID of the [connected account](https://docs.seam.co/core-concepts/connected-accounts) associated with the event.',
   )
 
 const connected_account_custom_metadata = custom_metadata
@@ -40,7 +40,7 @@ export const connect_webview_login_succeeded_event =
     ---
     route_path: /connect_webviews
     ---
-    A [Connect Webview](https://docs.seam.co/latest/core-concepts/connect-webviews) login succeeded.
+    A [Connect Webview](https://docs.seam.co/core-concepts/connect-webviews) login succeeded.
   `)
 
 export type ConnectWebviewLoginSucceededEvent = z.infer<
@@ -53,7 +53,7 @@ export const connect_webview_login_failed_event = connect_webview_event.extend({
     ---
     route_path: /connect_webviews
     ---
-    A [Connect Webview](https://docs.seam.co/latest/core-concepts/connect-webviews) login failed.
+    A [Connect Webview](https://docs.seam.co/core-concepts/connect-webviews) login failed.
   `)
 
 export type ConnectWebviewLoginFailedEvent = z.infer<

--- a/src/lib/seam/connect/models/events/connected-accounts.ts
+++ b/src/lib/seam/connect/models/events/connected-accounts.ts
@@ -12,7 +12,7 @@ const connected_account_event = common_event.extend({
     .string()
     .uuid()
     .describe(
-      'ID of the affected [connected account](https://docs.seam.co/latest/core-concepts/connected-accounts).',
+      'ID of the affected [connected account](https://docs.seam.co/core-concepts/connected-accounts).',
     ),
   connected_account_custom_metadata: custom_metadata
     .optional()
@@ -25,7 +25,7 @@ const connect_webview_id = z
   .string()
   .uuid()
   .describe(
-    'ID of the [Connect Webview](https://docs.seam.co/latest/core-concepts/connect-webviews) associated with the event.',
+    'ID of the [Connect Webview](https://docs.seam.co/core-concepts/connect-webviews) associated with the event.',
   )
 
 const connected_account_event_issue_properties = {
@@ -52,7 +52,7 @@ export const connected_account_connected_event = connected_account_event.extend(
   ---
   route_path: /connected_accounts
   ---
-  A [connected account](https://docs.seam.co/latest/core-concepts/connected-accounts) was connected for the first time or was reconnected after being disconnected.
+  A [connected account](https://docs.seam.co/core-concepts/connected-accounts) was connected for the first time or was reconnected after being disconnected.
 `)
 
 export type ConnectedAccountConnectedEvent = z.infer<
@@ -66,7 +66,7 @@ export const connected_account_created_event = connected_account_event.extend({
   ---
   route_path: /connected_accounts
   ---
-  A [connected account](https://docs.seam.co/latest/core-concepts/connected-accounts) was created.
+  A [connected account](https://docs.seam.co/core-concepts/connected-accounts) was created.
 `)
 
 export type ConnectedAccountCreatedEvent = z.infer<
@@ -82,7 +82,7 @@ export const connected_account_successful_login_event =
     deprecated: Use \`connect_webview.login_succeeded\`.
     route_path: /connected_accounts
     ---
-    A [connected account](https://docs.seam.co/latest/core-concepts/connected-accounts) had a successful login using a [Connect Webview](https://docs.seam.co/latest/core-concepts/connect-webviews).
+    A [connected account](https://docs.seam.co/core-concepts/connected-accounts) had a successful login using a [Connect Webview](https://docs.seam.co/core-concepts/connect-webviews).
   `)
 
 /** @deprecated Rely on ConnectWebviewLoginSucceededEvent instead */
@@ -98,7 +98,7 @@ export const connected_account_disconnected_event = connected_account_event
     ---
     route_path: /connected_accounts
     ---
-    A [connected account](https://docs.seam.co/latest/core-concepts/connected-accounts) was disconnected.
+    A [connected account](https://docs.seam.co/core-concepts/connected-accounts) was disconnected.
   `)
 
 export type ConnectedAccountDisconnectedEvent = z.infer<
@@ -112,7 +112,7 @@ export const connected_account_completed_first_sync_event =
     ---
     route_path: /connected_accounts
     ---
-    A [connected account](https://docs.seam.co/latest/core-concepts/connected-accounts) completed the first sync with Seam, and the corresponding devices or systems are now available.
+    A [connected account](https://docs.seam.co/core-concepts/connected-accounts) completed the first sync with Seam, and the corresponding devices or systems are now available.
   `)
 
 export type ConnectedAccountCompletedFirstSyncEvent = z.infer<
@@ -135,7 +135,7 @@ export const connected_account_deleted_event = connected_account_event.extend({
   ---
   route_path: /connected_accounts
   ---
-  A [connected account](https://docs.seam.co/latest/core-concepts/connected-accounts) was deleted.
+  A [connected account](https://docs.seam.co/core-concepts/connected-accounts) was deleted.
 `)
 
 export type ConnectedAccountDeletedEvent = z.infer<
@@ -151,7 +151,7 @@ export const connected_account_completed_first_sync_after_reconnection_event =
     ---
     route_path: /connected_accounts
     ---
-    A [connected account](https://docs.seam.co/latest/core-concepts/connected-accounts) completed the first sync after reconnection with Seam, and the corresponding devices or systems are now available.
+    A [connected account](https://docs.seam.co/core-concepts/connected-accounts) completed the first sync after reconnection with Seam, and the corresponding devices or systems are now available.
   `)
 
 export type ConnectedAccountCompletedFirstSyncAfterReconnectionEvent = z.infer<
@@ -167,7 +167,7 @@ export const connected_account_reauthorization_requested_event =
     ---
     route_path: /connected_accounts
     ---
-    A [connected account](https://docs.seam.co/latest/core-concepts/connected-accounts) requires reauthorization using a new Connect Webview. The account is still connected, but cannot access new features. Delaying reauthorization too long will eventually cause the Connected Account to become disconnected.
+    A [connected account](https://docs.seam.co/core-concepts/connected-accounts) requires reauthorization using a new Connect Webview. The account is still connected, but cannot access new features. Delaying reauthorization too long will eventually cause the Connected Account to become disconnected.
   `)
 
 export type ConnectedAccountReauthorizationRequestedEvent = z.infer<

--- a/src/lib/seam/connect/models/events/devices.ts
+++ b/src/lib/seam/connect/models/events/devices.ts
@@ -14,7 +14,7 @@ const device_event = common_event.extend({
     .string()
     .uuid()
     .describe(
-      'ID of the [connected account](https://docs.seam.co/latest/core-concepts/connected-accounts) associated with the event.',
+      'ID of the [connected account](https://docs.seam.co/core-concepts/connected-accounts) associated with the event.',
     ),
   customer_key: z
     .string()
@@ -78,7 +78,7 @@ export const device_connected_event = device_event.extend({
   ---
   route_path: /devices
   ---
-  The status of a [device](https://docs.seam.co/latest/core-concepts/devices) changed from offline to online. That is, the \`device.properties.online\` property changed from \`false\` to \`true\`. Note that some devices operate entirely in offline mode, so Seam never emits a \`device.connected\` event for these devices.
+  The status of a [device](https://docs.seam.co/core-concepts/devices) changed from offline to online. That is, the \`device.properties.online\` property changed from \`false\` to \`true\`. Note that some devices operate entirely in offline mode, so Seam never emits a \`device.connected\` event for these devices.
 `)
 
 export type DeviceConnectedEvent = z.infer<typeof device_connected_event>
@@ -89,7 +89,7 @@ export const device_added_event = device_event.extend({
   ---
   route_path: /devices
   ---
-  A [device](https://docs.seam.co/latest/core-concepts/devices) was added to Seam or was re-added to Seam after having been removed.
+  A [device](https://docs.seam.co/core-concepts/devices) was added to Seam or was re-added to Seam after having been removed.
 `)
 
 export type DeviceAddedEvent = z.infer<typeof device_added_event>
@@ -100,7 +100,7 @@ export const device_converted_to_unmanaged_event = device_event.extend({
   ---
   route_path: /devices
   ---
-  A managed device was successfully converted to an [unmanaged device](https://docs.seam.co/latest/core-concepts/devices/managed-and-unmanaged-devices).
+  A managed device was successfully converted to an [unmanaged device](https://docs.seam.co/core-concepts/devices/managed-and-unmanaged-devices).
 `)
 
 export type DeviceConvertedToUnmanagedEvent = z.infer<
@@ -113,7 +113,7 @@ export const unmanaged_device_converted_to_managed_event = device_event.extend({
   ---
   route_path: /devices/unmanaged
   ---
-  An [unmanaged device](https://docs.seam.co/latest/core-concepts/devices/managed-and-unmanaged-devices) was successfully converted to a managed device.
+  An [unmanaged device](https://docs.seam.co/core-concepts/devices/managed-and-unmanaged-devices) was successfully converted to a managed device.
 `)
 
 export type UnmanagedDeviceConvertedToManagedEvent = z.infer<
@@ -126,7 +126,7 @@ export const unmanaged_device_connected_event = device_event.extend({
   ---
   route_path: /devices/unmanaged
   ---
-  The status of an [unmanaged device](https://docs.seam.co/latest/core-concepts/devices/managed-and-unmanaged-devices) changed from offline to online. That is, the \`device.properties.online\` property changed from \`false\` to \`true\`.
+  The status of an [unmanaged device](https://docs.seam.co/core-concepts/devices/managed-and-unmanaged-devices) changed from offline to online. That is, the \`device.properties.online\` property changed from \`false\` to \`true\`.
 `)
 
 export type UnmanagedDeviceConnectedEvent = z.infer<
@@ -142,7 +142,7 @@ export const device_disconnected_event = device_event
   ---
   route_path: /devices
   ---
-  The status of a [device](https://docs.seam.co/latest/core-concepts/devices) changed from online to offline. That is, the \`device.properties.online\` property changed from \`true\` to \`false\`.
+  The status of a [device](https://docs.seam.co/core-concepts/devices) changed from online to offline. That is, the \`device.properties.online\` property changed from \`true\` to \`false\`.
 `)
 
 export type DeviceDisconnectedEvent = z.infer<typeof device_disconnected_event>
@@ -156,7 +156,7 @@ export const unmanaged_device_disconnected_event = device_event
   ---
   route_path: /devices/unmanaged
   ---
-  The status of an [unmanaged device](https://docs.seam.co/latest/core-concepts/devices/managed-and-unmanaged-devices) changed from online to offline. That is, the \`device.properties.online\` property changed from \`true\` to \`false\`.
+  The status of an [unmanaged device](https://docs.seam.co/core-concepts/devices/managed-and-unmanaged-devices) changed from online to offline. That is, the \`device.properties.online\` property changed from \`true\` to \`false\`.
 `)
 
 export type UnmanagedDeviceDisconnectedEvent = z.infer<
@@ -169,7 +169,7 @@ export const device_tampered_event = device_event.extend({
   ---
   route_path: /devices
   ---
-  A [device](https://docs.seam.co/latest/core-concepts/devices) detected that it was tampered with, for example, opened or moved.
+  A [device](https://docs.seam.co/core-concepts/devices) detected that it was tampered with, for example, opened or moved.
 `)
 
 export type DeviceTamperedEvent = z.infer<typeof device_tampered_event>
@@ -181,7 +181,7 @@ export const device_low_battery_event = device_event.extend({
   ---
   route_path: /devices
   ---
-  A [device](https://docs.seam.co/latest/core-concepts/devices) battery level dropped below the low threshold.
+  A [device](https://docs.seam.co/core-concepts/devices) battery level dropped below the low threshold.
 `)
 
 export type DeviceLowBatteryEvent = z.infer<typeof device_low_battery_event>
@@ -194,7 +194,7 @@ export const device_battery_status_changed_event = device_event.extend({
   ---
   route_path: /devices
   ---
-  A [device](https://docs.seam.co/latest/core-concepts/devices) battery status changed since the last \`battery_status_changed\` event.
+  A [device](https://docs.seam.co/core-concepts/devices) battery status changed since the last \`battery_status_changed\` event.
 `)
 
 export type DeviceBatteryStatusChangedEvent = z.infer<
@@ -207,7 +207,7 @@ export const device_removed_event = device_event.extend({
   ---
   route_path: /devices
   ---
-  A [device](https://docs.seam.co/latest/core-concepts/devices) was removed externally from the [connected account](https://docs.seam.co/latest/core-concepts/connected-accounts).
+  A [device](https://docs.seam.co/core-concepts/devices) was removed externally from the [connected account](https://docs.seam.co/core-concepts/connected-accounts).
 `)
 
 export type DeviceRemovedEvent = z.infer<typeof device_removed_event>
@@ -218,7 +218,7 @@ export const device_deleted_event = device_event.extend({
   ---
   route_path: /devices
   ---
-  A [device](https://docs.seam.co/latest/core-concepts/devices) was deleted.
+  A [device](https://docs.seam.co/core-concepts/devices) was deleted.
 `)
 
 export type DeviceDeletedEvent = z.infer<typeof device_deleted_event>
@@ -230,7 +230,7 @@ export const device_third_party_integration_detected_event =
     ---
     route_path: /devices
     ---
-    Seam detected that a [device](https://docs.seam.co/latest/core-concepts/devices) is using a third-party integration that will interfere with Seam device management.
+    Seam detected that a [device](https://docs.seam.co/core-concepts/devices) is using a third-party integration that will interfere with Seam device management.
   `)
 
 export type DeviceThirdPartyIntegrationDetectedEvent = z.infer<
@@ -244,7 +244,7 @@ export const device_third_party_integration_no_longer_detected_event =
     ---
     route_path: /devices
     ---
-    Seam detected that a [device](https://docs.seam.co/latest/core-concepts/devices) is no longer using a third-party integration that was interfering with Seam device management.
+    Seam detected that a [device](https://docs.seam.co/core-concepts/devices) is no longer using a third-party integration that was interfering with Seam device management.
   `)
 
 export type DeviceThirdPartyIntegrationNoLongerDetectedEvent = z.infer<
@@ -257,7 +257,7 @@ export const device_salto_privacy_mode_activated_event = device_event.extend({
   ---
   route_path: /devices
   ---
-  A [Salto device](https://docs.seam.co/latest/device-and-system-integration-guides/salto-locks) activated privacy mode.
+  A [Salto device](https://docs.seam.co/device-and-system-integration-guides/salto-locks) activated privacy mode.
 `)
 
 export type DeviceSaltoPrivacyModeActivatedEvent = z.infer<
@@ -270,7 +270,7 @@ export const device_salto_privacy_mode_deactivated_event = device_event.extend({
   ---
   route_path: /devices
   ---
-  A [Salto device](https://docs.seam.co/latest/device-and-system-integration-guides/salto-locks) deactivated privacy mode.
+  A [Salto device](https://docs.seam.co/device-and-system-integration-guides/salto-locks) deactivated privacy mode.
 `)
 
 export type DeviceSaltoPrivacyModeDeactivatedEvent = z.infer<
@@ -285,7 +285,7 @@ export const device_connection_became_flaky_event = device_event
   ---
   route_path: /devices
   ---
-  Seam detected a flaky [device](https://docs.seam.co/latest/core-concepts/devices) connection.
+  Seam detected a flaky [device](https://docs.seam.co/core-concepts/devices) connection.
 `)
 
 export type DeviceConnectionBecameFlakyEvent = z.infer<
@@ -298,7 +298,7 @@ export const device_connection_stabilized_event = device_event.extend({
   ---
   route_path: /devices
   ---
-  Seam detected that a previously-flaky [device](https://docs.seam.co/latest/core-concepts/devices) connection stabilized.
+  Seam detected that a previously-flaky [device](https://docs.seam.co/core-concepts/devices) connection stabilized.
 `)
 
 export type DeviceConnectionStabilizedEvent = z.infer<
@@ -313,7 +313,7 @@ export const device_error_subscription_required_event = device_event
   ---
   route_path: /devices
   ---
-  A third-party subscription is required to use all [device](https://docs.seam.co/latest/core-concepts/devices) features.
+  A third-party subscription is required to use all [device](https://docs.seam.co/core-concepts/devices) features.
 `)
 
 export type DeviceErrorSubscriptionRequiredEvent = z.infer<
@@ -327,7 +327,7 @@ export const device_error_subscription_required_resolved_event =
     ---
     route_path: /devices
     ---
-    A third-party subscription is active or no longer required to use all [device](https://docs.seam.co/latest/core-concepts/devices) features.
+    A third-party subscription is active or no longer required to use all [device](https://docs.seam.co/core-concepts/devices) features.
   `)
 
 export type DeviceErrorSubscriptionRequiredResolvedEvent = z.infer<
@@ -340,7 +340,7 @@ export const device_accessory_keypad_connected_event = device_event.extend({
   ---
   route_path: /devices
   ---
-  An accessory keypad was connected to a [device](https://docs.seam.co/latest/core-concepts/devices).
+  An accessory keypad was connected to a [device](https://docs.seam.co/core-concepts/devices).
 `)
 
 export type DeviceAccessoryKeypadConnectedEvent = z.infer<
@@ -355,7 +355,7 @@ export const device_accessory_keypad_disconnected_event = device_event
   ---
   route_path: /devices
   ---
-  An accessory keypad was disconnected from a [device](https://docs.seam.co/latest/core-concepts/devices).
+  An accessory keypad was disconnected from a [device](https://docs.seam.co/core-concepts/devices).
 `)
 
 export type DeviceAccessoryKeypadDisconnectedEvent = z.infer<
@@ -396,7 +396,7 @@ export const noise_sensor_noise_threshold_triggered_event = device_event.extend(
     ---
     route_path: /noise_sensors/noise_thresholds
     ---
-    Extended periods of noise or noise exceeding a [threshold](https://docs.seam.co/latest/capability-guides/noise-sensors#what-is-a-threshold) were detected.
+    Extended periods of noise or noise exceeding a [threshold](https://docs.seam.co/capability-guides/noise-sensors#what-is-a-threshold) were detected.
   `)
 
 export type NoiseSensorNoiseThresholdTriggeredEvent = z.infer<
@@ -436,7 +436,7 @@ export const lock_locked_event = device_event.extend({
   ---
   route_path: /locks
   ---
-  A [lock](https://docs.seam.co/latest/capability-guides/smart-locks) was locked.
+  A [lock](https://docs.seam.co/capability-guides/smart-locks) was locked.
 `)
 
 export type LockLockedEvent = z.infer<typeof lock_locked_event>
@@ -464,7 +464,7 @@ export const lock_unlocked_event = device_event.extend({
       'ID of the Seam action attempt that triggered this unlock. Present only when the unlock was initiated through Seam (via an `UNLOCK_DOOR` action attempt).',
     ),
   method: lock_method.describe(
-    'Method by which the lock was unlocked. `keycode`: an [access code](https://docs.seam.co/latest/capability-guides/smart-locks/access-codes) was used (see `access_code_id`). `manual`: a physical action such as a thumbturn or handle press. `remote`: a remote action via an app, Bluetooth, or the Seam API (see `action_attempt_id` if Seam-initiated; see `is_via_bluetooth` or `is_via_nfc` for the transport). `automatic`: triggered automatically, for example by a time-based schedule. `unknown`: could not be determined.',
+    'Method by which the lock was unlocked. `keycode`: an [access code](https://docs.seam.co/capability-guides/smart-locks/access-codes) was used (see `access_code_id`). `manual`: a physical action such as a thumbturn or handle press. `remote`: a remote action via an app, Bluetooth, or the Seam API (see `action_attempt_id` if Seam-initiated; see `is_via_bluetooth` or `is_via_nfc` for the transport). `automatic`: triggered automatically, for example by a time-based schedule. `unknown`: could not be determined.',
   ),
   user_identity_id: z.string().uuid().optional().describe(`
       undocumented: Unreleased.
@@ -501,7 +501,7 @@ export const lock_unlocked_event = device_event.extend({
   ---
   route_path: /locks
   ---
-  A [lock](https://docs.seam.co/latest/capability-guides/smart-locks) was unlocked.
+  A [lock](https://docs.seam.co/capability-guides/smart-locks) was unlocked.
 `)
 
 export type LockUnlockedEvent = z.infer<typeof lock_unlocked_event>
@@ -517,7 +517,7 @@ export const lock_access_denied_event = device_event.extend({
   ---
   route_path: /locks
   ---
-  The [lock](https://docs.seam.co/latest/capability-guides/smart-locks) denied access to a user after one or more consecutive invalid attempts to unlock the device.
+  The [lock](https://docs.seam.co/capability-guides/smart-locks) denied access to a user after one or more consecutive invalid attempts to unlock the device.
 `)
 
 export type LockAccessDeniedEvent = z.infer<typeof lock_access_denied_event>
@@ -543,7 +543,7 @@ export const thermostat_climate_preset_activated_event = device_event.extend({
   ---
   route_path: /thermostats
   ---
-  A thermostat [climate preset](https://docs.seam.co/latest/capability-guides/thermostats/creating-and-managing-climate-presets) was activated.
+  A thermostat [climate preset](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-climate-presets) was activated.
 `)
 
 export type ThermostatClimatePresetActivatedEvent = z.infer<
@@ -574,7 +574,7 @@ export const thermostat_manually_adjusted_event = device_event
     ---
     route_path: /thermostats
     ---
-    A [thermostat](https://docs.seam.co/latest/capability-guides/thermostats) was adjusted manually.
+    A [thermostat](https://docs.seam.co/capability-guides/thermostats) was adjusted manually.
   `)
 
 export type ThermostatManuallyAdjustedEvent = z.infer<
@@ -609,7 +609,7 @@ export const temperature_threshold_exceeded_event = device_event.extend({
   ---
   route_path: /thermostats
   ---
-  A [thermostat's](https://docs.seam.co/latest/capability-guides/thermostats) temperature reading exceeded the set [threshold](https://docs.seam.co/latest/capability-guides/thermostats/setting-and-monitoring-temperature-thresholds).
+  A [thermostat's](https://docs.seam.co/capability-guides/thermostats) temperature reading exceeded the set [threshold](https://docs.seam.co/capability-guides/thermostats/setting-and-monitoring-temperature-thresholds).
 `)
 
 export type TemperatureThresholdExceededEvent = z.infer<
@@ -655,7 +655,7 @@ export const temperature_threshold_no_longer_exceeded_event =
     ---
     route_path: /thermostats
     ---
-    A [thermostat's](https://docs.seam.co/latest/capability-guides/thermostats) temperature reading no longer exceeds the set [threshold](https://docs.seam.co/latest/capability-guides/thermostats/setting-and-monitoring-temperature-thresholds).
+    A [thermostat's](https://docs.seam.co/capability-guides/thermostats) temperature reading no longer exceeds the set [threshold](https://docs.seam.co/capability-guides/thermostats/setting-and-monitoring-temperature-thresholds).
   `)
 
 export type TemperatureThresholdNoLongerExceededEvent = z.infer<
@@ -686,7 +686,7 @@ export const temperature_reached_set_point_event = device_event.extend({
   ---
   route_path: /thermostats
   ---
-  A [thermostat's](https://docs.seam.co/latest/capability-guides/thermostats) temperature reading is within 1 °C of the configured cooling or heating [set point](https://docs.seam.co/latest/capability-guides/thermostats/understanding-thermostat-concepts/set-points).
+  A [thermostat's](https://docs.seam.co/capability-guides/thermostats) temperature reading is within 1 °C of the configured cooling or heating [set point](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/set-points).
 `)
 
 export type TemperatureReachedSetPointEvent = z.infer<
@@ -705,7 +705,7 @@ export const temperature_changed_event = device_event.extend({
   ---
   route_path: /thermostats
   ---
-  A [thermostat's](https://docs.seam.co/latest/capability-guides/thermostats) reported temperature changed by at least 1 °C.
+  A [thermostat's](https://docs.seam.co/capability-guides/thermostats) reported temperature changed by at least 1 °C.
 `)
 
 export type TemperatureChangedEvent = z.infer<typeof temperature_changed_event>
@@ -717,7 +717,7 @@ export const device_name_changed_event = device_event.extend({
   ---
   route_path: /devices
   ---
-  The name of a [device](https://docs.seam.co/latest/core-concepts/devices) was changed.
+  The name of a [device](https://docs.seam.co/core-concepts/devices) was changed.
 `)
 
 export type DeviceNameChangedEvent = z.infer<typeof device_name_changed_event>
@@ -745,7 +745,7 @@ export const camera_activated_event = device_event.extend({
   ---
   route_path: /devices
   ---
-  A [camera](https://docs.seam.co/latest/core-concepts/devices) was activated, for example, by motion detection.
+  A [camera](https://docs.seam.co/core-concepts/devices) was activated, for example, by motion detection.
 `)
 
 export type CameraActivatedEvent = z.infer<typeof camera_activated_event>
@@ -770,7 +770,7 @@ export const device_doorbell_rang_event = device_event.extend({
   ---
   route_path: /devices
   ---
-  A doorbell button was pressed on a [device](https://docs.seam.co/latest/core-concepts/devices).
+  A doorbell button was pressed on a [device](https://docs.seam.co/core-concepts/devices).
 `)
 
 export type DeviceDoorbellRangEvent = z.infer<typeof device_doorbell_rang_event>

--- a/src/lib/seam/connect/models/events/enrollment-automations.ts
+++ b/src/lib/seam/connect/models/events/enrollment-automations.ts
@@ -16,7 +16,7 @@ export const enrollment_automation_deleted_event =
     ---
     route_path: /user_identities/enrollment_automations
     ---
-    An [enrollment automation](https://docs.seam.co/latest/capability-guides/mobile-access/issuing-mobile-credentials-from-an-access-control-system#prepare-the-phones-for-a-user-identity-to-start-receiving-mobile-credentials-using-an-enrollment-aut) was deleted.
+    An [enrollment automation](https://docs.seam.co/capability-guides/mobile-access/issuing-mobile-credentials-from-an-access-control-system#prepare-the-phones-for-a-user-identity-to-start-receiving-mobile-credentials-using-an-enrollment-aut) was deleted.
   `)
 
 export type EnrollmentAutomationDeletedEvent = z.infer<

--- a/src/lib/seam/connect/models/events/seam-event.ts
+++ b/src/lib/seam/connect/models/events/seam-event.ts
@@ -32,7 +32,7 @@ export const seam_event = z.discriminatedUnion('event_type', [
   ---
   Represents an event. Events let you know when something interesting happens in your workspace. For example, when a lock is unlocked, Seam creates a \`lock.unlocked\` event. When a device's battery level is low, Seam creates a \`device.battery_low\` event.
 
-  As with other API resources, you can retrieve an individual event or a list of events. Seam also provides a separate [webhook](https://docs.seam.co/latest/developer-tools/webhooks) system for sending the event objects directly to an endpoint on your sever. Manage webhooks through [Seam Console](https://console.seam.co). You can also use the webhooks sandbox in Seam Console to see the different payloads for each event and test them against your own endpoints.
+  As with other API resources, you can retrieve an individual event or a list of events. Seam also provides a separate [webhook](https://docs.seam.co/developer-tools/webhooks) system for sending the event objects directly to an endpoint on your sever. Manage webhooks through [Seam Console](https://console.seam.co). You can also use the webhooks sandbox in Seam Console to see the different payloads for each event and test them against your own endpoints.
 `)
 
 export type SeamEvent = z.infer<typeof seam_event>

--- a/src/lib/seam/connect/models/instant-keys/instant-key.ts
+++ b/src/lib/seam/connect/models/instant-keys/instant-key.ts
@@ -6,7 +6,7 @@ export const instant_key = z.object({
     .string()
     .uuid()
     .describe(
-      'ID of the [workspace](https://docs.seam.co/latest/core-concepts/workspaces) that contains the Instant Key.',
+      'ID of the [workspace](https://docs.seam.co/core-concepts/workspaces) that contains the Instant Key.',
     ),
   created_at: z
     .string()
@@ -22,7 +22,7 @@ export const instant_key = z.object({
     .string()
     .uuid()
     .describe(
-      'ID of the [client session](https://docs.seam.co/latest/core-concepts/authentication/client-session-tokens) associated with the Instant Key.',
+      'ID of the [client session](https://docs.seam.co/core-concepts/authentication/client-session-tokens) associated with the Instant Key.',
     ),
   user_identity_id: z
     .string()

--- a/src/lib/seam/connect/models/noise-sensors/noise-threshold.ts
+++ b/src/lib/seam/connect/models/noise-sensors/noise-threshold.ts
@@ -16,7 +16,7 @@ export const noise_threshold = z.object({
     .number()
     .optional()
     .describe(
-      'Noise level in Noiseaware Noise Risk Score (NRS) for the noise threshold. This parameter is only relevant for [Noiseaware sensors](https://docs.seam.co/latest/device-and-system-integration-guides/noiseaware-sensors).',
+      'Noise level in Noiseaware Noise Risk Score (NRS) for the noise threshold. This parameter is only relevant for [Noiseaware sensors](https://docs.seam.co/device-and-system-integration-guides/noiseaware-sensors).',
     ),
   starts_daily_at: z
     .string()
@@ -33,7 +33,7 @@ export const noise_threshold = z.object({
   ---
   route_path: /noise_sensors/noise_thresholds
   ---
-  Represents a [noise threshold](https://docs.seam.co/latest/capability-guides/noise-sensors/configure-noise-threshold-settings) for a [noise sensor](https://docs.seam.co/latest/capability-guides/noise-sensors). Thresholds represent the limits of noise tolerated at a property, which can be customized for each hour of the day. Each device has its own default thresholds, but you can use the Seam API to modify them.
+  Represents a [noise threshold](https://docs.seam.co/capability-guides/noise-sensors/configure-noise-threshold-settings) for a [noise sensor](https://docs.seam.co/capability-guides/noise-sensors). Thresholds represent the limits of noise tolerated at a property, which can be customized for each hour of the day. Each device has its own default thresholds, but you can use the Seam API to modify them.
 `)
 
 export type NoiseThreshold = z.infer<typeof noise_threshold>

--- a/src/lib/seam/connect/models/partner/customer-portal.ts
+++ b/src/lib/seam/connect/models/partner/customer-portal.ts
@@ -12,7 +12,7 @@ export const customer_portal = z
       .string()
       .uuid()
       .describe(
-        'ID of the [workspace](https://docs.seam.co/latest/core-concepts/workspaces) associated with the customer portal.',
+        'ID of the [workspace](https://docs.seam.co/core-concepts/workspaces) associated with the customer portal.',
       ),
     created_at: z
       .string()

--- a/src/lib/seam/connect/models/partner/magic-link.ts
+++ b/src/lib/seam/connect/models/partner/magic-link.ts
@@ -11,7 +11,7 @@ export const magic_link = z.object({
     .string()
     .uuid()
     .describe(
-      'ID of the [workspace](https://docs.seam.co/latest/core-concepts/workspaces) associated with the magic link.',
+      'ID of the [workspace](https://docs.seam.co/core-concepts/workspaces) associated with the magic link.',
     ),
   created_at: z
     .string()

--- a/src/lib/seam/connect/models/spaces/space.ts
+++ b/src/lib/seam/connect/models/spaces/space.ts
@@ -31,7 +31,7 @@ export const space = z.object({
     .string()
     .uuid()
     .describe(
-      'ID of the [workspace](https://docs.seam.co/latest/core-concepts/workspaces) associated with the space.',
+      'ID of the [workspace](https://docs.seam.co/core-concepts/workspaces) associated with the space.',
     ),
   space_key: z
     .string()

--- a/src/lib/seam/connect/models/thermostats/climate-preset.ts
+++ b/src/lib/seam/connect/models/thermostats/climate-preset.ts
@@ -10,22 +10,22 @@ export const climate_preset = z.object({
   climate_preset_key: z
     .string()
     .describe(
-      'Unique key to identify the [climate preset](https://docs.seam.co/latest/capability-guides/thermostats/creating-and-managing-climate-presets).',
+      'Unique key to identify the [climate preset](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-climate-presets).',
     ),
   can_edit: z
     .boolean()
     .describe(
-      'Indicates whether the [climate preset](https://docs.seam.co/latest/capability-guides/thermostats/creating-and-managing-climate-presets) key can be edited.',
+      'Indicates whether the [climate preset](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-climate-presets) key can be edited.',
     ),
   can_delete: z
     .boolean()
     .describe(
-      'Indicates whether the [climate preset](https://docs.seam.co/latest/capability-guides/thermostats/creating-and-managing-climate-presets) key can be deleted.',
+      'Indicates whether the [climate preset](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-climate-presets) key can be deleted.',
     ),
   can_use_with_thermostat_daily_programs: z
     .boolean()
     .describe(
-      'Indicates whether the [climate preset](https://docs.seam.co/latest/capability-guides/thermostats/creating-and-managing-climate-presets) key can be programmed in a thermostat daily program.',
+      'Indicates whether the [climate preset](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-climate-presets) key can be programmed in a thermostat daily program.',
     ),
   name: z
     .string()
@@ -33,12 +33,12 @@ export const climate_preset = z.object({
     .default(null)
     .optional()
     .describe(
-      'User-friendly name to identify the [climate preset](https://docs.seam.co/latest/capability-guides/thermostats/creating-and-managing-climate-presets).',
+      'User-friendly name to identify the [climate preset](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-climate-presets).',
     ),
   display_name: z
     .string()
     .describe(
-      'Display name for the [climate preset](https://docs.seam.co/latest/capability-guides/thermostats/creating-and-managing-climate-presets).',
+      'Display name for the [climate preset](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-climate-presets).',
     ),
   climate_preset_mode: climate_preset_mode.optional().describe(`
     The climate preset mode for the thermostat, based on the available climate preset modes reported by the device.
@@ -46,43 +46,43 @@ export const climate_preset = z.object({
   fan_mode_setting: fan_mode_setting
     .optional()
     .describe(
-      'Desired [fan mode setting](https://docs.seam.co/latest/capability-guides/thermostats/configure-current-climate-settings#fan-mode-settings), such as `on`, `auto`, or `circulate`.',
+      'Desired [fan mode setting](https://docs.seam.co/capability-guides/thermostats/configure-current-climate-settings#fan-mode-settings), such as `on`, `auto`, or `circulate`.',
     ),
   hvac_mode_setting: hvac_mode_setting
     .optional()
     .describe(
-      'Desired [HVAC mode](https://docs.seam.co/latest/capability-guides/thermostats/understanding-thermostat-concepts/hvac-mode) setting, such as `heat`, `cool`, `heat_cool`, or `off`.',
+      'Desired [HVAC mode](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/hvac-mode) setting, such as `heat`, `cool`, `heat_cool`, or `off`.',
     ),
   cooling_set_point_celsius: z
     .number()
     .optional()
     .describe(
-      'Temperature to which the thermostat should cool (in °C). See also [Set Points](https://docs.seam.co/latest/capability-guides/thermostats/understanding-thermostat-concepts/set-points).',
+      'Temperature to which the thermostat should cool (in °C). See also [Set Points](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/set-points).',
     ),
   heating_set_point_celsius: z
     .number()
     .optional()
     .describe(
-      'Temperature to which the thermostat should heat (in °C). See also [Set Points](https://docs.seam.co/latest/capability-guides/thermostats/understanding-thermostat-concepts/set-points).',
+      'Temperature to which the thermostat should heat (in °C). See also [Set Points](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/set-points).',
     ),
   cooling_set_point_fahrenheit: z
     .number()
     .optional()
     .describe(
-      'Temperature to which the thermostat should cool (in °F). See also [Set Points](https://docs.seam.co/latest/capability-guides/thermostats/understanding-thermostat-concepts/set-points).',
+      'Temperature to which the thermostat should cool (in °F). See also [Set Points](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/set-points).',
     ),
   heating_set_point_fahrenheit: z
     .number()
     .optional()
     .describe(
-      'Temperature to which the thermostat should heat (in °F). See also [Set Points](https://docs.seam.co/latest/capability-guides/thermostats/understanding-thermostat-concepts/set-points).',
+      'Temperature to which the thermostat should heat (in °F). See also [Set Points](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/set-points).',
     ),
   manual_override_allowed: z.boolean().describe(
     `
       ---
       deprecated: Use 'thermostat_schedule.is_override_allowed'
       ---
-      Indicates whether a person at the thermostat can change the thermostat's settings. See [Specifying Manual Override Permissions](https://docs.seam.co/latest/capability-guides/thermostats/creating-and-managing-thermostat-schedules#specifying-manual-override-permissions).`,
+      Indicates whether a person at the thermostat can change the thermostat's settings. See [Specifying Manual Override Permissions](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-thermostat-schedules#specifying-manual-override-permissions).`,
   ),
   ecobee_metadata: z
     .object({

--- a/src/lib/seam/connect/models/thermostats/thermostat-program.ts
+++ b/src/lib/seam/connect/models/thermostats/thermostat-program.ts
@@ -11,7 +11,7 @@ export const thermostat_daily_program_period = z
     climate_preset_key: z
       .string()
       .describe(
-        'Key of the [climate preset](https://docs.seam.co/latest/capability-guides/thermostats/creating-and-managing-climate-presets) to activate at the `starts_at_time`.',
+        'Key of the [climate preset](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-climate-presets) to activate at the `starts_at_time`.',
       ),
   })
   .describe(
@@ -40,7 +40,7 @@ export const thermostat_daily_program = z.object({
     .string()
     .uuid()
     .describe(
-      'ID of the [workspace](https://docs.seam.co/latest/core-concepts/workspaces) that contains the thermostat daily program.',
+      'ID of the [workspace](https://docs.seam.co/core-concepts/workspaces) that contains the thermostat daily program.',
     ),
   created_at: z
     .string()

--- a/src/lib/seam/connect/models/thermostats/thermostat-schedule.ts
+++ b/src/lib/seam/connect/models/thermostats/thermostat-schedule.ts
@@ -5,24 +5,24 @@ export const thermostat_schedule = z.object({
     .string()
     .uuid()
     .describe(
-      'ID of the [thermostat schedule](https://docs.seam.co/latest/capability-guides/thermostats/creating-and-managing-thermostat-schedules).',
+      'ID of the [thermostat schedule](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-thermostat-schedules).',
     ),
   device_id: z
     .string()
     .uuid()
     .describe(
-      'ID of the desired [thermostat](https://docs.seam.co/latest/capability-guides/thermostats) device.',
+      'ID of the desired [thermostat](https://docs.seam.co/capability-guides/thermostats) device.',
     ),
   name: z
     .string()
     .nullable()
     .describe(
-      'User-friendly name to identify the [thermostat schedule](https://docs.seam.co/latest/capability-guides/thermostats/creating-and-managing-thermostat-schedules).',
+      'User-friendly name to identify the [thermostat schedule](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-thermostat-schedules).',
     ),
   climate_preset_key: z
     .string()
     .describe(
-      'Key of the [climate preset](https://docs.seam.co/latest/capability-guides/thermostats/creating-and-managing-climate-presets) to use for the [thermostat schedule](https://docs.seam.co/latest/capability-guides/thermostats/creating-and-managing-thermostat-schedules).',
+      'Key of the [climate preset](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-climate-presets) to use for the [thermostat schedule](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-thermostat-schedules).',
     ),
   max_override_period_minutes: z
     .number()
@@ -31,37 +31,37 @@ export const thermostat_schedule = z.object({
     .nullable()
     .optional()
     .describe(
-      "Number of minutes for which a person at the thermostat can change the thermostat's settings after the activation of the scheduled [climate preset](https://docs.seam.co/latest/capability-guides/thermostats/creating-and-managing-climate-presets). See also [Specifying Manual Override Permissions](https://docs.seam.co/latest/capability-guides/thermostats/creating-and-managing-thermostat-schedules#specifying-manual-override-permissions).",
+      "Number of minutes for which a person at the thermostat can change the thermostat's settings after the activation of the scheduled [climate preset](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-climate-presets). See also [Specifying Manual Override Permissions](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-thermostat-schedules#specifying-manual-override-permissions).",
     ),
   starts_at: z
     .string()
     .datetime()
     .describe(
-      'Date and time at which the [thermostat schedule](https://docs.seam.co/latest/capability-guides/thermostats/creating-and-managing-thermostat-schedules) starts, in [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) format.',
+      'Date and time at which the [thermostat schedule](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-thermostat-schedules) starts, in [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) format.',
     ),
   is_override_allowed: z
     .boolean()
     .optional()
     .describe(
-      "Indicates whether a person at the thermostat can change the thermostat's settings after the [thermostat schedule](https://docs.seam.co/latest/capability-guides/thermostats/creating-and-managing-thermostat-schedules) starts.",
+      "Indicates whether a person at the thermostat can change the thermostat's settings after the [thermostat schedule](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-thermostat-schedules) starts.",
     ),
   ends_at: z
     .string()
     .datetime()
     .describe(
-      'Date and time at which the [thermostat schedule](https://docs.seam.co/latest/capability-guides/thermostats/creating-and-managing-thermostat-schedules) ends, in [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) format.',
+      'Date and time at which the [thermostat schedule](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-thermostat-schedules) ends, in [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) format.',
     ),
   workspace_id: z
     .string()
     .uuid()
     .describe(
-      'ID of the [workspace](https://docs.seam.co/latest/core-concepts/workspaces) that contains the thermostat schedule.',
+      'ID of the [workspace](https://docs.seam.co/core-concepts/workspaces) that contains the thermostat schedule.',
     ),
   created_at: z
     .string()
     .datetime()
     .describe(
-      'Date and time at which the [thermostat schedule](https://docs.seam.co/latest/capability-guides/thermostats/creating-and-managing-thermostat-schedules) was created.',
+      'Date and time at which the [thermostat schedule](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-thermostat-schedules) was created.',
     ),
   errors: z
     .array(
@@ -79,13 +79,13 @@ export const thermostat_schedule = z.object({
       }),
     )
     .describe(
-      'Errors associated with the [thermostat schedule](https://docs.seam.co/latest/capability-guides/thermostats/creating-and-managing-thermostat-schedules).',
+      'Errors associated with the [thermostat schedule](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-thermostat-schedules).',
     ),
 }).describe(`
   ---
   route_path: /thermostats/schedules
   ---
-  Represents a [thermostat schedule](https://docs.seam.co/latest/capability-guides/thermostats/creating-and-managing-thermostat-schedules) that activates a configured [climate preset](https://docs.seam.co/latest/capability-guides/thermostats/creating-and-managing-climate-presets) on a [thermostat](https://docs.seam.co/latest/capability-guides/thermostats) at a specified starting time and deactivates the climate preset at a specified ending time.
+  Represents a [thermostat schedule](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-thermostat-schedules) that activates a configured [climate preset](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-climate-presets) on a [thermostat](https://docs.seam.co/capability-guides/thermostats) at a specified starting time and deactivates the climate preset at a specified ending time.
 `)
 
 export type ThermostatSchedule = z.infer<typeof thermostat_schedule>

--- a/src/lib/seam/connect/models/user-identities/user-identity.ts
+++ b/src/lib/seam/connect/models/user-identities/user-identity.ts
@@ -131,7 +131,7 @@ export const user_identity = z.object({
     .string()
     .uuid()
     .describe(
-      'ID of the [workspace](https://docs.seam.co/latest/core-concepts/workspaces) that contains the user identity.',
+      'ID of the [workspace](https://docs.seam.co/core-concepts/workspaces) that contains the user identity.',
     ),
   errors: z
     .array(user_identity_errors)
@@ -152,7 +152,7 @@ export const user_identity = z.object({
   ---
   route_path: /user_identities
   ---
-  Represents a [user identity](https://docs.seam.co/latest/capability-guides/mobile-access/managing-mobile-app-user-accounts-with-user-identities#what-is-a-user-identity) associated with an application user account.
+  Represents a [user identity](https://docs.seam.co/capability-guides/mobile-access/managing-mobile-app-user-accounts-with-user-identities#what-is-a-user-identity) associated with an application user account.
 `)
 
 export type UserIdentity = z.output<typeof user_identity>

--- a/src/lib/seam/connect/models/webhooks/webhook.ts
+++ b/src/lib/seam/connect/models/webhooks/webhook.ts
@@ -4,30 +4,30 @@ export const webhook = z.object({
   webhook_id: z
     .string()
     .describe(
-      'ID of the [webhook](https://docs.seam.co/latest/developer-tools/webhooks).',
+      'ID of the [webhook](https://docs.seam.co/developer-tools/webhooks).',
     ),
   url: z
     .string()
     .describe(
-      'URL for the [webhook](https://docs.seam.co/latest/developer-tools/webhooks).',
+      'URL for the [webhook](https://docs.seam.co/developer-tools/webhooks).',
     ),
   event_types: z
     .array(z.string())
     .optional()
     .describe(
-      'Types of events that the [webhook](https://docs.seam.co/latest/developer-tools/webhooks) should receive.',
+      'Types of events that the [webhook](https://docs.seam.co/developer-tools/webhooks) should receive.',
     ),
   secret: z
     .string()
     .optional()
     .describe(
-      'Secret associated with the [webhook](https://docs.seam.co/latest/developer-tools/webhooks).',
+      'Secret associated with the [webhook](https://docs.seam.co/developer-tools/webhooks).',
     ),
 }).describe(`
   ---
   route_path: /webhooks
   ---
-  Represents a [webhook](https://docs.seam.co/latest/developer-tools/webhooks) that enables you to receive notifications of events. When you create a webhook, specify the endpoint URL at which you want to receive events and the set of event types that you want to receive.
+  Represents a [webhook](https://docs.seam.co/developer-tools/webhooks) that enables you to receive notifications of events. When you create a webhook, specify the endpoint URL at which you want to receive events and the set of event types that you want to receive.
   `)
 
 export type Webhook = z.infer<typeof webhook>

--- a/src/lib/seam/connect/models/workspaces/workspace.ts
+++ b/src/lib/seam/connect/models/workspaces/workspace.ts
@@ -7,57 +7,57 @@ export const workspace = z.object({
     .string()
     .uuid()
     .describe(
-      'ID of the [workspace](https://docs.seam.co/latest/core-concepts/workspaces).',
+      'ID of the [workspace](https://docs.seam.co/core-concepts/workspaces).',
     ),
   name: z
     .string()
     .describe(
-      'Name of the [workspace](https://docs.seam.co/latest/core-concepts/workspaces).',
+      'Name of the [workspace](https://docs.seam.co/core-concepts/workspaces).',
     ),
   company_name: z
     .string()
     .describe(
-      'Company name associated with the [workspace](https://docs.seam.co/latest/core-concepts/workspaces).',
+      'Company name associated with the [workspace](https://docs.seam.co/core-concepts/workspaces).',
     ),
   is_sandbox: z
     .boolean()
     .describe(
-      'Indicates whether the workspace is a [sandbox workspace](https://docs.seam.co/latest/core-concepts/workspaces#sandbox-workspaces).',
+      'Indicates whether the workspace is a [sandbox workspace](https://docs.seam.co/core-concepts/workspaces#sandbox-workspaces).',
     ),
   connect_webview_customization: z.object({
     primary_button_color: hex_color_code
       .optional()
       .describe(
-        'Primary button color for [Connect Webviews](https://docs.seam.co/latest/core-concepts/connect-webviews) in the workspace. See also [Customize the Look and Feel of Your Connect Webviews](https://docs.seam.co/latest/core-concepts/connect-webviews/customizing-connect-webviews#customize-the-look-and-feel-of-your-connect-webviews).',
+        'Primary button color for [Connect Webviews](https://docs.seam.co/core-concepts/connect-webviews) in the workspace. See also [Customize the Look and Feel of Your Connect Webviews](https://docs.seam.co/core-concepts/connect-webviews/customizing-connect-webviews#customize-the-look-and-feel-of-your-connect-webviews).',
       ),
     primary_button_text_color: hex_color_code
       .optional()
       .describe(
-        'Primary button text color for [Connect Webviews](https://docs.seam.co/latest/core-concepts/connect-webviews) in the workspace. See also [Customize the Look and Feel of Your Connect Webviews](https://docs.seam.co/latest/core-concepts/connect-webviews/customizing-connect-webviews#customize-the-look-and-feel-of-your-connect-webviews).',
+        'Primary button text color for [Connect Webviews](https://docs.seam.co/core-concepts/connect-webviews) in the workspace. See also [Customize the Look and Feel of Your Connect Webviews](https://docs.seam.co/core-concepts/connect-webviews/customizing-connect-webviews#customize-the-look-and-feel-of-your-connect-webviews).',
       ),
     success_message: z
       .string()
       .optional()
       .describe(
-        'Success message for [Connect Webviews](https://docs.seam.co/latest/core-concepts/connect-webviews) in the workspace. See also [Customize the Look and Feel of Your Connect Webviews](https://docs.seam.co/latest/core-concepts/connect-webviews/customizing-connect-webviews#customize-the-look-and-feel-of-your-connect-webviews).',
+        'Success message for [Connect Webviews](https://docs.seam.co/core-concepts/connect-webviews) in the workspace. See also [Customize the Look and Feel of Your Connect Webviews](https://docs.seam.co/core-concepts/connect-webviews/customizing-connect-webviews#customize-the-look-and-feel-of-your-connect-webviews).',
       ),
     logo_shape: z
       .enum(['circle', 'square'])
       .optional()
       .describe(
-        'Logo shape for [Connect Webviews](https://docs.seam.co/latest/core-concepts/connect-webviews) in the workspace. See also [Customize the Look and Feel of Your Connect Webviews](https://docs.seam.co/latest/core-concepts/connect-webviews/customizing-connect-webviews#customize-the-look-and-feel-of-your-connect-webviews).',
+        'Logo shape for [Connect Webviews](https://docs.seam.co/core-concepts/connect-webviews) in the workspace. See also [Customize the Look and Feel of Your Connect Webviews](https://docs.seam.co/core-concepts/connect-webviews/customizing-connect-webviews#customize-the-look-and-feel-of-your-connect-webviews).',
       ),
     inviter_logo_url: z
       .string()
       .optional()
       .describe(
-        'URL of the inviter logo for [Connect Webviews](https://docs.seam.co/latest/core-concepts/connect-webviews) in the workspace. See also [Customize the Look and Feel of Your Connect Webviews](https://docs.seam.co/latest/core-concepts/connect-webviews/customizing-connect-webviews#customize-the-look-and-feel-of-your-connect-webviews).',
+        'URL of the inviter logo for [Connect Webviews](https://docs.seam.co/core-concepts/connect-webviews) in the workspace. See also [Customize the Look and Feel of Your Connect Webviews](https://docs.seam.co/core-concepts/connect-webviews/customizing-connect-webviews#customize-the-look-and-feel-of-your-connect-webviews).',
       ),
   }),
   is_suspended: z
     .boolean()
     .describe(
-      'Indicates whether the [sandbox workspace](https://docs.seam.co/latest/core-concepts/workspaces#sandbox-workspaces) is suspended. Seam suspends sandbox workspaces that have not been accessed in 14 days.',
+      'Indicates whether the [sandbox workspace](https://docs.seam.co/core-concepts/workspaces#sandbox-workspaces) is suspended. Seam suspends sandbox workspaces that have not been accessed in 14 days.',
     ),
   connect_partner_name: z
     .string()
@@ -74,7 +74,7 @@ export const workspace = z.object({
     .string()
     .optional()
     .describe(
-      'Publishable key for the [workspace](https://docs.seam.co/latest/core-concepts/workspaces). This key is used to identify the workspace in client-side applications.',
+      'Publishable key for the [workspace](https://docs.seam.co/core-concepts/workspaces). This key is used to identify the workspace in client-side applications.',
     ),
   is_publishable_key_auth_enabled: z
     .boolean()
@@ -85,7 +85,7 @@ export const workspace = z.object({
   ---
   route_path: /workspaces
   ---
-  Represents a Seam [workspace](https://docs.seam.co/latest/core-concepts/workspaces). A workspace is a top-level entity that encompasses all other resources below it, such as devices, connected accounts, and Connect Webviews. Seam provides two types of workspaces. A [sandbox workspace](https://docs.seam.co/latest/core-concepts/workspaces#sandbox-workspaces) is a special type of workspace designed for testing code. Sandbox workspaces offer test device accounts and virtual devices that you can connect and control. This ability to work with virtual devices is quite handy because it removes the need to own physical devices from multiple brands. To connect real devices and systems to Seam, use a [production workspace](https://docs.seam.co/latest/core-concepts/workspaces#production-workspaces).
+  Represents a Seam [workspace](https://docs.seam.co/core-concepts/workspaces). A workspace is a top-level entity that encompasses all other resources below it, such as devices, connected accounts, and Connect Webviews. Seam provides two types of workspaces. A [sandbox workspace](https://docs.seam.co/core-concepts/workspaces#sandbox-workspaces) is a special type of workspace designed for testing code. Sandbox workspaces offer test device accounts and virtual devices that you can connect and control. This ability to work with virtual devices is quite handy because it removes the need to own physical devices from multiple brands. To connect real devices and systems to Seam, use a [production workspace](https://docs.seam.co/core-concepts/workspaces#production-workspaces).
 `)
 
 export type Workspace = z.infer<typeof workspace>

--- a/src/lib/seam/connect/openapi.ts
+++ b/src/lib/seam/connect/openapi.ts
@@ -10,7 +10,7 @@ const openapi: OpenAPISpec = {
     schemas: {
       access_code: {
         description:
-          'Represents a smart lock [access code](https://docs.seam.co/latest/capability-guides/smart-locks/access-codes).\n\nAn access code is a code used for a keypad or pinpad device. Unlike physical keys, which can easily be lost or duplicated, PIN codes can be customized, tracked, and altered on the fly. Using the Seam Access Code API, you can easily generate access codes on the hundreds of door lock models with which we integrate.\n\nSeam supports programming two types of access codes: [ongoing](https://docs.seam.co/latest/capability-guides/smart-locks/access-codes#ongoing-access-codes) and [time-bound](https://docs.seam.co/latest/capability-guides/smart-locks/access-codes#time-bound-access-codes). To differentiate between the two, refer to the `type` property of the access code. Ongoing codes display as `ongoing`, whereas time-bound codes are labeled `time_bound`. An ongoing access code is active, until it has been removed from the device. To specify an ongoing access code, leave both `starts_at` and `ends_at` empty. A time-bound access code will be programmed at the `starts_at` time and removed at the `ends_at` time.\n\nIn addition, for certain devices, Seam also supports [offline access codes](https://docs.seam.co/latest/capability-guides/smart-locks/access-codes#offline-access-codes). Offline access (PIN) codes are designed for door locks that might not always maintain an internet connection. For this type of access code, the device manufacturer uses encryption keys (tokens) to create server-based registries of algorithmically-generated offline PIN codes. Because the tokens remain synchronized with the managed devices, the locks do not require an active internet connection—and you do not need to be near the locks—to create an offline access code. Then, owners or managers can share these offline codes with users through a variety of mechanisms, such as messaging applications. That is, lock users do not need to install a smartphone application to receive an offline access code.',
+          'Represents a smart lock [access code](https://docs.seam.co/capability-guides/smart-locks/access-codes).\n\nAn access code is a code used for a keypad or pinpad device. Unlike physical keys, which can easily be lost or duplicated, PIN codes can be customized, tracked, and altered on the fly. Using the Seam Access Code API, you can easily generate access codes on the hundreds of door lock models with which we integrate.\n\nSeam supports programming two types of access codes: [ongoing](https://docs.seam.co/capability-guides/smart-locks/access-codes#ongoing-access-codes) and [time-bound](https://docs.seam.co/capability-guides/smart-locks/access-codes#time-bound-access-codes). To differentiate between the two, refer to the `type` property of the access code. Ongoing codes display as `ongoing`, whereas time-bound codes are labeled `time_bound`. An ongoing access code is active, until it has been removed from the device. To specify an ongoing access code, leave both `starts_at` and `ends_at` empty. A time-bound access code will be programmed at the `starts_at` time and removed at the `ends_at` time.\n\nIn addition, for certain devices, Seam also supports [offline access codes](https://docs.seam.co/capability-guides/smart-locks/access-codes#offline-access-codes). Offline access (PIN) codes are designed for door locks that might not always maintain an internet connection. For this type of access code, the device manufacturer uses encryption keys (tokens) to create server-based registries of algorithmically-generated offline PIN codes. Because the tokens remain synchronized with the managed devices, the locks do not require an active internet connection—and you do not need to be near the locks—to create an offline access code. Then, owners or managers can share these offline codes with users through a variety of mechanisms, such as messaging applications. That is, lock users do not need to install a smartphone application to receive an offline access code.',
         properties: {
           access_code_id: {
             description: 'Unique identifier for the access code.',
@@ -100,7 +100,7 @@ const openapi: OpenAPISpec = {
           },
           errors: {
             description:
-              'Errors associated with the [access code](https://docs.seam.co/latest/capability-guides/smart-locks/access-codes).',
+              'Errors associated with the [access code](https://docs.seam.co/capability-guides/smart-locks/access-codes).',
             items: {
               discriminator: { propertyName: 'error_code' },
               oneOf: [
@@ -895,7 +895,7 @@ const openapi: OpenAPISpec = {
                     },
                     is_connected_account_error: {
                       description:
-                        'Indicates that the error is a [connected account](https://docs.seam.co/latest/api/connected_accounts) error.',
+                        'Indicates that the error is a [connected account](https://docs.seam.co/api/connected_accounts) error.',
                       enum: [true],
                       type: 'boolean',
                     },
@@ -938,7 +938,7 @@ const openapi: OpenAPISpec = {
                     },
                     is_connected_account_error: {
                       description:
-                        'Indicates that the error is a [connected account](https://docs.seam.co/latest/api/connected_accounts) error.',
+                        'Indicates that the error is a [connected account](https://docs.seam.co/api/connected_accounts) error.',
                       enum: [true],
                       type: 'boolean',
                     },
@@ -1108,7 +1108,7 @@ const openapi: OpenAPISpec = {
                 },
                 {
                   description:
-                    'Indicates that the [backup access code pool](https://docs.seam.co/latest/capability-guides/smart-locks/access-codes/backup-access-codes) is empty.',
+                    'Indicates that the [backup access code pool](https://docs.seam.co/capability-guides/smart-locks/access-codes/backup-access-codes) is empty.',
                   properties: {
                     created_at: {
                       description:
@@ -1404,7 +1404,7 @@ const openapi: OpenAPISpec = {
                 },
                 {
                   description:
-                    'Indicates that the Seam API cannot communicate with [Seam Bridge](https://docs.seam.co/latest/capability-guides/seam-bridge), for example, if the Seam Bridge executable has stopped or if the computer running the Seam Bridge executable is offline. See also [Troubleshooting Your Access Control System](https://docs.seam.co/latest/capability-guides/access-systems/troubleshooting-your-access-control-system#acs_system.errors.seam_bridge_disconnected).',
+                    'Indicates that the Seam API cannot communicate with [Seam Bridge](https://docs.seam.co/capability-guides/seam-bridge), for example, if the Seam Bridge executable has stopped or if the computer running the Seam Bridge executable is offline. See also [Troubleshooting Your Access Control System](https://docs.seam.co/capability-guides/access-systems/troubleshooting-your-access-control-system#acs_system.errors.seam_bridge_disconnected).',
                   properties: {
                     created_at: {
                       description:
@@ -1420,7 +1420,7 @@ const openapi: OpenAPISpec = {
                     },
                     is_bridge_error: {
                       description:
-                        'Indicates whether the error is related to [Seam Bridge](https://docs.seam.co/latest/capability-guides/seam-bridge).',
+                        'Indicates whether the error is related to [Seam Bridge](https://docs.seam.co/capability-guides/seam-bridge).',
                       type: 'boolean',
                     },
                     is_connected_account_error: {
@@ -1781,7 +1781,7 @@ const openapi: OpenAPISpec = {
           },
           status: {
             description:
-              'Current status of the access code within the operational lifecycle. Values are `setting`, a transitional phase that indicates that the code is being configured or activated; `set`, which indicates that the code is active and operational; `unset`, which indicates a deactivated or unused state, either before activation or after deliberate deactivation; `removing`, which indicates a transitional period in which the code is being deleted or made inactive; and `unknown`, which indicates an indeterminate state, due to reasons such as system errors or incomplete data, that highlights a potential need for system review or troubleshooting. See also [Lifecycle of Access Codes](https://docs.seam.co/latest/capability-guides/smart-locks/access-codes/lifecycle-of-access-codes).',
+              'Current status of the access code within the operational lifecycle. Values are `setting`, a transitional phase that indicates that the code is being configured or activated; `set`, which indicates that the code is active and operational; `unset`, which indicates a deactivated or unused state, either before activation or after deliberate deactivation; `removing`, which indicates a transitional period in which the code is being deleted or made inactive; and `unknown`, which indicates an indeterminate state, due to reasons such as system errors or incomplete data, that highlights a potential need for system review or troubleshooting. See also [Lifecycle of Access Codes](https://docs.seam.co/capability-guides/smart-locks/access-codes/lifecycle-of-access-codes).',
             enum: ['setting', 'set', 'unset', 'removing', 'unknown'],
             type: 'string',
           },
@@ -1793,10 +1793,10 @@ const openapi: OpenAPISpec = {
           },
           warnings: {
             description:
-              'Warnings associated with the [access code](https://docs.seam.co/latest/capability-guides/smart-locks/access-codes).',
+              'Warnings associated with the [access code](https://docs.seam.co/capability-guides/smart-locks/access-codes).',
             items: {
               description:
-                'Warnings associated with the [access code](https://docs.seam.co/latest/capability-guides/smart-locks/access-codes).',
+                'Warnings associated with the [access code](https://docs.seam.co/capability-guides/smart-locks/access-codes).',
               discriminator: { propertyName: 'warning_code' },
               oneOf: [
                 {
@@ -2346,7 +2346,7 @@ const openapi: OpenAPISpec = {
           },
           errors: {
             description:
-              'Errors associated with the [access grant](https://docs.seam.co/latest/capability-guides/access-grants).',
+              'Errors associated with the [access grant](https://docs.seam.co/capability-guides/access-grants).',
             items: {
               discriminator: { propertyName: 'error_code' },
               oneOf: [
@@ -2622,15 +2622,15 @@ const openapi: OpenAPISpec = {
           },
           warnings: {
             description:
-              'Warnings associated with the [access grant](https://docs.seam.co/latest/capability-guides/access-grants).',
+              'Warnings associated with the [access grant](https://docs.seam.co/capability-guides/access-grants).',
             items: {
               description:
-                'Warning associated with the [access grant](https://docs.seam.co/latest/capability-guides/access-grants).',
+                'Warning associated with the [access grant](https://docs.seam.co/capability-guides/access-grants).',
               discriminator: { propertyName: 'warning_code' },
               oneOf: [
                 {
                   description:
-                    'Indicates that the [access grant](https://docs.seam.co/latest/capability-guides/access-grants) is being deleted.',
+                    'Indicates that the [access grant](https://docs.seam.co/capability-guides/access-grants) is being deleted.',
                   properties: {
                     created_at: {
                       description:
@@ -2732,7 +2732,7 @@ const openapi: OpenAPISpec = {
                 },
                 {
                   description:
-                    'Indicates that the access times for this [access grant](https://docs.seam.co/latest/capability-guides/access-grants) are being updated.',
+                    'Indicates that the access times for this [access grant](https://docs.seam.co/capability-guides/access-grants) are being updated.',
                   properties: {
                     access_method_ids: {
                       description: 'IDs of the access methods being updated.',
@@ -3007,7 +3007,7 @@ const openapi: OpenAPISpec = {
           },
           pending_mutations: {
             description:
-              'Pending mutations for the [access method](https://docs.seam.co/latest/capability-guides/access-grants/delivering-access-methods). Indicates operations that are in progress.',
+              'Pending mutations for the [access method](https://docs.seam.co/capability-guides/access-grants/delivering-access-methods). Indicates operations that are in progress.',
             items: {
               discriminator: { propertyName: 'mutation_code' },
               oneOf: [
@@ -3197,15 +3197,15 @@ const openapi: OpenAPISpec = {
           },
           warnings: {
             description:
-              'Warnings associated with the [access method](https://docs.seam.co/latest/capability-guides/access-grants/delivering-access-methods).',
+              'Warnings associated with the [access method](https://docs.seam.co/capability-guides/access-grants/delivering-access-methods).',
             items: {
               description:
-                'Warning associated with the [access method](https://docs.seam.co/latest/capability-guides/access-grants/delivering-access-methods).',
+                'Warning associated with the [access method](https://docs.seam.co/capability-guides/access-grants/delivering-access-methods).',
               discriminator: { propertyName: 'warning_code' },
               oneOf: [
                 {
                   description:
-                    'Indicates that the [access method](https://docs.seam.co/latest/capability-guides/access-grants/delivering-access-methods) is being deleted.',
+                    'Indicates that the [access method](https://docs.seam.co/capability-guides/access-grants/delivering-access-methods) is being deleted.',
                   properties: {
                     created_at: {
                       description:
@@ -3230,7 +3230,7 @@ const openapi: OpenAPISpec = {
                 },
                 {
                   description:
-                    'Indicates that the access times for this [access method](https://docs.seam.co/latest/capability-guides/access-grants/delivering-access-methods) are being updated.',
+                    'Indicates that the access times for this [access method](https://docs.seam.co/capability-guides/access-grants/delivering-access-methods) are being updated.',
                   properties: {
                     created_at: {
                       description:
@@ -3312,7 +3312,7 @@ const openapi: OpenAPISpec = {
       },
       acs_access_group: {
         description:
-          'Group that defines the entrances to which a set of users has access and, in some cases, the access schedule for these entrances and users.\n\nSome access control systems use [access group](https://docs.seam.co/latest/capability-guides/access-systems/user-management/assigning-users-to-access-groups), which are sets of users, combined with sets of permissions. These permissions include both the set of areas or assets that the users can access and the schedule during which the users can access these areas or assets. Instead of assigning access rights individually to each access control system user, which can be time-consuming and error-prone, administrators can assign users to an access group, thereby ensuring that the users inherit all the permissions associated with the access group. Using access groups streamlines the process of managing large numbers of access control system users, especially in bigger organizations or complexes.\n\nTo learn whether your access control system supports access groups, see the corresponding [system integration guide](https://docs.seam.co/latest/device-and-system-integration-guides#access-control-systems).',
+          'Group that defines the entrances to which a set of users has access and, in some cases, the access schedule for these entrances and users.\n\nSome access control systems use [access group](https://docs.seam.co/capability-guides/access-systems/user-management/assigning-users-to-access-groups), which are sets of users, combined with sets of permissions. These permissions include both the set of areas or assets that the users can access and the schedule during which the users can access these areas or assets. Instead of assigning access rights individually to each access control system user, which can be time-consuming and error-prone, administrators can assign users to an access group, thereby ensuring that the users inherit all the permissions associated with the access group. Using access groups streamlines the process of managing large numbers of access control system users, especially in bigger organizations or complexes.\n\nTo learn whether your access control system supports access groups, see the corresponding [system integration guide](https://docs.seam.co/device-and-system-integration-guides#access-control-systems).',
         properties: {
           access_group_type: {
             deprecated: true,
@@ -3368,7 +3368,7 @@ const openapi: OpenAPISpec = {
           },
           connected_account_id: {
             description:
-              'ID of the [connected account](https://docs.seam.co/latest/core-concepts/connected-accounts) that contains the access group.',
+              'ID of the [connected account](https://docs.seam.co/core-concepts/connected-accounts) that contains the access group.',
             format: 'uuid',
             type: 'string',
           },
@@ -3386,7 +3386,7 @@ const openapi: OpenAPISpec = {
               oneOf: [
                 {
                   description:
-                    'Indicates that the [access group](https://docs.seam.co/latest/capability-guides/access-systems/user-management/assigning-users-to-access-groups) was not created on the [access system](https://docs.seam.co/latest/capability-guides/access-systems). This is likely due to an internal unexpected error. Contact Seam [support](mailto:support@seam.co).',
+                    'Indicates that the [access group](https://docs.seam.co/capability-guides/access-systems/user-management/assigning-users-to-access-groups) was not created on the [access system](https://docs.seam.co/capability-guides/access-systems). This is likely due to an internal unexpected error. Contact Seam [support](mailto:support@seam.co).',
                   properties: {
                     created_at: {
                       description:
@@ -3852,7 +3852,7 @@ const openapi: OpenAPISpec = {
           },
           workspace_id: {
             description:
-              'ID of the [workspace](https://docs.seam.co/latest/core-concepts/workspaces) that contains the access group.',
+              'ID of the [workspace](https://docs.seam.co/core-concepts/workspaces) that contains the access group.',
             format: 'uuid',
             type: 'string',
           },
@@ -3879,36 +3879,36 @@ const openapi: OpenAPISpec = {
       },
       acs_credential: {
         description:
-          'Means by which an [access control system user](https://docs.seam.co/latest/capability-guides/access-systems/user-management) gains access at an [entrance](https://docs.seam.co/latest/capability-guides/access-systems/retrieving-entrance-details). The `acs_credential` object represents a [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials) that provides an ACS user access within an [access control system](https://docs.seam.co/latest/capability-guides/access-systems).\n\nAn access control system generally uses digital means of access to authorize a user trying to get through a specific entrance. Examples of credentials include plastic key cards, mobile keys, biometric identifiers, and PIN codes. The electronic nature of these credentials, as well as the fact that access is centralized, enables both the rapid provisioning and rescinding of access and the ability to compile access audit logs.\n\nFor each `acs_credential`, you define the access method. You can also specify additional properties, such as a PIN code, depending on the credential type.',
+          'Means by which an [access control system user](https://docs.seam.co/capability-guides/access-systems/user-management) gains access at an [entrance](https://docs.seam.co/capability-guides/access-systems/retrieving-entrance-details). The `acs_credential` object represents a [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials) that provides an ACS user access within an [access control system](https://docs.seam.co/capability-guides/access-systems).\n\nAn access control system generally uses digital means of access to authorize a user trying to get through a specific entrance. Examples of credentials include plastic key cards, mobile keys, biometric identifiers, and PIN codes. The electronic nature of these credentials, as well as the fact that access is centralized, enables both the rapid provisioning and rescinding of access and the ability to compile access audit logs.\n\nFor each `acs_credential`, you define the access method. You can also specify additional properties, such as a PIN code, depending on the credential type.',
         properties: {
           access_method: {
             description:
-              'Access method for the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials). Supported values: `code`, `card`, `mobile_key`, `cloud_key`.',
+              'Access method for the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials). Supported values: `code`, `card`, `mobile_key`, `cloud_key`.',
             enum: ['code', 'card', 'mobile_key', 'cloud_key'],
             type: 'string',
           },
           acs_credential_id: {
             description:
-              'ID of the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials).',
+              'ID of the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials).',
             format: 'uuid',
             type: 'string',
           },
           acs_credential_pool_id: { format: 'uuid', type: 'string' },
           acs_system_id: {
             description:
-              'ID of the [access control system](https://docs.seam.co/latest/capability-guides/access-systems) that contains the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials).',
+              'ID of the [access control system](https://docs.seam.co/capability-guides/access-systems) that contains the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials).',
             format: 'uuid',
             type: 'string',
           },
           acs_user_id: {
             description:
-              'ID of the [ACS user](https://docs.seam.co/latest/capability-guides/access-systems/user-management) to whom the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials) belongs.',
+              'ID of the [ACS user](https://docs.seam.co/capability-guides/access-systems/user-management) to whom the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials) belongs.',
             format: 'uuid',
             type: 'string',
           },
           assa_abloy_vostio_metadata: {
             description:
-              'Vostio-specific metadata for the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials).',
+              'Vostio-specific metadata for the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials).',
             properties: {
               auto_join: {
                 description:
@@ -3945,42 +3945,42 @@ const openapi: OpenAPISpec = {
           },
           card_number: {
             description:
-              'Number of the card associated with the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials).',
+              'Number of the card associated with the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials).',
             nullable: true,
             type: 'string',
           },
           code: {
             description:
-              'Access (PIN) code for the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials).',
+              'Access (PIN) code for the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials).',
             nullable: true,
             type: 'string',
           },
           connected_account_id: {
             description:
-              'ID of the [connected account](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials#connected-accounts) to which the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials) belongs.',
+              'ID of the [connected account](https://docs.seam.co/capability-guides/access-systems/managing-credentials#connected-accounts) to which the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials) belongs.',
             format: 'uuid',
             type: 'string',
           },
           created_at: {
             description:
-              'Date and time at which the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials) was created.',
+              'Date and time at which the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials) was created.',
             format: 'date-time',
             type: 'string',
           },
           display_name: {
             description:
-              'Display name that corresponds to the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials) type.',
+              'Display name that corresponds to the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials) type.',
             minLength: 1,
             type: 'string',
           },
           ends_at: {
             description:
-              'Date and time at which the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials) validity ends, in [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) format. Must be a time in the future and after `starts_at`.',
+              'Date and time at which the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials) validity ends, in [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) format. Must be a time in the future and after `starts_at`.',
             type: 'string',
           },
           errors: {
             description:
-              'Errors associated with the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials).',
+              'Errors associated with the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials).',
             items: {
               properties: {
                 error_code: { type: 'string' },
@@ -3993,7 +3993,7 @@ const openapi: OpenAPISpec = {
           },
           external_type: {
             description:
-              'Brand-specific terminology for the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials) type. Supported values: `pti_card`, `brivo_credential`, `hid_credential`, `visionline_card`.',
+              'Brand-specific terminology for the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials) type. Supported values: `pti_card`, `brivo_credential`, `hid_credential`, `visionline_card`.',
             enum: [
               'pti_card',
               'brivo_credential',
@@ -4012,65 +4012,65 @@ const openapi: OpenAPISpec = {
           },
           external_type_display_name: {
             description:
-              'Display name that corresponds to the brand-specific terminology for the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials) type.',
+              'Display name that corresponds to the brand-specific terminology for the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials) type.',
             type: 'string',
           },
           is_issued: {
             description:
-              'Indicates whether the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials) has been encoded onto a card.',
+              'Indicates whether the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials) has been encoded onto a card.',
             type: 'boolean',
           },
           is_latest_desired_state_synced_with_provider: {
             description:
-              'Indicates whether the latest state of the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials) has been synced from Seam to the provider.',
+              'Indicates whether the latest state of the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials) has been synced from Seam to the provider.',
             nullable: true,
             type: 'boolean',
           },
           is_managed: { enum: [true], type: 'boolean' },
           is_multi_phone_sync_credential: {
             description:
-              'Indicates whether the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials) is a [multi-phone sync credential](https://docs.seam.co/latest/capability-guides/mobile-access/issuing-mobile-credentials-from-an-access-control-system#what-are-multi-phone-sync-credentials).',
+              'Indicates whether the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials) is a [multi-phone sync credential](https://docs.seam.co/capability-guides/mobile-access/issuing-mobile-credentials-from-an-access-control-system#what-are-multi-phone-sync-credentials).',
             type: 'boolean',
           },
           is_one_time_use: {
             description:
-              'Indicates whether the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials) can only be used once. If `true`, the code becomes invalid after the first use.',
+              'Indicates whether the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials) can only be used once. If `true`, the code becomes invalid after the first use.',
             type: 'boolean',
           },
           issued_at: {
             description:
-              'Date and time at which the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials) was encoded onto a card.',
+              'Date and time at which the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials) was encoded onto a card.',
             format: 'date-time',
             nullable: true,
             type: 'string',
           },
           latest_desired_state_synced_with_provider_at: {
             description:
-              'Date and time at which the state of the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials) was most recently synced from Seam to the provider.',
+              'Date and time at which the state of the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials) was most recently synced from Seam to the provider.',
             format: 'date-time',
             nullable: true,
             type: 'string',
           },
           parent_acs_credential_id: {
             description:
-              'ID of the parent [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials).',
+              'ID of the parent [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials).',
             format: 'uuid',
             type: 'string',
           },
           starts_at: {
             description:
-              'Date and time at which the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials) validity starts, in [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) format.',
+              'Date and time at which the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials) validity starts, in [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) format.',
             type: 'string',
           },
           user_identity_id: {
             description:
-              'ID of the [user identity](https://docs.seam.co/latest/api/user_identities) to whom the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials) belongs.',
+              'ID of the [user identity](https://docs.seam.co/api/user_identities) to whom the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials) belongs.',
             format: 'uuid',
             type: 'string',
           },
           visionline_metadata: {
             description:
-              'Visionline-specific metadata for the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials).',
+              'Visionline-specific metadata for the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials).',
             properties: {
               auto_join: {
                 description:
@@ -4120,15 +4120,15 @@ const openapi: OpenAPISpec = {
           },
           warnings: {
             description:
-              'Warnings associated with the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials).',
+              'Warnings associated with the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials).',
             items: {
               description:
-                'Warning associated with the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials).',
+                'Warning associated with the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials).',
               discriminator: { propertyName: 'warning_code' },
               oneOf: [
                 {
                   description:
-                    'Indicates that the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials) is waiting to be issued.',
+                    'Indicates that the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials) is waiting to be issued.',
                   properties: {
                     created_at: {
                       description:
@@ -4153,7 +4153,7 @@ const openapi: OpenAPISpec = {
                 },
                 {
                   description:
-                    "Indicates that the schedule of one of the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials)'s children was modified externally.",
+                    "Indicates that the schedule of one of the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials)'s children was modified externally.",
                   properties: {
                     created_at: {
                       description:
@@ -4178,7 +4178,7 @@ const openapi: OpenAPISpec = {
                 },
                 {
                   description:
-                    'Indicates that the schedule of the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials) was modified to avoid creating a credential with a start date in the past.',
+                    'Indicates that the schedule of the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials) was modified to avoid creating a credential with a start date in the past.',
                   properties: {
                     created_at: {
                       description:
@@ -4203,7 +4203,7 @@ const openapi: OpenAPISpec = {
                 },
                 {
                   description:
-                    'Indicates that the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials) is being deleted.',
+                    'Indicates that the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials) is being deleted.',
                   properties: {
                     created_at: {
                       description:
@@ -4228,7 +4228,7 @@ const openapi: OpenAPISpec = {
                 },
                 {
                   description:
-                    'An unknown issue occurred while syncing the state of the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials) with the provider. This issue may affect the proper functioning of the credential.',
+                    'An unknown issue occurred while syncing the state of the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials) with the provider. This issue may affect the proper functioning of the credential.',
                   properties: {
                     created_at: {
                       description:
@@ -4253,7 +4253,7 @@ const openapi: OpenAPISpec = {
                 },
                 {
                   description:
-                    'Access permissions for the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials) have changed. [Reissue](https://docs.seam.co/latest/capability-guides/access-systems/working-with-card-encoders-and-scanners/creating-and-encoding-card-based-credentials) (re-encode) the credential. This issue may affect the proper functioning of the credential.',
+                    'Access permissions for the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials) have changed. [Reissue](https://docs.seam.co/capability-guides/access-systems/working-with-card-encoders-and-scanners/creating-and-encoding-card-based-credentials) (re-encode) the credential. This issue may affect the proper functioning of the credential.',
                   properties: {
                     created_at: {
                       description:
@@ -4282,7 +4282,7 @@ const openapi: OpenAPISpec = {
           },
           workspace_id: {
             description:
-              'ID of the [workspace](https://docs.seam.co/latest/core-concepts/workspaces) that contains the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials).',
+              'ID of the [workspace](https://docs.seam.co/core-concepts/workspaces) that contains the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials).',
             format: 'uuid',
             type: 'string',
           },
@@ -4353,43 +4353,43 @@ const openapi: OpenAPISpec = {
       },
       acs_encoder: {
         description:
-          'Represents a hardware device that encodes [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials) data onto physical cards within an [access control system](https://docs.seam.co/latest/capability-guides/access-systems).\n\nSome access control systems require credentials to be encoded onto plastic key cards using a card encoder. This process involves the following two key steps:\n\n1. Credential creation\n   Configure the access parameters for the credential.\n2. Card encoding\n   Write the credential data onto the card using a compatible card encoder.\n\nSeparately, the Seam API also supports card scanning, which enables you to scan and read the encoded data on a card. You can use this action to confirm consistency with access control system records or diagnose discrepancies if needed.\n\n See [Working with Card Encoders and Scanners](https://docs.seam.co/latest/capability-guides/access-systems/working-with-card-encoders-and-scanners).\n\nTo verify if your access control system requires a card encoder, see the corresponding [system integration guide](https://docs.seam.co/latest/device-and-system-integration-guides#access-control-systems).',
+          'Represents a hardware device that encodes [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials) data onto physical cards within an [access control system](https://docs.seam.co/capability-guides/access-systems).\n\nSome access control systems require credentials to be encoded onto plastic key cards using a card encoder. This process involves the following two key steps:\n\n1. Credential creation\n   Configure the access parameters for the credential.\n2. Card encoding\n   Write the credential data onto the card using a compatible card encoder.\n\nSeparately, the Seam API also supports card scanning, which enables you to scan and read the encoded data on a card. You can use this action to confirm consistency with access control system records or diagnose discrepancies if needed.\n\n See [Working with Card Encoders and Scanners](https://docs.seam.co/capability-guides/access-systems/working-with-card-encoders-and-scanners).\n\nTo verify if your access control system requires a card encoder, see the corresponding [system integration guide](https://docs.seam.co/device-and-system-integration-guides#access-control-systems).',
         properties: {
           acs_encoder_id: {
             description:
-              'ID of the [encoder](https://docs.seam.co/latest/capability-guides/access-systems/working-with-card-encoders-and-scanners.',
+              'ID of the [encoder](https://docs.seam.co/capability-guides/access-systems/working-with-card-encoders-and-scanners.',
             format: 'uuid',
             type: 'string',
           },
           acs_system_id: {
             description:
-              'ID of the [access control system](https://docs.seam.co/latest/capability-guides/access-systems) that contains the [encoder](https://docs.seam.co/latest/capability-guides/access-systems/working-with-card-encoders-and-scanners).',
+              'ID of the [access control system](https://docs.seam.co/capability-guides/access-systems) that contains the [encoder](https://docs.seam.co/capability-guides/access-systems/working-with-card-encoders-and-scanners).',
             format: 'uuid',
             type: 'string',
           },
           connected_account_id: {
             description:
-              'ID of the [connected account](https://docs.seam.co/latest/core-concepts/connected-accounts) that contains the [encoder](https://docs.seam.co/latest/capability-guides/access-systems/working-with-card-encoders-and-scanners).',
+              'ID of the [connected account](https://docs.seam.co/core-concepts/connected-accounts) that contains the [encoder](https://docs.seam.co/capability-guides/access-systems/working-with-card-encoders-and-scanners).',
             format: 'uuid',
             type: 'string',
           },
           created_at: {
             description:
-              'Date and time at which the [encoder](https://docs.seam.co/latest/capability-guides/access-systems/working-with-card-encoders-and-scanners) was created.',
+              'Date and time at which the [encoder](https://docs.seam.co/capability-guides/access-systems/working-with-card-encoders-and-scanners) was created.',
             format: 'date-time',
             type: 'string',
           },
           display_name: {
             description:
-              'Display name for the [encoder](https://docs.seam.co/latest/capability-guides/access-systems/working-with-card-encoders-and-scanners).',
+              'Display name for the [encoder](https://docs.seam.co/capability-guides/access-systems/working-with-card-encoders-and-scanners).',
             type: 'string',
           },
           errors: {
             description:
-              'Errors associated with the [encoder](https://docs.seam.co/latest/capability-guides/access-systems/working-with-card-encoders-and-scanners).',
+              'Errors associated with the [encoder](https://docs.seam.co/capability-guides/access-systems/working-with-card-encoders-and-scanners).',
             items: {
               description:
-                'Error associated with the [encoder](https://docs.seam.co/latest/capability-guides/access-systems/working-with-card-encoders-and-scanners).',
+                'Error associated with the [encoder](https://docs.seam.co/capability-guides/access-systems/working-with-card-encoders-and-scanners).',
               properties: {
                 created_at: {
                   description: 'Date and time at which Seam created the error.',
@@ -4415,7 +4415,7 @@ const openapi: OpenAPISpec = {
           },
           workspace_id: {
             description:
-              'ID of the [workspace](https://docs.seam.co/latest/core-concepts/workspaces) that contains the [encoder](https://docs.seam.co/latest/capability-guides/access-systems/working-with-card-encoders-and-scanners).',
+              'ID of the [workspace](https://docs.seam.co/core-concepts/workspaces) that contains the [encoder](https://docs.seam.co/capability-guides/access-systems/working-with-card-encoders-and-scanners).',
             format: 'uuid',
             type: 'string',
           },
@@ -4434,23 +4434,23 @@ const openapi: OpenAPISpec = {
       },
       acs_entrance: {
         description:
-          'Represents an [entrance](https://docs.seam.co/latest/capability-guides/access-systems/retrieving-entrance-details) within an [access control system](https://docs.seam.co/latest/capability-guides/access-systems).\n\nIn an access control system, an entrance is a secured door, gate, zone, or other method of entry. You can list details for all the `acs_entrance` resources in your workspace or get these details for a specific `acs_entrance`. You can also list all entrances associated with a specific credential, and you can list all credentials associated with a specific entrance.',
+          'Represents an [entrance](https://docs.seam.co/capability-guides/access-systems/retrieving-entrance-details) within an [access control system](https://docs.seam.co/capability-guides/access-systems).\n\nIn an access control system, an entrance is a secured door, gate, zone, or other method of entry. You can list details for all the `acs_entrance` resources in your workspace or get these details for a specific `acs_entrance`. You can also list all entrances associated with a specific credential, and you can list all credentials associated with a specific entrance.',
         properties: {
           acs_entrance_id: {
             description:
-              'ID of the [entrance](https://docs.seam.co/latest/capability-guides/access-systems/retrieving-entrance-details).',
+              'ID of the [entrance](https://docs.seam.co/capability-guides/access-systems/retrieving-entrance-details).',
             format: 'uuid',
             type: 'string',
           },
           acs_system_id: {
             description:
-              'ID of the [access control system](https://docs.seam.co/latest/capability-guides/access-systems) that contains the [entrance](https://docs.seam.co/latest/capability-guides/access-systems/retrieving-entrance-details).',
+              'ID of the [access control system](https://docs.seam.co/capability-guides/access-systems) that contains the [entrance](https://docs.seam.co/capability-guides/access-systems/retrieving-entrance-details).',
             format: 'uuid',
             type: 'string',
           },
           assa_abloy_vostio_metadata: {
             description:
-              'ASSA ABLOY Vostio-specific metadata associated with the [entrance](https://docs.seam.co/latest/capability-guides/access-systems/retrieving-entrance-details).',
+              'ASSA ABLOY Vostio-specific metadata associated with the [entrance](https://docs.seam.co/capability-guides/access-systems/retrieving-entrance-details).',
             properties: {
               door_name: {
                 description: 'Name of the door in the Vostio access system.',
@@ -4481,7 +4481,7 @@ const openapi: OpenAPISpec = {
           },
           avigilon_alta_metadata: {
             description:
-              'Avigilon Alta-specific metadata associated with the [entrance](https://docs.seam.co/latest/capability-guides/access-systems/retrieving-entrance-details).',
+              'Avigilon Alta-specific metadata associated with the [entrance](https://docs.seam.co/capability-guides/access-systems/retrieving-entrance-details).',
             properties: {
               entry_name: {
                 description: 'Entry name for an Avigilon Alta system.',
@@ -4529,7 +4529,7 @@ const openapi: OpenAPISpec = {
           },
           brivo_metadata: {
             description:
-              'Brivo-specific metadata associated with the [entrance](https://docs.seam.co/latest/capability-guides/access-systems/retrieving-entrance-details).',
+              'Brivo-specific metadata associated with the [entrance](https://docs.seam.co/capability-guides/access-systems/retrieving-entrance-details).',
             properties: {
               access_point_id: {
                 description:
@@ -4577,24 +4577,24 @@ const openapi: OpenAPISpec = {
           },
           connected_account_id: {
             description:
-              'ID of the [connected account](https://docs.seam.co/latest/capability-guides/access-systems/retrieving-entrance-details) associated with the [entrance](https://docs.seam.co/latest/capability-guides/access-systems/retrieving-entrance-details).',
+              'ID of the [connected account](https://docs.seam.co/capability-guides/access-systems/retrieving-entrance-details) associated with the [entrance](https://docs.seam.co/capability-guides/access-systems/retrieving-entrance-details).',
             format: 'uuid',
             type: 'string',
           },
           created_at: {
             description:
-              'Date and time at which the [entrance](https://docs.seam.co/latest/capability-guides/access-systems/retrieving-entrance-details) was created.',
+              'Date and time at which the [entrance](https://docs.seam.co/capability-guides/access-systems/retrieving-entrance-details) was created.',
             format: 'date-time',
             type: 'string',
           },
           display_name: {
             description:
-              'Display name for the [entrance](https://docs.seam.co/latest/capability-guides/access-systems/retrieving-entrance-details).',
+              'Display name for the [entrance](https://docs.seam.co/capability-guides/access-systems/retrieving-entrance-details).',
             type: 'string',
           },
           dormakaba_ambiance_metadata: {
             description:
-              'dormakaba Ambiance-specific metadata associated with the [entrance](https://docs.seam.co/latest/capability-guides/access-systems/retrieving-entrance-details).',
+              'dormakaba Ambiance-specific metadata associated with the [entrance](https://docs.seam.co/capability-guides/access-systems/retrieving-entrance-details).',
             properties: {
               access_point_name: {
                 description:
@@ -4607,7 +4607,7 @@ const openapi: OpenAPISpec = {
           },
           dormakaba_community_metadata: {
             description:
-              'dormakaba Community-specific metadata associated with the [entrance](https://docs.seam.co/latest/capability-guides/access-systems/retrieving-entrance-details).',
+              'dormakaba Community-specific metadata associated with the [entrance](https://docs.seam.co/capability-guides/access-systems/retrieving-entrance-details).',
             properties: {
               access_point_profile: {
                 description:
@@ -4620,7 +4620,7 @@ const openapi: OpenAPISpec = {
           },
           errors: {
             description:
-              'Errors associated with the [entrance](https://docs.seam.co/latest/capability-guides/access-systems/retrieving-entrance-details).',
+              'Errors associated with the [entrance](https://docs.seam.co/capability-guides/access-systems/retrieving-entrance-details).',
             items: {
               properties: {
                 error_code: {
@@ -4641,7 +4641,7 @@ const openapi: OpenAPISpec = {
           },
           hotek_metadata: {
             description:
-              'Hotek-specific metadata associated with the [entrance](https://docs.seam.co/latest/capability-guides/access-systems/retrieving-entrance-details).',
+              'Hotek-specific metadata associated with the [entrance](https://docs.seam.co/capability-guides/access-systems/retrieving-entrance-details).',
             properties: {
               common_area_name: {
                 description: 'Display name of the entrance.',
@@ -4660,12 +4660,12 @@ const openapi: OpenAPISpec = {
           },
           is_locked: {
             description:
-              'Indicates whether the [entrance](https://docs.seam.co/latest/capability-guides/access-systems/retrieving-entrance-details) is currently locked.',
+              'Indicates whether the [entrance](https://docs.seam.co/capability-guides/access-systems/retrieving-entrance-details) is currently locked.',
             type: 'boolean',
           },
           latch_metadata: {
             description:
-              'Latch-specific metadata associated with the [entrance](https://docs.seam.co/latest/capability-guides/access-systems/retrieving-entrance-details).',
+              'Latch-specific metadata associated with the [entrance](https://docs.seam.co/capability-guides/access-systems/retrieving-entrance-details).',
             properties: {
               accessibility_type: {
                 description: 'Accessibility type in the Latch access system.',
@@ -4694,7 +4694,7 @@ const openapi: OpenAPISpec = {
           },
           salto_ks_metadata: {
             description:
-              'Salto KS-specific metadata associated with the [entrance](https://docs.seam.co/latest/capability-guides/access-systems/retrieving-entrance-details).',
+              'Salto KS-specific metadata associated with the [entrance](https://docs.seam.co/capability-guides/access-systems/retrieving-entrance-details).',
             properties: {
               battery_level: {
                 description: 'Battery level of the door access device.',
@@ -4743,7 +4743,7 @@ const openapi: OpenAPISpec = {
           },
           salto_space_metadata: {
             description:
-              'Salto Space-specific metadata associated with the [entrance](https://docs.seam.co/latest/capability-guides/access-systems/retrieving-entrance-details).',
+              'Salto Space-specific metadata associated with the [entrance](https://docs.seam.co/capability-guides/access-systems/retrieving-entrance-details).',
             properties: {
               audit_on_keys: {
                 description:
@@ -4784,7 +4784,7 @@ const openapi: OpenAPISpec = {
           },
           visionline_metadata: {
             description:
-              'Visionline-specific metadata associated with the [entrance](https://docs.seam.co/latest/capability-guides/access-systems/retrieving-entrance-details).',
+              'Visionline-specific metadata associated with the [entrance](https://docs.seam.co/capability-guides/access-systems/retrieving-entrance-details).',
             properties: {
               door_category: {
                 description:
@@ -4834,10 +4834,10 @@ const openapi: OpenAPISpec = {
           },
           warnings: {
             description:
-              'Warnings associated with the [entrance](https://docs.seam.co/latest/capability-guides/access-systems/retrieving-entrance-details).',
+              'Warnings associated with the [entrance](https://docs.seam.co/capability-guides/access-systems/retrieving-entrance-details).',
             items: {
               description:
-                'Warning associated with the [entrance](https://docs.seam.co/latest/capability-guides/access-systems/retrieving-entrance-details).',
+                'Warning associated with the [entrance](https://docs.seam.co/capability-guides/access-systems/retrieving-entrance-details).',
               discriminator: { propertyName: 'warning_code' },
               oneOf: [
                 {
@@ -4960,54 +4960,54 @@ const openapi: OpenAPISpec = {
       },
       acs_system: {
         description:
-          'Represents an [access control system](https://docs.seam.co/latest/capability-guides/access-systems).\n\nWithin an `acs_system`, create [`acs_user`s](https://docs.seam.co/latest/api/acs/users#acs_user) and [`acs_credential`s](https://docs.seam.co/latest/api/acs/credentials#acs_credential) to grant access to the `acs_user`s.\n\nFor details about the resources associated with an access control system, see the [access control systems namespace](https://docs.seam.co/latest/api/acs).',
+          'Represents an [access control system](https://docs.seam.co/capability-guides/access-systems).\n\nWithin an `acs_system`, create [`acs_user`s](https://docs.seam.co/api/acs/users#acs_user) and [`acs_credential`s](https://docs.seam.co/api/acs/credentials#acs_credential) to grant access to the `acs_user`s.\n\nFor details about the resources associated with an access control system, see the [access control systems namespace](https://docs.seam.co/api/acs).',
         properties: {
           acs_access_group_count: { format: 'float', type: 'number' },
           acs_system_id: {
             description:
-              'ID of the [access control system](https://docs.seam.co/latest/capability-guides/access-systems).',
+              'ID of the [access control system](https://docs.seam.co/capability-guides/access-systems).',
             format: 'uuid',
             type: 'string',
           },
           acs_user_count: { format: 'float', type: 'number' },
           connected_account_id: {
             description:
-              'ID of the [connected account](https://docs.seam.co/latest/core-concepts/connected-accounts) associated with the [access control system](https://docs.seam.co/latest/capability-guides/access-systems).',
+              'ID of the [connected account](https://docs.seam.co/core-concepts/connected-accounts) associated with the [access control system](https://docs.seam.co/capability-guides/access-systems).',
             format: 'uuid',
             type: 'string',
           },
           connected_account_ids: {
             deprecated: true,
             description:
-              'IDs of the [connected accounts](https://docs.seam.co/latest/core-concepts/connected-accounts) associated with the [access control system](https://docs.seam.co/latest/capability-guides/access-systems).',
+              'IDs of the [connected accounts](https://docs.seam.co/core-concepts/connected-accounts) associated with the [access control system](https://docs.seam.co/capability-guides/access-systems).',
             items: { format: 'uuid', type: 'string' },
             type: 'array',
             'x-deprecated': 'Use `connected_account_id`.',
           },
           created_at: {
             description:
-              'Date and time at which the [access control system](https://docs.seam.co/latest/capability-guides/access-systems) was created.',
+              'Date and time at which the [access control system](https://docs.seam.co/capability-guides/access-systems) was created.',
             format: 'date-time',
             type: 'string',
           },
           default_credential_manager_acs_system_id: {
             description:
-              'ID of the default credential manager `acs_system` for this [access control system](https://docs.seam.co/latest/capability-guides/access-systems).',
+              'ID of the default credential manager `acs_system` for this [access control system](https://docs.seam.co/capability-guides/access-systems).',
             format: 'uuid',
             nullable: true,
             type: 'string',
           },
           errors: {
             description:
-              'Errors associated with the [access control system](https://docs.seam.co/latest/capability-guides/access-systems).',
+              'Errors associated with the [access control system](https://docs.seam.co/capability-guides/access-systems).',
             items: {
               description:
-                'Error associated with the [access control system](https://docs.seam.co/latest/capability-guides/access-systems).',
+                'Error associated with the [access control system](https://docs.seam.co/capability-guides/access-systems).',
               discriminator: { propertyName: 'error_code' },
               oneOf: [
                 {
                   description:
-                    'Indicates that the Seam API cannot communicate with [Seam Bridge](https://docs.seam.co/latest/capability-guides/seam-bridge), for example, if Seam Bridge executable has stopped or if the computer running the Seam Bridge executable is offline.\n  This error might also occur if Seam Bridge is connected to the wrong [workspace](https://docs.seam.co/latest/core-concepts/workspaces).\n  See also [Troubleshooting Your Access Control System](https://docs.seam.co/latest/capability-guides/access-systems/troubleshooting-your-access-control-system#acs_system.errors.seam_bridge_disconnected).',
+                    'Indicates that the Seam API cannot communicate with [Seam Bridge](https://docs.seam.co/capability-guides/seam-bridge), for example, if Seam Bridge executable has stopped or if the computer running the Seam Bridge executable is offline.\n  This error might also occur if Seam Bridge is connected to the wrong [workspace](https://docs.seam.co/core-concepts/workspaces).\n  See also [Troubleshooting Your Access Control System](https://docs.seam.co/capability-guides/access-systems/troubleshooting-your-access-control-system#acs_system.errors.seam_bridge_disconnected).',
                   properties: {
                     created_at: {
                       description:
@@ -5032,7 +5032,7 @@ const openapi: OpenAPISpec = {
                 },
                 {
                   description:
-                    'Indicates that the Seam API cannot communicate with [Seam Bridge](https://docs.seam.co/latest/capability-guides/seam-bridge), for example, if Seam Bridge executable has stopped or if the computer running the Seam Bridge executable is offline.\n    See also [Troubleshooting Your Access Control System](https://docs.seam.co/latest/capability-guides/access-systems/troubleshooting-your-access-control-system#acs_system.errors.seam_bridge_disconnected).',
+                    'Indicates that the Seam API cannot communicate with [Seam Bridge](https://docs.seam.co/capability-guides/seam-bridge), for example, if Seam Bridge executable has stopped or if the computer running the Seam Bridge executable is offline.\n    See also [Troubleshooting Your Access Control System](https://docs.seam.co/capability-guides/access-systems/troubleshooting-your-access-control-system#acs_system.errors.seam_bridge_disconnected).',
                   properties: {
                     created_at: {
                       description:
@@ -5058,7 +5058,7 @@ const openapi: OpenAPISpec = {
                 },
                 {
                   description:
-                    'Indicates that [Seam Bridge](https://docs.seam.co/latest/capability-guides/seam-bridge) is functioning correctly and the Seam API can communicate with Seam Bridge, but the Seam API cannot connect to the on-premises [Visionline access control system](https://docs.seam.co/latest/device-and-system-integration-guides/assa-abloy-visionline-access-control-system).\n  For example, the IP address of the on-premises access control system may be set incorrectly within the Seam [workspace](https://docs.seam.co/latest/core-concepts/workspaces).\n  See also [Troubleshooting Your Access Control System](https://docs.seam.co/latest/capability-guides/access-systems/troubleshooting-your-access-control-system#acs_system.errors.visionline_instance_unreachable).',
+                    'Indicates that [Seam Bridge](https://docs.seam.co/capability-guides/seam-bridge) is functioning correctly and the Seam API can communicate with Seam Bridge, but the Seam API cannot connect to the on-premises [Visionline access control system](https://docs.seam.co/device-and-system-integration-guides/assa-abloy-visionline-access-control-system).\n  For example, the IP address of the on-premises access control system may be set incorrectly within the Seam [workspace](https://docs.seam.co/core-concepts/workspaces).\n  See also [Troubleshooting Your Access Control System](https://docs.seam.co/capability-guides/access-systems/troubleshooting-your-access-control-system#acs_system.errors.visionline_instance_unreachable).',
                   properties: {
                     created_at: {
                       description:
@@ -5108,7 +5108,7 @@ const openapi: OpenAPISpec = {
                 },
                 {
                   description:
-                    'Indicates that the [access control system](https://docs.seam.co/latest/capability-guides/access-systems) has been disconnected. See [Troubleshooting Your Access Control System](https://docs.seam.co/latest/capability-guides/access-systems/troubleshooting-your-access-control-system) to resolve the issue.',
+                    'Indicates that the [access control system](https://docs.seam.co/capability-guides/access-systems) has been disconnected. See [Troubleshooting Your Access Control System](https://docs.seam.co/capability-guides/access-systems/troubleshooting-your-access-control-system) to resolve the issue.',
                   properties: {
                     created_at: {
                       description:
@@ -5133,7 +5133,7 @@ const openapi: OpenAPISpec = {
                 },
                 {
                   description:
-                    'Indicates that the login credentials are invalid. Reconnect the account using a [Connect Webview](https://docs.seam.co/latest/core-concepts/connect-webviews) to restore access.',
+                    'Indicates that the login credentials are invalid. Reconnect the account using a [Connect Webview](https://docs.seam.co/core-concepts/connect-webviews) to restore access.',
                   properties: {
                     created_at: {
                       description:
@@ -5158,7 +5158,7 @@ const openapi: OpenAPISpec = {
                 },
                 {
                   description:
-                    'Indicates that the [access control system](https://docs.seam.co/latest/capability-guides/access-systems) has lost its Salto KS certification. Contact [support](mailto:support@seam.co) to regain access.',
+                    'Indicates that the [access control system](https://docs.seam.co/capability-guides/access-systems) has lost its Salto KS certification. Contact [support](mailto:support@seam.co) to regain access.',
                   properties: {
                     created_at: {
                       description:
@@ -5212,7 +5212,7 @@ const openapi: OpenAPISpec = {
           },
           external_type: {
             description:
-              'Brand-specific terminology for the [access control system](https://docs.seam.co/latest/capability-guides/access-systems) type.',
+              'Brand-specific terminology for the [access control system](https://docs.seam.co/capability-guides/access-systems) type.',
             enum: [
               'pti_site',
               'avigilon_alta_org',
@@ -5234,17 +5234,17 @@ const openapi: OpenAPISpec = {
           },
           external_type_display_name: {
             description:
-              'Display name that corresponds to the brand-specific terminology for the [access control system](https://docs.seam.co/latest/capability-guides/access-systems) type.',
+              'Display name that corresponds to the brand-specific terminology for the [access control system](https://docs.seam.co/capability-guides/access-systems) type.',
             type: 'string',
           },
           image_alt_text: {
             description:
-              'Alternative text for the [access control system](https://docs.seam.co/latest/capability-guides/access-systems) image.',
+              'Alternative text for the [access control system](https://docs.seam.co/capability-guides/access-systems) image.',
             type: 'string',
           },
           image_url: {
             description:
-              'URL for the image that represents the [access control system](https://docs.seam.co/latest/capability-guides/access-systems).',
+              'URL for the image that represents the [access control system](https://docs.seam.co/capability-guides/access-systems).',
             type: 'string',
           },
           is_credential_manager: {
@@ -5256,7 +5256,7 @@ const openapi: OpenAPISpec = {
             properties: {
               time_zone: {
                 description:
-                  'Time zone in which the [access control system](https://docs.seam.co/latest/capability-guides/access-systems) is located.',
+                  'Time zone in which the [access control system](https://docs.seam.co/capability-guides/access-systems) is located.',
                 nullable: true,
                 type: 'string',
               },
@@ -5266,7 +5266,7 @@ const openapi: OpenAPISpec = {
           },
           name: {
             description:
-              'Name of the [access control system](https://docs.seam.co/latest/capability-guides/access-systems).',
+              'Name of the [access control system](https://docs.seam.co/capability-guides/access-systems).',
             type: 'string',
           },
           system_type: {
@@ -5300,7 +5300,7 @@ const openapi: OpenAPISpec = {
             properties: {
               lan_address: {
                 description:
-                  'IP address or hostname of the main Visionline server relative to [Seam Bridge](https://docs.seam.co/latest/capability-guides/seam-bridge) on the local network.',
+                  'IP address or hostname of the main Visionline server relative to [Seam Bridge](https://docs.seam.co/capability-guides/seam-bridge) on the local network.',
                 type: 'string',
               },
               mobile_access_uuid: {
@@ -5319,10 +5319,10 @@ const openapi: OpenAPISpec = {
           },
           warnings: {
             description:
-              'Warnings associated with the [access control system](https://docs.seam.co/latest/capability-guides/access-systems).',
+              'Warnings associated with the [access control system](https://docs.seam.co/capability-guides/access-systems).',
             items: {
               description:
-                'Warning associated with the [access control system](https://docs.seam.co/latest/capability-guides/access-systems).',
+                'Warning associated with the [access control system](https://docs.seam.co/capability-guides/access-systems).',
               discriminator: { propertyName: 'warning_code' },
               oneOf: [
                 {
@@ -5352,7 +5352,7 @@ const openapi: OpenAPISpec = {
                 },
                 {
                   description:
-                    'Indicates the [access control system](https://docs.seam.co/latest/capability-guides/access-systems) time zone could not be determined because the reported physical location does not match the time zone configured on the physical [ACS entrances](https://docs.seam.co/latest/capability-guides/access-systems/retrieving-entrance-details).',
+                    'Indicates the [access control system](https://docs.seam.co/capability-guides/access-systems) time zone could not be determined because the reported physical location does not match the time zone configured on the physical [ACS entrances](https://docs.seam.co/capability-guides/access-systems/retrieving-entrance-details).',
                   properties: {
                     created_at: {
                       description:
@@ -5387,7 +5387,7 @@ const openapi: OpenAPISpec = {
           },
           workspace_id: {
             description:
-              'ID of the [workspace](https://docs.seam.co/latest/core-concepts/workspaces) that contains the [access control system](https://docs.seam.co/latest/capability-guides/access-systems).',
+              'ID of the [workspace](https://docs.seam.co/core-concepts/workspaces) that contains the [access control system](https://docs.seam.co/capability-guides/access-systems).',
             format: 'uuid',
             type: 'string',
           },
@@ -5411,11 +5411,11 @@ const openapi: OpenAPISpec = {
       },
       acs_user: {
         description:
-          'Represents a [user](https://docs.seam.co/latest/capability-guides/access-systems/user-management) in an [access system](https://docs.seam.co/latest/capability-guides/access-systems).\n\nAn access system user typically refers to an individual who requires access, like an employee or resident. Each user can possess multiple credentials that serve as their keys or identifiers for access. The type of credential can vary widely. For example, in the Salto system, a user can have a PIN code, a mobile app account, and a fob. In other platforms, it is not uncommon for a user to have more than one of the same credential type, such as multiple key cards. Additionally, these credentials can have a schedule or validity period.\n\nFor details about how to configure users in your access system, see the corresponding [system integration guide](https://docs.seam.co/latest/device-and-system-integration-guides#access-control-systems).',
+          'Represents a [user](https://docs.seam.co/capability-guides/access-systems/user-management) in an [access system](https://docs.seam.co/capability-guides/access-systems).\n\nAn access system user typically refers to an individual who requires access, like an employee or resident. Each user can possess multiple credentials that serve as their keys or identifiers for access. The type of credential can vary widely. For example, in the Salto system, a user can have a PIN code, a mobile app account, and a fob. In other platforms, it is not uncommon for a user to have more than one of the same credential type, such as multiple key cards. Additionally, these credentials can have a schedule or validity period.\n\nFor details about how to configure users in your access system, see the corresponding [system integration guide](https://docs.seam.co/device-and-system-integration-guides#access-control-systems).',
         properties: {
           access_schedule: {
             description:
-              "`starts_at` and `ends_at` timestamps for the [access system user's](https://docs.seam.co/latest/capability-guides/access-systems/user-management) access.",
+              "`starts_at` and `ends_at` timestamps for the [access system user's](https://docs.seam.co/capability-guides/access-systems/user-management) access.",
             properties: {
               ends_at: {
                 description:
@@ -5436,31 +5436,31 @@ const openapi: OpenAPISpec = {
           },
           acs_system_id: {
             description:
-              'ID of the [access system](https://docs.seam.co/latest/capability-guides/access-systems) that contains the [access system user](https://docs.seam.co/latest/capability-guides/access-systems/user-management).',
+              'ID of the [access system](https://docs.seam.co/capability-guides/access-systems) that contains the [access system user](https://docs.seam.co/capability-guides/access-systems/user-management).',
             format: 'uuid',
             type: 'string',
           },
           acs_user_id: {
             description:
-              'ID of the [access system user](https://docs.seam.co/latest/capability-guides/access-systems/user-management).',
+              'ID of the [access system user](https://docs.seam.co/capability-guides/access-systems/user-management).',
             format: 'uuid',
             type: 'string',
           },
           connected_account_id: {
             description:
-              '\n      The ID of the [connected account](https://docs.seam.co/latest/core-concepts/connected-accounts) that is associated with the [access system user](https://docs.seam.co/latest/capability-guides/access-systems/user-management).\n    ',
+              '\n      The ID of the [connected account](https://docs.seam.co/core-concepts/connected-accounts) that is associated with the [access system user](https://docs.seam.co/capability-guides/access-systems/user-management).\n    ',
             format: 'uuid',
             type: 'string',
           },
           created_at: {
             description:
-              'Date and time at which the [access system user](https://docs.seam.co/latest/capability-guides/access-systems/user-management) was created.',
+              'Date and time at which the [access system user](https://docs.seam.co/capability-guides/access-systems/user-management) was created.',
             format: 'date-time',
             type: 'string',
           },
           display_name: {
             description:
-              'Display name for the [access system user](https://docs.seam.co/latest/capability-guides/access-systems/user-management).',
+              'Display name for the [access system user](https://docs.seam.co/capability-guides/access-systems/user-management).',
             type: 'string',
           },
           email: {
@@ -5471,21 +5471,21 @@ const openapi: OpenAPISpec = {
           },
           email_address: {
             description:
-              'Email address of the [access system user](https://docs.seam.co/latest/capability-guides/access-systems/user-management).',
+              'Email address of the [access system user](https://docs.seam.co/capability-guides/access-systems/user-management).',
             format: 'email',
             type: 'string',
           },
           errors: {
             description:
-              'Errors associated with the [access system user](https://docs.seam.co/latest/capability-guides/access-systems/user-management).',
+              'Errors associated with the [access system user](https://docs.seam.co/capability-guides/access-systems/user-management).',
             items: {
               description:
-                'Errors associated with the [access system user](https://docs.seam.co/latest/capability-guides/access-systems/user-management).',
+                'Errors associated with the [access system user](https://docs.seam.co/capability-guides/access-systems/user-management).',
               discriminator: { propertyName: 'error_code' },
               oneOf: [
                 {
                   description:
-                    'Indicates that the [access system user](https://docs.seam.co/latest/capability-guides/access-systems/user-management) was deleted from the [access system](https://docs.seam.co/latest/capability-guides/access-systems) outside of Seam.',
+                    'Indicates that the [access system user](https://docs.seam.co/capability-guides/access-systems/user-management) was deleted from the [access system](https://docs.seam.co/capability-guides/access-systems) outside of Seam.',
                   properties: {
                     created_at: {
                       description:
@@ -5508,7 +5508,7 @@ const openapi: OpenAPISpec = {
                 },
                 {
                   description:
-                    'Indicates that the [access system user](https://docs.seam.co/latest/capability-guides/access-systems/user-management) could not be subscribed on Salto KS because the subscription limit has been exceeded.',
+                    'Indicates that the [access system user](https://docs.seam.co/capability-guides/access-systems/user-management) could not be subscribed on Salto KS because the subscription limit has been exceeded.',
                   properties: {
                     created_at: {
                       description:
@@ -5531,7 +5531,7 @@ const openapi: OpenAPISpec = {
                 },
                 {
                   description:
-                    'Indicates that the [access system user](https://docs.seam.co/latest/capability-guides/access-systems/user-management) was not created on the [access system](https://docs.seam.co/latest/capability-guides/access-systems). This is likely due to an internal unexpected error. Contact Seam [support](mailto:support@seam.co).',
+                    'Indicates that the [access system user](https://docs.seam.co/capability-guides/access-systems/user-management) was not created on the [access system](https://docs.seam.co/capability-guides/access-systems). This is likely due to an internal unexpected error. Contact Seam [support](mailto:support@seam.co).',
                   properties: {
                     created_at: {
                       description:
@@ -5554,7 +5554,7 @@ const openapi: OpenAPISpec = {
                 },
                 {
                   description:
-                    'Indicates that the [access system user](https://docs.seam.co/latest/capability-guides/access-systems/user-management) was not updated on the [access system](https://docs.seam.co/latest/capability-guides/access-systems). This is likely due to an internal unexpected error. Contact Seam [support](mailto:support@seam.co).',
+                    'Indicates that the [access system user](https://docs.seam.co/capability-guides/access-systems/user-management) was not updated on the [access system](https://docs.seam.co/capability-guides/access-systems). This is likely due to an internal unexpected error. Contact Seam [support](mailto:support@seam.co).',
                   properties: {
                     created_at: {
                       description:
@@ -5577,7 +5577,7 @@ const openapi: OpenAPISpec = {
                 },
                 {
                   description:
-                    'Indicates that the [access system user](https://docs.seam.co/latest/capability-guides/access-systems/user-management) was not deleted on the [access system](https://docs.seam.co/latest/capability-guides/access-systems). This is likely due to an internal unexpected error. Contact Seam [support](mailto:support@seam.co).',
+                    'Indicates that the [access system user](https://docs.seam.co/capability-guides/access-systems/user-management) was not deleted on the [access system](https://docs.seam.co/capability-guides/access-systems). This is likely due to an internal unexpected error. Contact Seam [support](mailto:support@seam.co).',
                   properties: {
                     created_at: {
                       description:
@@ -5600,7 +5600,7 @@ const openapi: OpenAPISpec = {
                 },
                 {
                   description:
-                    'Indicates that the [access system user](https://docs.seam.co/latest/capability-guides/access-systems/user-management) was created from the Seam API but also exists on Mission Control. This is unsupported. Contact Seam [support](mailto:support@seam.co).',
+                    'Indicates that the [access system user](https://docs.seam.co/capability-guides/access-systems/user-management) was created from the Seam API but also exists on Mission Control. This is unsupported. Contact Seam [support](mailto:support@seam.co).',
                   properties: {
                     created_at: {
                       description:
@@ -5627,7 +5627,7 @@ const openapi: OpenAPISpec = {
           },
           external_type: {
             description:
-              'Brand-specific terminology for the [access system user](https://docs.seam.co/latest/capability-guides/access-systems/user-management) type.',
+              'Brand-specific terminology for the [access system user](https://docs.seam.co/capability-guides/access-systems/user-management) type.',
             enum: [
               'pti_user',
               'brivo_user',
@@ -5642,12 +5642,12 @@ const openapi: OpenAPISpec = {
           },
           external_type_display_name: {
             description:
-              'Display name that corresponds to the brand-specific terminology for the [access system user](https://docs.seam.co/latest/capability-guides/access-systems/user-management) type.',
+              'Display name that corresponds to the brand-specific terminology for the [access system user](https://docs.seam.co/capability-guides/access-systems/user-management) type.',
             type: 'string',
           },
           full_name: {
             description:
-              'Full name of the [access system user](https://docs.seam.co/latest/capability-guides/access-systems/user-management).',
+              'Full name of the [access system user](https://docs.seam.co/capability-guides/access-systems/user-management).',
             minLength: 1,
             type: 'string',
           },
@@ -5655,7 +5655,7 @@ const openapi: OpenAPISpec = {
           is_managed: { enum: [true], type: 'boolean' },
           is_suspended: {
             description:
-              'Indicates whether the [access system user](https://docs.seam.co/latest/capability-guides/access-systems/user-management) is currently [suspended](https://docs.seam.co/latest/capability-guides/access-systems/user-management/suspending-and-unsuspending-users).',
+              'Indicates whether the [access system user](https://docs.seam.co/capability-guides/access-systems/user-management) is currently [suspended](https://docs.seam.co/capability-guides/access-systems/user-management/suspending-and-unsuspending-users).',
             type: 'boolean',
           },
           last_successful_sync_at: {
@@ -5668,7 +5668,7 @@ const openapi: OpenAPISpec = {
           },
           pending_mutations: {
             description:
-              'Pending mutations associated with the [access system user](https://docs.seam.co/latest/capability-guides/access-systems/user-management). Seam is in the process of pushing these mutations to the integrated access system.',
+              'Pending mutations associated with the [access system user](https://docs.seam.co/capability-guides/access-systems/user-management). Seam is in the process of pushing these mutations to the integrated access system.',
             items: {
               discriminator: { propertyName: 'mutation_code' },
               oneOf: [
@@ -6097,12 +6097,12 @@ const openapi: OpenAPISpec = {
           },
           phone_number: {
             description:
-              'Phone number of the [access system user](https://docs.seam.co/latest/capability-guides/access-systems/user-management) in E.164 format (for example, `+15555550100`).',
+              'Phone number of the [access system user](https://docs.seam.co/capability-guides/access-systems/user-management) in E.164 format (for example, `+15555550100`).',
             type: 'string',
           },
           salto_space_metadata: {
             description:
-              'Salto Space-specific metadata associated with the [access system user](https://docs.seam.co/latest/capability-guides/access-systems/user-management).',
+              'Salto Space-specific metadata associated with the [access system user](https://docs.seam.co/capability-guides/access-systems/user-management).',
             properties: {
               audit_openings: {
                 description:
@@ -6118,38 +6118,38 @@ const openapi: OpenAPISpec = {
           },
           user_identity_email_address: {
             description:
-              'Email address of the user identity associated with the [access system user](https://docs.seam.co/latest/capability-guides/access-systems/user-management).',
+              'Email address of the user identity associated with the [access system user](https://docs.seam.co/capability-guides/access-systems/user-management).',
             nullable: true,
             type: 'string',
           },
           user_identity_full_name: {
             description:
-              'Full name of the user identity associated with the [access system user](https://docs.seam.co/latest/capability-guides/access-systems/user-management).',
+              'Full name of the user identity associated with the [access system user](https://docs.seam.co/capability-guides/access-systems/user-management).',
             nullable: true,
             type: 'string',
           },
           user_identity_id: {
             description:
-              'ID of the user identity associated with the [access system user](https://docs.seam.co/latest/capability-guides/access-systems/user-management).',
+              'ID of the user identity associated with the [access system user](https://docs.seam.co/capability-guides/access-systems/user-management).',
             type: 'string',
           },
           user_identity_phone_number: {
             description:
-              'Phone number of the user identity associated with the [access system user](https://docs.seam.co/latest/capability-guides/access-systems/user-management) in E.164 format (for example, `+15555550100`).',
+              'Phone number of the user identity associated with the [access system user](https://docs.seam.co/capability-guides/access-systems/user-management) in E.164 format (for example, `+15555550100`).',
             nullable: true,
             type: 'string',
           },
           warnings: {
             description:
-              'Warnings associated with the [access system user](https://docs.seam.co/latest/capability-guides/access-systems/user-management).',
+              'Warnings associated with the [access system user](https://docs.seam.co/capability-guides/access-systems/user-management).',
             items: {
               description:
-                'Warnings associated with the [access system user](https://docs.seam.co/latest/capability-guides/access-systems/user-management).',
+                'Warnings associated with the [access system user](https://docs.seam.co/capability-guides/access-systems/user-management).',
               discriminator: { propertyName: 'warning_code' },
               oneOf: [
                 {
                   description:
-                    'Indicates that the [access system user](https://docs.seam.co/latest/capability-guides/access-systems/user-management) is being deleted from the [access system](https://docs.seam.co/latest/capability-guides/access-systems). This is a temporary state, and the access system user will be deleted shortly.',
+                    'Indicates that the [access system user](https://docs.seam.co/capability-guides/access-systems/user-management) is being deleted from the [access system](https://docs.seam.co/capability-guides/access-systems). This is a temporary state, and the access system user will be deleted shortly.',
                   properties: {
                     created_at: {
                       description:
@@ -6169,7 +6169,7 @@ const openapi: OpenAPISpec = {
                 },
                 {
                   description:
-                    'Indicates that the [access system user](https://docs.seam.co/latest/capability-guides/access-systems/user-management) is not subscribed on Salto KS, so they cannot unlock doors or perform any actions. This occurs when the their access schedule hasn’t started yet, if their access schedule has ended, if the site has reached its limit for active users (subscription slots), or if they have been manually unsubscribed.',
+                    'Indicates that the [access system user](https://docs.seam.co/capability-guides/access-systems/user-management) is not subscribed on Salto KS, so they cannot unlock doors or perform any actions. This occurs when the their access schedule hasn’t started yet, if their access schedule has ended, if the site has reached its limit for active users (subscription slots), or if they have been manually unsubscribed.',
                   properties: {
                     created_at: {
                       description:
@@ -6192,7 +6192,7 @@ const openapi: OpenAPISpec = {
                 },
                 {
                   description:
-                    'An unknown issue occurred while syncing the state of this [access system user](https://docs.seam.co/latest/capability-guides/access-systems/user-management) with the provider. This issue may affect the proper functioning of this user.',
+                    'An unknown issue occurred while syncing the state of this [access system user](https://docs.seam.co/capability-guides/access-systems/user-management) with the provider. This issue may affect the proper functioning of this user.',
                   properties: {
                     created_at: {
                       description:
@@ -6215,7 +6215,7 @@ const openapi: OpenAPISpec = {
                 },
                 {
                   description:
-                    'Indicates that the [access system user](https://docs.seam.co/latest/capability-guides/access-systems/user-management) was created on Latch Mission Control. Please use the Latch Mission Control to manage this user.',
+                    'Indicates that the [access system user](https://docs.seam.co/capability-guides/access-systems/user-management) was created on Latch Mission Control. Please use the Latch Mission Control to manage this user.',
                   properties: {
                     created_at: {
                       description:
@@ -6242,7 +6242,7 @@ const openapi: OpenAPISpec = {
           },
           workspace_id: {
             description:
-              'ID of the [workspace](https://docs.seam.co/latest/core-concepts/workspaces) that contains the [access system user](https://docs.seam.co/latest/capability-guides/access-systems/user-management).',
+              'ID of the [workspace](https://docs.seam.co/core-concepts/workspaces) that contains the [access system user](https://docs.seam.co/capability-guides/access-systems/user-management).',
             format: 'uuid',
             type: 'string',
           },
@@ -6264,7 +6264,7 @@ const openapi: OpenAPISpec = {
       },
       action_attempt: {
         description:
-          'Represents an action attempt that enables you to keep track of the progress of your action that affects a physical device or system.actions against a device. Action attempts are useful because the physical world is intrinsically asynchronous.\n\nWhen you request for a device to perform an action, the Seam API immediately returns an action attempt object. In the background, the Seam API performs the action.\n\nSee also [Action Attempts](https://docs.seam.co/latest/core-concepts/action-attempts).',
+          'Represents an action attempt that enables you to keep track of the progress of your action that affects a physical device or system.actions against a device. Action attempts are useful because the physical world is intrinsically asynchronous.\n\nWhen you request for a device to perform an action, the Seam API immediately returns an action attempt object. In the background, the Seam API performs the action.\n\nSee also [Action Attempts](https://docs.seam.co/core-concepts/action-attempts).',
         oneOf: [
           {
             description: 'Locking a door is pending.',
@@ -6571,20 +6571,20 @@ const openapi: OpenAPISpec = {
                     properties: {
                       card_number: {
                         description:
-                          'A number or string that physically identifies the card associated with the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials).',
+                          'A number or string that physically identifies the card associated with the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials).',
                         nullable: true,
                         type: 'string',
                       },
                       created_at: {
                         description:
-                          'Date and time at which the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials) was created.',
+                          'Date and time at which the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials) was created.',
                         format: 'date-time',
                         nullable: true,
                         type: 'string',
                       },
                       ends_at: {
                         description:
-                          'Date and time at which the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials) will stop being usable.',
+                          'Date and time at which the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials) will stop being usable.',
                         format: 'date-time',
                         nullable: true,
                         type: 'string',
@@ -6592,77 +6592,77 @@ const openapi: OpenAPISpec = {
                       is_issued: { nullable: true, type: 'boolean' },
                       starts_at: {
                         description:
-                          'Date and time at which the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials) becomes usable.',
+                          'Date and time at which the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials) becomes usable.',
                         format: 'date-time',
                         nullable: true,
                         type: 'string',
                       },
                       visionline_metadata: {
                         description:
-                          'Visionline-specific metadata for the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials).',
+                          'Visionline-specific metadata for the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials).',
                         properties: {
                           cancelled: {
                             description:
-                              'Indicates whether the card associated with the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials) is cancelled.',
+                              'Indicates whether the card associated with the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials) is cancelled.',
                             type: 'boolean',
                           },
                           card_format: {
                             description:
-                              'Format of the card associated with the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials).',
+                              'Format of the card associated with the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials).',
                             enum: ['TLCode', 'rfid48'],
                             type: 'string',
                           },
                           card_holder: {
                             description:
-                              'Holder of the card associated with the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials).',
+                              'Holder of the card associated with the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials).',
                             type: 'string',
                           },
                           card_id: {
                             description:
-                              'Card ID for the Visionline card associated with the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials).',
+                              'Card ID for the Visionline card associated with the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials).',
                             type: 'string',
                           },
                           common_acs_entrance_ids: {
                             description:
-                              'IDs of the common [entrances](https://docs.seam.co/latest/capability-guides/access-systems/retrieving-entrance-details) for the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials).',
+                              'IDs of the common [entrances](https://docs.seam.co/capability-guides/access-systems/retrieving-entrance-details) for the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials).',
                             items: { format: 'uuid', type: 'string' },
                             type: 'array',
                           },
                           discarded: {
                             description:
-                              'Indicates whether the card associated with the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials) is discarded.',
+                              'Indicates whether the card associated with the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials) is discarded.',
                             type: 'boolean',
                           },
                           expired: {
                             description:
-                              'Indicates whether the card associated with the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials) is expired.',
+                              'Indicates whether the card associated with the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials) is expired.',
                             type: 'boolean',
                           },
                           guest_acs_entrance_ids: {
                             description:
-                              'IDs of the guest [entrances](https://docs.seam.co/latest/capability-guides/access-systems/retrieving-entrance-details) for the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials).',
+                              'IDs of the guest [entrances](https://docs.seam.co/capability-guides/access-systems/retrieving-entrance-details) for the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials).',
                             items: { format: 'uuid', type: 'string' },
                             type: 'array',
                           },
                           number_of_issued_cards: {
                             description:
-                              'Number of issued cards associated with the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials).',
+                              'Number of issued cards associated with the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials).',
                             format: 'float',
                             type: 'number',
                           },
                           overridden: {
                             description:
-                              'Indicates whether the card associated with the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials) is overridden.',
+                              'Indicates whether the card associated with the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials) is overridden.',
                             type: 'boolean',
                           },
                           overwritten: {
                             description:
-                              'Indicates whether the card associated with the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials) is overwritten.',
+                              'Indicates whether the card associated with the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials) is overwritten.',
                             type: 'boolean',
                           },
                           pending_auto_update: {
                             description:
-                              'Indicates whether the card associated with the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials) is pending auto-update.',
+                              'Indicates whether the card associated with the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials) is pending auto-update.',
                             type: 'boolean',
                           },
                         },
@@ -6695,17 +6695,17 @@ const openapi: OpenAPISpec = {
                     oneOf: [
                       {
                         description:
-                          'Means by which an [access control system user](https://docs.seam.co/latest/capability-guides/access-systems/user-management) gains access at an [entrance](https://docs.seam.co/latest/capability-guides/access-systems/retrieving-entrance-details). The `acs_credential` object represents a [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials) that provides an ACS user access within an [access control system](https://docs.seam.co/latest/capability-guides/access-systems).\n\nAn access control system generally uses digital means of access to authorize a user trying to get through a specific entrance. Examples of credentials include plastic key cards, mobile keys, biometric identifiers, and PIN codes. The electronic nature of these credentials, as well as the fact that access is centralized, enables both the rapid provisioning and rescinding of access and the ability to compile access audit logs.\n\nFor each `acs_credential`, you define the access method. You can also specify additional properties, such as a PIN code, depending on the credential type.',
+                          'Means by which an [access control system user](https://docs.seam.co/capability-guides/access-systems/user-management) gains access at an [entrance](https://docs.seam.co/capability-guides/access-systems/retrieving-entrance-details). The `acs_credential` object represents a [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials) that provides an ACS user access within an [access control system](https://docs.seam.co/capability-guides/access-systems).\n\nAn access control system generally uses digital means of access to authorize a user trying to get through a specific entrance. Examples of credentials include plastic key cards, mobile keys, biometric identifiers, and PIN codes. The electronic nature of these credentials, as well as the fact that access is centralized, enables both the rapid provisioning and rescinding of access and the ability to compile access audit logs.\n\nFor each `acs_credential`, you define the access method. You can also specify additional properties, such as a PIN code, depending on the credential type.',
                         properties: {
                           access_method: {
                             description:
-                              'Access method for the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials). Supported values: `code`, `card`, `mobile_key`, `cloud_key`.',
+                              'Access method for the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials). Supported values: `code`, `card`, `mobile_key`, `cloud_key`.',
                             enum: ['code', 'card', 'mobile_key', 'cloud_key'],
                             type: 'string',
                           },
                           acs_credential_id: {
                             description:
-                              'ID of the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials).',
+                              'ID of the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials).',
                             format: 'uuid',
                             type: 'string',
                           },
@@ -6715,19 +6715,19 @@ const openapi: OpenAPISpec = {
                           },
                           acs_system_id: {
                             description:
-                              'ID of the [access control system](https://docs.seam.co/latest/capability-guides/access-systems) that contains the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials).',
+                              'ID of the [access control system](https://docs.seam.co/capability-guides/access-systems) that contains the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials).',
                             format: 'uuid',
                             type: 'string',
                           },
                           acs_user_id: {
                             description:
-                              'ID of the [ACS user](https://docs.seam.co/latest/capability-guides/access-systems/user-management) to whom the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials) belongs.',
+                              'ID of the [ACS user](https://docs.seam.co/capability-guides/access-systems/user-management) to whom the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials) belongs.',
                             format: 'uuid',
                             type: 'string',
                           },
                           assa_abloy_vostio_metadata: {
                             description:
-                              'Vostio-specific metadata for the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials).',
+                              'Vostio-specific metadata for the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials).',
                             properties: {
                               auto_join: {
                                 description:
@@ -6766,42 +6766,42 @@ const openapi: OpenAPISpec = {
                           },
                           card_number: {
                             description:
-                              'Number of the card associated with the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials).',
+                              'Number of the card associated with the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials).',
                             nullable: true,
                             type: 'string',
                           },
                           code: {
                             description:
-                              'Access (PIN) code for the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials).',
+                              'Access (PIN) code for the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials).',
                             nullable: true,
                             type: 'string',
                           },
                           connected_account_id: {
                             description:
-                              'ID of the [connected account](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials#connected-accounts) to which the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials) belongs.',
+                              'ID of the [connected account](https://docs.seam.co/capability-guides/access-systems/managing-credentials#connected-accounts) to which the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials) belongs.',
                             format: 'uuid',
                             type: 'string',
                           },
                           created_at: {
                             description:
-                              'Date and time at which the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials) was created.',
+                              'Date and time at which the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials) was created.',
                             format: 'date-time',
                             type: 'string',
                           },
                           display_name: {
                             description:
-                              'Display name that corresponds to the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials) type.',
+                              'Display name that corresponds to the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials) type.',
                             minLength: 1,
                             type: 'string',
                           },
                           ends_at: {
                             description:
-                              'Date and time at which the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials) validity ends, in [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) format. Must be a time in the future and after `starts_at`.',
+                              'Date and time at which the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials) validity ends, in [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) format. Must be a time in the future and after `starts_at`.',
                             type: 'string',
                           },
                           errors: {
                             description:
-                              'Errors associated with the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials).',
+                              'Errors associated with the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials).',
                             items: {
                               properties: {
                                 error_code: { type: 'string' },
@@ -6814,7 +6814,7 @@ const openapi: OpenAPISpec = {
                           },
                           external_type: {
                             description:
-                              'Brand-specific terminology for the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials) type. Supported values: `pti_card`, `brivo_credential`, `hid_credential`, `visionline_card`.',
+                              'Brand-specific terminology for the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials) type. Supported values: `pti_card`, `brivo_credential`, `hid_credential`, `visionline_card`.',
                             enum: [
                               'pti_card',
                               'brivo_credential',
@@ -6833,65 +6833,65 @@ const openapi: OpenAPISpec = {
                           },
                           external_type_display_name: {
                             description:
-                              'Display name that corresponds to the brand-specific terminology for the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials) type.',
+                              'Display name that corresponds to the brand-specific terminology for the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials) type.',
                             type: 'string',
                           },
                           is_issued: {
                             description:
-                              'Indicates whether the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials) has been encoded onto a card.',
+                              'Indicates whether the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials) has been encoded onto a card.',
                             type: 'boolean',
                           },
                           is_latest_desired_state_synced_with_provider: {
                             description:
-                              'Indicates whether the latest state of the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials) has been synced from Seam to the provider.',
+                              'Indicates whether the latest state of the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials) has been synced from Seam to the provider.',
                             nullable: true,
                             type: 'boolean',
                           },
                           is_managed: { enum: [true], type: 'boolean' },
                           is_multi_phone_sync_credential: {
                             description:
-                              'Indicates whether the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials) is a [multi-phone sync credential](https://docs.seam.co/latest/capability-guides/mobile-access/issuing-mobile-credentials-from-an-access-control-system#what-are-multi-phone-sync-credentials).',
+                              'Indicates whether the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials) is a [multi-phone sync credential](https://docs.seam.co/capability-guides/mobile-access/issuing-mobile-credentials-from-an-access-control-system#what-are-multi-phone-sync-credentials).',
                             type: 'boolean',
                           },
                           is_one_time_use: {
                             description:
-                              'Indicates whether the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials) can only be used once. If `true`, the code becomes invalid after the first use.',
+                              'Indicates whether the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials) can only be used once. If `true`, the code becomes invalid after the first use.',
                             type: 'boolean',
                           },
                           issued_at: {
                             description:
-                              'Date and time at which the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials) was encoded onto a card.',
+                              'Date and time at which the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials) was encoded onto a card.',
                             format: 'date-time',
                             nullable: true,
                             type: 'string',
                           },
                           latest_desired_state_synced_with_provider_at: {
                             description:
-                              'Date and time at which the state of the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials) was most recently synced from Seam to the provider.',
+                              'Date and time at which the state of the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials) was most recently synced from Seam to the provider.',
                             format: 'date-time',
                             nullable: true,
                             type: 'string',
                           },
                           parent_acs_credential_id: {
                             description:
-                              'ID of the parent [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials).',
+                              'ID of the parent [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials).',
                             format: 'uuid',
                             type: 'string',
                           },
                           starts_at: {
                             description:
-                              'Date and time at which the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials) validity starts, in [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) format.',
+                              'Date and time at which the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials) validity starts, in [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) format.',
                             type: 'string',
                           },
                           user_identity_id: {
                             description:
-                              'ID of the [user identity](https://docs.seam.co/latest/api/user_identities) to whom the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials) belongs.',
+                              'ID of the [user identity](https://docs.seam.co/api/user_identities) to whom the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials) belongs.',
                             format: 'uuid',
                             type: 'string',
                           },
                           visionline_metadata: {
                             description:
-                              'Visionline-specific metadata for the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials).',
+                              'Visionline-specific metadata for the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials).',
                             properties: {
                               auto_join: {
                                 description:
@@ -6943,15 +6943,15 @@ const openapi: OpenAPISpec = {
                           },
                           warnings: {
                             description:
-                              'Warnings associated with the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials).',
+                              'Warnings associated with the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials).',
                             items: {
                               description:
-                                'Warning associated with the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials).',
+                                'Warning associated with the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials).',
                               discriminator: { propertyName: 'warning_code' },
                               oneOf: [
                                 {
                                   description:
-                                    'Indicates that the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials) is waiting to be issued.',
+                                    'Indicates that the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials) is waiting to be issued.',
                                   properties: {
                                     created_at: {
                                       description:
@@ -6980,7 +6980,7 @@ const openapi: OpenAPISpec = {
                                 },
                                 {
                                   description:
-                                    "Indicates that the schedule of one of the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials)'s children was modified externally.",
+                                    "Indicates that the schedule of one of the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials)'s children was modified externally.",
                                   properties: {
                                     created_at: {
                                       description:
@@ -7009,7 +7009,7 @@ const openapi: OpenAPISpec = {
                                 },
                                 {
                                   description:
-                                    'Indicates that the schedule of the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials) was modified to avoid creating a credential with a start date in the past.',
+                                    'Indicates that the schedule of the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials) was modified to avoid creating a credential with a start date in the past.',
                                   properties: {
                                     created_at: {
                                       description:
@@ -7038,7 +7038,7 @@ const openapi: OpenAPISpec = {
                                 },
                                 {
                                   description:
-                                    'Indicates that the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials) is being deleted.',
+                                    'Indicates that the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials) is being deleted.',
                                   properties: {
                                     created_at: {
                                       description:
@@ -7067,7 +7067,7 @@ const openapi: OpenAPISpec = {
                                 },
                                 {
                                   description:
-                                    'An unknown issue occurred while syncing the state of the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials) with the provider. This issue may affect the proper functioning of the credential.',
+                                    'An unknown issue occurred while syncing the state of the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials) with the provider. This issue may affect the proper functioning of the credential.',
                                   properties: {
                                     created_at: {
                                       description:
@@ -7098,7 +7098,7 @@ const openapi: OpenAPISpec = {
                                 },
                                 {
                                   description:
-                                    'Access permissions for the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials) have changed. [Reissue](https://docs.seam.co/latest/capability-guides/access-systems/working-with-card-encoders-and-scanners/creating-and-encoding-card-based-credentials) (re-encode) the credential. This issue may affect the proper functioning of the credential.',
+                                    'Access permissions for the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials) have changed. [Reissue](https://docs.seam.co/capability-guides/access-systems/working-with-card-encoders-and-scanners/creating-and-encoding-card-based-credentials) (re-encode) the credential. This issue may affect the proper functioning of the credential.',
                                   properties: {
                                     created_at: {
                                       description:
@@ -7131,7 +7131,7 @@ const openapi: OpenAPISpec = {
                           },
                           workspace_id: {
                             description:
-                              'ID of the [workspace](https://docs.seam.co/latest/core-concepts/workspaces) that contains the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials).',
+                              'ID of the [workspace](https://docs.seam.co/core-concepts/workspaces) that contains the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials).',
                             format: 'uuid',
                             type: 'string',
                           },
@@ -7153,17 +7153,17 @@ const openapi: OpenAPISpec = {
                       },
                       {
                         description:
-                          'Means by which an [ACS user](https://docs.seam.co/latest/capability-guides/access-systems/user-management) gains access at an [entrance](https://docs.seam.co/latest/capability-guides/access-systems/retrieving-entrance-details). The `unmanaged_acs_credential` object, which is not managed by Seam, represents a [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials) that provides an ACS user access within an [access control system](https://docs.seam.co/latest/capability-guides/access-systems). For each `acs_credential` object, you define the access method. You can also specify additional properties, such as a PIN code.',
+                          'Means by which an [ACS user](https://docs.seam.co/capability-guides/access-systems/user-management) gains access at an [entrance](https://docs.seam.co/capability-guides/access-systems/retrieving-entrance-details). The `unmanaged_acs_credential` object, which is not managed by Seam, represents a [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials) that provides an ACS user access within an [access control system](https://docs.seam.co/capability-guides/access-systems). For each `acs_credential` object, you define the access method. You can also specify additional properties, such as a PIN code.',
                         properties: {
                           access_method: {
                             description:
-                              'Access method for the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials). Supported values: `code`, `card`, `mobile_key`, `cloud_key`.',
+                              'Access method for the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials). Supported values: `code`, `card`, `mobile_key`, `cloud_key`.',
                             enum: ['code', 'card', 'mobile_key', 'cloud_key'],
                             type: 'string',
                           },
                           acs_credential_id: {
                             description:
-                              'ID of the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials).',
+                              'ID of the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials).',
                             format: 'uuid',
                             type: 'string',
                           },
@@ -7173,19 +7173,19 @@ const openapi: OpenAPISpec = {
                           },
                           acs_system_id: {
                             description:
-                              'ID of the [access control system](https://docs.seam.co/latest/capability-guides/access-systems) that contains the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials).',
+                              'ID of the [access control system](https://docs.seam.co/capability-guides/access-systems) that contains the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials).',
                             format: 'uuid',
                             type: 'string',
                           },
                           acs_user_id: {
                             description:
-                              'ID of the [ACS user](https://docs.seam.co/latest/capability-guides/access-systems/user-management) to whom the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials) belongs.',
+                              'ID of the [ACS user](https://docs.seam.co/capability-guides/access-systems/user-management) to whom the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials) belongs.',
                             format: 'uuid',
                             type: 'string',
                           },
                           assa_abloy_vostio_metadata: {
                             description:
-                              'Vostio-specific metadata for the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials).',
+                              'Vostio-specific metadata for the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials).',
                             properties: {
                               auto_join: {
                                 description:
@@ -7224,42 +7224,42 @@ const openapi: OpenAPISpec = {
                           },
                           card_number: {
                             description:
-                              'Number of the card associated with the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials).',
+                              'Number of the card associated with the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials).',
                             nullable: true,
                             type: 'string',
                           },
                           code: {
                             description:
-                              'Access (PIN) code for the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials).',
+                              'Access (PIN) code for the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials).',
                             nullable: true,
                             type: 'string',
                           },
                           connected_account_id: {
                             description:
-                              'ID of the [connected account](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials#connected-accounts) to which the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials) belongs.',
+                              'ID of the [connected account](https://docs.seam.co/capability-guides/access-systems/managing-credentials#connected-accounts) to which the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials) belongs.',
                             format: 'uuid',
                             type: 'string',
                           },
                           created_at: {
                             description:
-                              'Date and time at which the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials) was created.',
+                              'Date and time at which the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials) was created.',
                             format: 'date-time',
                             type: 'string',
                           },
                           display_name: {
                             description:
-                              'Display name that corresponds to the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials) type.',
+                              'Display name that corresponds to the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials) type.',
                             minLength: 1,
                             type: 'string',
                           },
                           ends_at: {
                             description:
-                              'Date and time at which the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials) validity ends, in [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) format. Must be a time in the future and after `starts_at`.',
+                              'Date and time at which the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials) validity ends, in [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) format. Must be a time in the future and after `starts_at`.',
                             type: 'string',
                           },
                           errors: {
                             description:
-                              'Errors associated with the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials).',
+                              'Errors associated with the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials).',
                             items: {
                               properties: {
                                 error_code: { type: 'string' },
@@ -7272,7 +7272,7 @@ const openapi: OpenAPISpec = {
                           },
                           external_type: {
                             description:
-                              'Brand-specific terminology for the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials) type. Supported values: `pti_card`, `brivo_credential`, `hid_credential`, `visionline_card`.',
+                              'Brand-specific terminology for the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials) type. Supported values: `pti_card`, `brivo_credential`, `hid_credential`, `visionline_card`.',
                             enum: [
                               'pti_card',
                               'brivo_credential',
@@ -7291,65 +7291,65 @@ const openapi: OpenAPISpec = {
                           },
                           external_type_display_name: {
                             description:
-                              'Display name that corresponds to the brand-specific terminology for the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials) type.',
+                              'Display name that corresponds to the brand-specific terminology for the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials) type.',
                             type: 'string',
                           },
                           is_issued: {
                             description:
-                              'Indicates whether the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials) has been encoded onto a card.',
+                              'Indicates whether the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials) has been encoded onto a card.',
                             type: 'boolean',
                           },
                           is_latest_desired_state_synced_with_provider: {
                             description:
-                              'Indicates whether the latest state of the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials) has been synced from Seam to the provider.',
+                              'Indicates whether the latest state of the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials) has been synced from Seam to the provider.',
                             nullable: true,
                             type: 'boolean',
                           },
                           is_managed: { enum: [false], type: 'boolean' },
                           is_multi_phone_sync_credential: {
                             description:
-                              'Indicates whether the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials) is a [multi-phone sync credential](https://docs.seam.co/latest/capability-guides/mobile-access/issuing-mobile-credentials-from-an-access-control-system#what-are-multi-phone-sync-credentials).',
+                              'Indicates whether the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials) is a [multi-phone sync credential](https://docs.seam.co/capability-guides/mobile-access/issuing-mobile-credentials-from-an-access-control-system#what-are-multi-phone-sync-credentials).',
                             type: 'boolean',
                           },
                           is_one_time_use: {
                             description:
-                              'Indicates whether the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials) can only be used once. If `true`, the code becomes invalid after the first use.',
+                              'Indicates whether the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials) can only be used once. If `true`, the code becomes invalid after the first use.',
                             type: 'boolean',
                           },
                           issued_at: {
                             description:
-                              'Date and time at which the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials) was encoded onto a card.',
+                              'Date and time at which the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials) was encoded onto a card.',
                             format: 'date-time',
                             nullable: true,
                             type: 'string',
                           },
                           latest_desired_state_synced_with_provider_at: {
                             description:
-                              'Date and time at which the state of the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials) was most recently synced from Seam to the provider.',
+                              'Date and time at which the state of the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials) was most recently synced from Seam to the provider.',
                             format: 'date-time',
                             nullable: true,
                             type: 'string',
                           },
                           parent_acs_credential_id: {
                             description:
-                              'ID of the parent [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials).',
+                              'ID of the parent [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials).',
                             format: 'uuid',
                             type: 'string',
                           },
                           starts_at: {
                             description:
-                              'Date and time at which the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials) validity starts, in [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) format.',
+                              'Date and time at which the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials) validity starts, in [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) format.',
                             type: 'string',
                           },
                           user_identity_id: {
                             description:
-                              'ID of the [user identity](https://docs.seam.co/latest/api/user_identities) to whom the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials) belongs.',
+                              'ID of the [user identity](https://docs.seam.co/api/user_identities) to whom the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials) belongs.',
                             format: 'uuid',
                             type: 'string',
                           },
                           visionline_metadata: {
                             description:
-                              'Visionline-specific metadata for the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials).',
+                              'Visionline-specific metadata for the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials).',
                             properties: {
                               auto_join: {
                                 description:
@@ -7401,15 +7401,15 @@ const openapi: OpenAPISpec = {
                           },
                           warnings: {
                             description:
-                              'Warnings associated with the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials).',
+                              'Warnings associated with the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials).',
                             items: {
                               description:
-                                'Warning associated with the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials).',
+                                'Warning associated with the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials).',
                               discriminator: { propertyName: 'warning_code' },
                               oneOf: [
                                 {
                                   description:
-                                    'Indicates that the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials) is waiting to be issued.',
+                                    'Indicates that the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials) is waiting to be issued.',
                                   properties: {
                                     created_at: {
                                       description:
@@ -7438,7 +7438,7 @@ const openapi: OpenAPISpec = {
                                 },
                                 {
                                   description:
-                                    "Indicates that the schedule of one of the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials)'s children was modified externally.",
+                                    "Indicates that the schedule of one of the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials)'s children was modified externally.",
                                   properties: {
                                     created_at: {
                                       description:
@@ -7467,7 +7467,7 @@ const openapi: OpenAPISpec = {
                                 },
                                 {
                                   description:
-                                    'Indicates that the schedule of the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials) was modified to avoid creating a credential with a start date in the past.',
+                                    'Indicates that the schedule of the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials) was modified to avoid creating a credential with a start date in the past.',
                                   properties: {
                                     created_at: {
                                       description:
@@ -7496,7 +7496,7 @@ const openapi: OpenAPISpec = {
                                 },
                                 {
                                   description:
-                                    'Indicates that the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials) is being deleted.',
+                                    'Indicates that the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials) is being deleted.',
                                   properties: {
                                     created_at: {
                                       description:
@@ -7525,7 +7525,7 @@ const openapi: OpenAPISpec = {
                                 },
                                 {
                                   description:
-                                    'An unknown issue occurred while syncing the state of the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials) with the provider. This issue may affect the proper functioning of the credential.',
+                                    'An unknown issue occurred while syncing the state of the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials) with the provider. This issue may affect the proper functioning of the credential.',
                                   properties: {
                                     created_at: {
                                       description:
@@ -7556,7 +7556,7 @@ const openapi: OpenAPISpec = {
                                 },
                                 {
                                   description:
-                                    'Access permissions for the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials) have changed. [Reissue](https://docs.seam.co/latest/capability-guides/access-systems/working-with-card-encoders-and-scanners/creating-and-encoding-card-based-credentials) (re-encode) the credential. This issue may affect the proper functioning of the credential.',
+                                    'Access permissions for the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials) have changed. [Reissue](https://docs.seam.co/capability-guides/access-systems/working-with-card-encoders-and-scanners/creating-and-encoding-card-based-credentials) (re-encode) the credential. This issue may affect the proper functioning of the credential.',
                                   properties: {
                                     created_at: {
                                       description:
@@ -7589,7 +7589,7 @@ const openapi: OpenAPISpec = {
                           },
                           workspace_id: {
                             description:
-                              'ID of the [workspace](https://docs.seam.co/latest/core-concepts/workspaces) that contains the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials).',
+                              'ID of the [workspace](https://docs.seam.co/core-concepts/workspaces) that contains the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials).',
                             format: 'uuid',
                             type: 'string',
                           },
@@ -7868,17 +7868,17 @@ const openapi: OpenAPISpec = {
                 oneOf: [
                   {
                     description:
-                      'Means by which an [access control system user](https://docs.seam.co/latest/capability-guides/access-systems/user-management) gains access at an [entrance](https://docs.seam.co/latest/capability-guides/access-systems/retrieving-entrance-details). The `acs_credential` object represents a [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials) that provides an ACS user access within an [access control system](https://docs.seam.co/latest/capability-guides/access-systems).\n\nAn access control system generally uses digital means of access to authorize a user trying to get through a specific entrance. Examples of credentials include plastic key cards, mobile keys, biometric identifiers, and PIN codes. The electronic nature of these credentials, as well as the fact that access is centralized, enables both the rapid provisioning and rescinding of access and the ability to compile access audit logs.\n\nFor each `acs_credential`, you define the access method. You can also specify additional properties, such as a PIN code, depending on the credential type.',
+                      'Means by which an [access control system user](https://docs.seam.co/capability-guides/access-systems/user-management) gains access at an [entrance](https://docs.seam.co/capability-guides/access-systems/retrieving-entrance-details). The `acs_credential` object represents a [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials) that provides an ACS user access within an [access control system](https://docs.seam.co/capability-guides/access-systems).\n\nAn access control system generally uses digital means of access to authorize a user trying to get through a specific entrance. Examples of credentials include plastic key cards, mobile keys, biometric identifiers, and PIN codes. The electronic nature of these credentials, as well as the fact that access is centralized, enables both the rapid provisioning and rescinding of access and the ability to compile access audit logs.\n\nFor each `acs_credential`, you define the access method. You can also specify additional properties, such as a PIN code, depending on the credential type.',
                     properties: {
                       access_method: {
                         description:
-                          'Access method for the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials). Supported values: `code`, `card`, `mobile_key`, `cloud_key`.',
+                          'Access method for the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials). Supported values: `code`, `card`, `mobile_key`, `cloud_key`.',
                         enum: ['code', 'card', 'mobile_key', 'cloud_key'],
                         type: 'string',
                       },
                       acs_credential_id: {
                         description:
-                          'ID of the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials).',
+                          'ID of the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials).',
                         format: 'uuid',
                         type: 'string',
                       },
@@ -7888,19 +7888,19 @@ const openapi: OpenAPISpec = {
                       },
                       acs_system_id: {
                         description:
-                          'ID of the [access control system](https://docs.seam.co/latest/capability-guides/access-systems) that contains the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials).',
+                          'ID of the [access control system](https://docs.seam.co/capability-guides/access-systems) that contains the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials).',
                         format: 'uuid',
                         type: 'string',
                       },
                       acs_user_id: {
                         description:
-                          'ID of the [ACS user](https://docs.seam.co/latest/capability-guides/access-systems/user-management) to whom the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials) belongs.',
+                          'ID of the [ACS user](https://docs.seam.co/capability-guides/access-systems/user-management) to whom the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials) belongs.',
                         format: 'uuid',
                         type: 'string',
                       },
                       assa_abloy_vostio_metadata: {
                         description:
-                          'Vostio-specific metadata for the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials).',
+                          'Vostio-specific metadata for the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials).',
                         properties: {
                           auto_join: {
                             description:
@@ -7938,42 +7938,42 @@ const openapi: OpenAPISpec = {
                       },
                       card_number: {
                         description:
-                          'Number of the card associated with the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials).',
+                          'Number of the card associated with the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials).',
                         nullable: true,
                         type: 'string',
                       },
                       code: {
                         description:
-                          'Access (PIN) code for the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials).',
+                          'Access (PIN) code for the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials).',
                         nullable: true,
                         type: 'string',
                       },
                       connected_account_id: {
                         description:
-                          'ID of the [connected account](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials#connected-accounts) to which the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials) belongs.',
+                          'ID of the [connected account](https://docs.seam.co/capability-guides/access-systems/managing-credentials#connected-accounts) to which the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials) belongs.',
                         format: 'uuid',
                         type: 'string',
                       },
                       created_at: {
                         description:
-                          'Date and time at which the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials) was created.',
+                          'Date and time at which the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials) was created.',
                         format: 'date-time',
                         type: 'string',
                       },
                       display_name: {
                         description:
-                          'Display name that corresponds to the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials) type.',
+                          'Display name that corresponds to the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials) type.',
                         minLength: 1,
                         type: 'string',
                       },
                       ends_at: {
                         description:
-                          'Date and time at which the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials) validity ends, in [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) format. Must be a time in the future and after `starts_at`.',
+                          'Date and time at which the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials) validity ends, in [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) format. Must be a time in the future and after `starts_at`.',
                         type: 'string',
                       },
                       errors: {
                         description:
-                          'Errors associated with the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials).',
+                          'Errors associated with the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials).',
                         items: {
                           properties: {
                             error_code: { type: 'string' },
@@ -7986,7 +7986,7 @@ const openapi: OpenAPISpec = {
                       },
                       external_type: {
                         description:
-                          'Brand-specific terminology for the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials) type. Supported values: `pti_card`, `brivo_credential`, `hid_credential`, `visionline_card`.',
+                          'Brand-specific terminology for the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials) type. Supported values: `pti_card`, `brivo_credential`, `hid_credential`, `visionline_card`.',
                         enum: [
                           'pti_card',
                           'brivo_credential',
@@ -8005,65 +8005,65 @@ const openapi: OpenAPISpec = {
                       },
                       external_type_display_name: {
                         description:
-                          'Display name that corresponds to the brand-specific terminology for the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials) type.',
+                          'Display name that corresponds to the brand-specific terminology for the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials) type.',
                         type: 'string',
                       },
                       is_issued: {
                         description:
-                          'Indicates whether the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials) has been encoded onto a card.',
+                          'Indicates whether the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials) has been encoded onto a card.',
                         type: 'boolean',
                       },
                       is_latest_desired_state_synced_with_provider: {
                         description:
-                          'Indicates whether the latest state of the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials) has been synced from Seam to the provider.',
+                          'Indicates whether the latest state of the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials) has been synced from Seam to the provider.',
                         nullable: true,
                         type: 'boolean',
                       },
                       is_managed: { enum: [true], type: 'boolean' },
                       is_multi_phone_sync_credential: {
                         description:
-                          'Indicates whether the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials) is a [multi-phone sync credential](https://docs.seam.co/latest/capability-guides/mobile-access/issuing-mobile-credentials-from-an-access-control-system#what-are-multi-phone-sync-credentials).',
+                          'Indicates whether the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials) is a [multi-phone sync credential](https://docs.seam.co/capability-guides/mobile-access/issuing-mobile-credentials-from-an-access-control-system#what-are-multi-phone-sync-credentials).',
                         type: 'boolean',
                       },
                       is_one_time_use: {
                         description:
-                          'Indicates whether the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials) can only be used once. If `true`, the code becomes invalid after the first use.',
+                          'Indicates whether the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials) can only be used once. If `true`, the code becomes invalid after the first use.',
                         type: 'boolean',
                       },
                       issued_at: {
                         description:
-                          'Date and time at which the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials) was encoded onto a card.',
+                          'Date and time at which the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials) was encoded onto a card.',
                         format: 'date-time',
                         nullable: true,
                         type: 'string',
                       },
                       latest_desired_state_synced_with_provider_at: {
                         description:
-                          'Date and time at which the state of the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials) was most recently synced from Seam to the provider.',
+                          'Date and time at which the state of the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials) was most recently synced from Seam to the provider.',
                         format: 'date-time',
                         nullable: true,
                         type: 'string',
                       },
                       parent_acs_credential_id: {
                         description:
-                          'ID of the parent [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials).',
+                          'ID of the parent [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials).',
                         format: 'uuid',
                         type: 'string',
                       },
                       starts_at: {
                         description:
-                          'Date and time at which the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials) validity starts, in [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) format.',
+                          'Date and time at which the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials) validity starts, in [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) format.',
                         type: 'string',
                       },
                       user_identity_id: {
                         description:
-                          'ID of the [user identity](https://docs.seam.co/latest/api/user_identities) to whom the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials) belongs.',
+                          'ID of the [user identity](https://docs.seam.co/api/user_identities) to whom the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials) belongs.',
                         format: 'uuid',
                         type: 'string',
                       },
                       visionline_metadata: {
                         description:
-                          'Visionline-specific metadata for the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials).',
+                          'Visionline-specific metadata for the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials).',
                         properties: {
                           auto_join: {
                             description:
@@ -8115,15 +8115,15 @@ const openapi: OpenAPISpec = {
                       },
                       warnings: {
                         description:
-                          'Warnings associated with the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials).',
+                          'Warnings associated with the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials).',
                         items: {
                           description:
-                            'Warning associated with the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials).',
+                            'Warning associated with the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials).',
                           discriminator: { propertyName: 'warning_code' },
                           oneOf: [
                             {
                               description:
-                                'Indicates that the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials) is waiting to be issued.',
+                                'Indicates that the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials) is waiting to be issued.',
                               properties: {
                                 created_at: {
                                   description:
@@ -8152,7 +8152,7 @@ const openapi: OpenAPISpec = {
                             },
                             {
                               description:
-                                "Indicates that the schedule of one of the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials)'s children was modified externally.",
+                                "Indicates that the schedule of one of the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials)'s children was modified externally.",
                               properties: {
                                 created_at: {
                                   description:
@@ -8181,7 +8181,7 @@ const openapi: OpenAPISpec = {
                             },
                             {
                               description:
-                                'Indicates that the schedule of the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials) was modified to avoid creating a credential with a start date in the past.',
+                                'Indicates that the schedule of the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials) was modified to avoid creating a credential with a start date in the past.',
                               properties: {
                                 created_at: {
                                   description:
@@ -8210,7 +8210,7 @@ const openapi: OpenAPISpec = {
                             },
                             {
                               description:
-                                'Indicates that the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials) is being deleted.',
+                                'Indicates that the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials) is being deleted.',
                               properties: {
                                 created_at: {
                                   description:
@@ -8239,7 +8239,7 @@ const openapi: OpenAPISpec = {
                             },
                             {
                               description:
-                                'An unknown issue occurred while syncing the state of the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials) with the provider. This issue may affect the proper functioning of the credential.',
+                                'An unknown issue occurred while syncing the state of the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials) with the provider. This issue may affect the proper functioning of the credential.',
                               properties: {
                                 created_at: {
                                   description:
@@ -8268,7 +8268,7 @@ const openapi: OpenAPISpec = {
                             },
                             {
                               description:
-                                'Access permissions for the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials) have changed. [Reissue](https://docs.seam.co/latest/capability-guides/access-systems/working-with-card-encoders-and-scanners/creating-and-encoding-card-based-credentials) (re-encode) the credential. This issue may affect the proper functioning of the credential.',
+                                'Access permissions for the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials) have changed. [Reissue](https://docs.seam.co/capability-guides/access-systems/working-with-card-encoders-and-scanners/creating-and-encoding-card-based-credentials) (re-encode) the credential. This issue may affect the proper functioning of the credential.',
                               properties: {
                                 created_at: {
                                   description:
@@ -8301,7 +8301,7 @@ const openapi: OpenAPISpec = {
                       },
                       workspace_id: {
                         description:
-                          'ID of the [workspace](https://docs.seam.co/latest/core-concepts/workspaces) that contains the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials).',
+                          'ID of the [workspace](https://docs.seam.co/core-concepts/workspaces) that contains the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials).',
                         format: 'uuid',
                         type: 'string',
                       },
@@ -8323,17 +8323,17 @@ const openapi: OpenAPISpec = {
                   },
                   {
                     description:
-                      'Means by which an [ACS user](https://docs.seam.co/latest/capability-guides/access-systems/user-management) gains access at an [entrance](https://docs.seam.co/latest/capability-guides/access-systems/retrieving-entrance-details). The `unmanaged_acs_credential` object, which is not managed by Seam, represents a [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials) that provides an ACS user access within an [access control system](https://docs.seam.co/latest/capability-guides/access-systems). For each `acs_credential` object, you define the access method. You can also specify additional properties, such as a PIN code.',
+                      'Means by which an [ACS user](https://docs.seam.co/capability-guides/access-systems/user-management) gains access at an [entrance](https://docs.seam.co/capability-guides/access-systems/retrieving-entrance-details). The `unmanaged_acs_credential` object, which is not managed by Seam, represents a [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials) that provides an ACS user access within an [access control system](https://docs.seam.co/capability-guides/access-systems). For each `acs_credential` object, you define the access method. You can also specify additional properties, such as a PIN code.',
                     properties: {
                       access_method: {
                         description:
-                          'Access method for the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials). Supported values: `code`, `card`, `mobile_key`, `cloud_key`.',
+                          'Access method for the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials). Supported values: `code`, `card`, `mobile_key`, `cloud_key`.',
                         enum: ['code', 'card', 'mobile_key', 'cloud_key'],
                         type: 'string',
                       },
                       acs_credential_id: {
                         description:
-                          'ID of the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials).',
+                          'ID of the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials).',
                         format: 'uuid',
                         type: 'string',
                       },
@@ -8343,19 +8343,19 @@ const openapi: OpenAPISpec = {
                       },
                       acs_system_id: {
                         description:
-                          'ID of the [access control system](https://docs.seam.co/latest/capability-guides/access-systems) that contains the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials).',
+                          'ID of the [access control system](https://docs.seam.co/capability-guides/access-systems) that contains the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials).',
                         format: 'uuid',
                         type: 'string',
                       },
                       acs_user_id: {
                         description:
-                          'ID of the [ACS user](https://docs.seam.co/latest/capability-guides/access-systems/user-management) to whom the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials) belongs.',
+                          'ID of the [ACS user](https://docs.seam.co/capability-guides/access-systems/user-management) to whom the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials) belongs.',
                         format: 'uuid',
                         type: 'string',
                       },
                       assa_abloy_vostio_metadata: {
                         description:
-                          'Vostio-specific metadata for the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials).',
+                          'Vostio-specific metadata for the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials).',
                         properties: {
                           auto_join: {
                             description:
@@ -8393,42 +8393,42 @@ const openapi: OpenAPISpec = {
                       },
                       card_number: {
                         description:
-                          'Number of the card associated with the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials).',
+                          'Number of the card associated with the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials).',
                         nullable: true,
                         type: 'string',
                       },
                       code: {
                         description:
-                          'Access (PIN) code for the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials).',
+                          'Access (PIN) code for the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials).',
                         nullable: true,
                         type: 'string',
                       },
                       connected_account_id: {
                         description:
-                          'ID of the [connected account](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials#connected-accounts) to which the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials) belongs.',
+                          'ID of the [connected account](https://docs.seam.co/capability-guides/access-systems/managing-credentials#connected-accounts) to which the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials) belongs.',
                         format: 'uuid',
                         type: 'string',
                       },
                       created_at: {
                         description:
-                          'Date and time at which the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials) was created.',
+                          'Date and time at which the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials) was created.',
                         format: 'date-time',
                         type: 'string',
                       },
                       display_name: {
                         description:
-                          'Display name that corresponds to the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials) type.',
+                          'Display name that corresponds to the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials) type.',
                         minLength: 1,
                         type: 'string',
                       },
                       ends_at: {
                         description:
-                          'Date and time at which the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials) validity ends, in [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) format. Must be a time in the future and after `starts_at`.',
+                          'Date and time at which the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials) validity ends, in [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) format. Must be a time in the future and after `starts_at`.',
                         type: 'string',
                       },
                       errors: {
                         description:
-                          'Errors associated with the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials).',
+                          'Errors associated with the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials).',
                         items: {
                           properties: {
                             error_code: { type: 'string' },
@@ -8441,7 +8441,7 @@ const openapi: OpenAPISpec = {
                       },
                       external_type: {
                         description:
-                          'Brand-specific terminology for the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials) type. Supported values: `pti_card`, `brivo_credential`, `hid_credential`, `visionline_card`.',
+                          'Brand-specific terminology for the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials) type. Supported values: `pti_card`, `brivo_credential`, `hid_credential`, `visionline_card`.',
                         enum: [
                           'pti_card',
                           'brivo_credential',
@@ -8460,65 +8460,65 @@ const openapi: OpenAPISpec = {
                       },
                       external_type_display_name: {
                         description:
-                          'Display name that corresponds to the brand-specific terminology for the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials) type.',
+                          'Display name that corresponds to the brand-specific terminology for the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials) type.',
                         type: 'string',
                       },
                       is_issued: {
                         description:
-                          'Indicates whether the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials) has been encoded onto a card.',
+                          'Indicates whether the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials) has been encoded onto a card.',
                         type: 'boolean',
                       },
                       is_latest_desired_state_synced_with_provider: {
                         description:
-                          'Indicates whether the latest state of the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials) has been synced from Seam to the provider.',
+                          'Indicates whether the latest state of the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials) has been synced from Seam to the provider.',
                         nullable: true,
                         type: 'boolean',
                       },
                       is_managed: { enum: [false], type: 'boolean' },
                       is_multi_phone_sync_credential: {
                         description:
-                          'Indicates whether the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials) is a [multi-phone sync credential](https://docs.seam.co/latest/capability-guides/mobile-access/issuing-mobile-credentials-from-an-access-control-system#what-are-multi-phone-sync-credentials).',
+                          'Indicates whether the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials) is a [multi-phone sync credential](https://docs.seam.co/capability-guides/mobile-access/issuing-mobile-credentials-from-an-access-control-system#what-are-multi-phone-sync-credentials).',
                         type: 'boolean',
                       },
                       is_one_time_use: {
                         description:
-                          'Indicates whether the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials) can only be used once. If `true`, the code becomes invalid after the first use.',
+                          'Indicates whether the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials) can only be used once. If `true`, the code becomes invalid after the first use.',
                         type: 'boolean',
                       },
                       issued_at: {
                         description:
-                          'Date and time at which the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials) was encoded onto a card.',
+                          'Date and time at which the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials) was encoded onto a card.',
                         format: 'date-time',
                         nullable: true,
                         type: 'string',
                       },
                       latest_desired_state_synced_with_provider_at: {
                         description:
-                          'Date and time at which the state of the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials) was most recently synced from Seam to the provider.',
+                          'Date and time at which the state of the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials) was most recently synced from Seam to the provider.',
                         format: 'date-time',
                         nullable: true,
                         type: 'string',
                       },
                       parent_acs_credential_id: {
                         description:
-                          'ID of the parent [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials).',
+                          'ID of the parent [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials).',
                         format: 'uuid',
                         type: 'string',
                       },
                       starts_at: {
                         description:
-                          'Date and time at which the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials) validity starts, in [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) format.',
+                          'Date and time at which the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials) validity starts, in [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) format.',
                         type: 'string',
                       },
                       user_identity_id: {
                         description:
-                          'ID of the [user identity](https://docs.seam.co/latest/api/user_identities) to whom the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials) belongs.',
+                          'ID of the [user identity](https://docs.seam.co/api/user_identities) to whom the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials) belongs.',
                         format: 'uuid',
                         type: 'string',
                       },
                       visionline_metadata: {
                         description:
-                          'Visionline-specific metadata for the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials).',
+                          'Visionline-specific metadata for the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials).',
                         properties: {
                           auto_join: {
                             description:
@@ -8570,15 +8570,15 @@ const openapi: OpenAPISpec = {
                       },
                       warnings: {
                         description:
-                          'Warnings associated with the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials).',
+                          'Warnings associated with the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials).',
                         items: {
                           description:
-                            'Warning associated with the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials).',
+                            'Warning associated with the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials).',
                           discriminator: { propertyName: 'warning_code' },
                           oneOf: [
                             {
                               description:
-                                'Indicates that the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials) is waiting to be issued.',
+                                'Indicates that the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials) is waiting to be issued.',
                               properties: {
                                 created_at: {
                                   description:
@@ -8607,7 +8607,7 @@ const openapi: OpenAPISpec = {
                             },
                             {
                               description:
-                                "Indicates that the schedule of one of the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials)'s children was modified externally.",
+                                "Indicates that the schedule of one of the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials)'s children was modified externally.",
                               properties: {
                                 created_at: {
                                   description:
@@ -8636,7 +8636,7 @@ const openapi: OpenAPISpec = {
                             },
                             {
                               description:
-                                'Indicates that the schedule of the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials) was modified to avoid creating a credential with a start date in the past.',
+                                'Indicates that the schedule of the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials) was modified to avoid creating a credential with a start date in the past.',
                               properties: {
                                 created_at: {
                                   description:
@@ -8665,7 +8665,7 @@ const openapi: OpenAPISpec = {
                             },
                             {
                               description:
-                                'Indicates that the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials) is being deleted.',
+                                'Indicates that the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials) is being deleted.',
                               properties: {
                                 created_at: {
                                   description:
@@ -8694,7 +8694,7 @@ const openapi: OpenAPISpec = {
                             },
                             {
                               description:
-                                'An unknown issue occurred while syncing the state of the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials) with the provider. This issue may affect the proper functioning of the credential.',
+                                'An unknown issue occurred while syncing the state of the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials) with the provider. This issue may affect the proper functioning of the credential.',
                               properties: {
                                 created_at: {
                                   description:
@@ -8723,7 +8723,7 @@ const openapi: OpenAPISpec = {
                             },
                             {
                               description:
-                                'Access permissions for the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials) have changed. [Reissue](https://docs.seam.co/latest/capability-guides/access-systems/working-with-card-encoders-and-scanners/creating-and-encoding-card-based-credentials) (re-encode) the credential. This issue may affect the proper functioning of the credential.',
+                                'Access permissions for the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials) have changed. [Reissue](https://docs.seam.co/capability-guides/access-systems/working-with-card-encoders-and-scanners/creating-and-encoding-card-based-credentials) (re-encode) the credential. This issue may affect the proper functioning of the credential.',
                               properties: {
                                 created_at: {
                                   description:
@@ -8756,7 +8756,7 @@ const openapi: OpenAPISpec = {
                       },
                       workspace_id: {
                         description:
-                          'ID of the [workspace](https://docs.seam.co/latest/core-concepts/workspaces) that contains the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials).',
+                          'ID of the [workspace](https://docs.seam.co/core-concepts/workspaces) that contains the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials).',
                         format: 'uuid',
                         type: 'string',
                       },
@@ -9076,32 +9076,32 @@ const openapi: OpenAPISpec = {
                 properties: {
                   access_method: {
                     description:
-                      'Access method for the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials). Supported values: `code`, `card`, `mobile_key`, `cloud_key`.',
+                      'Access method for the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials). Supported values: `code`, `card`, `mobile_key`, `cloud_key`.',
                     enum: ['code', 'card', 'mobile_key', 'cloud_key'],
                     type: 'string',
                   },
                   acs_credential_id: {
                     description:
-                      'ID of the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials).',
+                      'ID of the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials).',
                     format: 'uuid',
                     type: 'string',
                   },
                   acs_credential_pool_id: { format: 'uuid', type: 'string' },
                   acs_system_id: {
                     description:
-                      'ID of the [access control system](https://docs.seam.co/latest/capability-guides/access-systems) that contains the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials).',
+                      'ID of the [access control system](https://docs.seam.co/capability-guides/access-systems) that contains the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials).',
                     format: 'uuid',
                     type: 'string',
                   },
                   acs_user_id: {
                     description:
-                      'ID of the [ACS user](https://docs.seam.co/latest/capability-guides/access-systems/user-management) to whom the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials) belongs.',
+                      'ID of the [ACS user](https://docs.seam.co/capability-guides/access-systems/user-management) to whom the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials) belongs.',
                     format: 'uuid',
                     type: 'string',
                   },
                   assa_abloy_vostio_metadata: {
                     description:
-                      'Vostio-specific metadata for the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials).',
+                      'Vostio-specific metadata for the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials).',
                     properties: {
                       auto_join: {
                         description:
@@ -9138,42 +9138,42 @@ const openapi: OpenAPISpec = {
                   },
                   card_number: {
                     description:
-                      'Number of the card associated with the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials).',
+                      'Number of the card associated with the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials).',
                     nullable: true,
                     type: 'string',
                   },
                   code: {
                     description:
-                      'Access (PIN) code for the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials).',
+                      'Access (PIN) code for the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials).',
                     nullable: true,
                     type: 'string',
                   },
                   connected_account_id: {
                     description:
-                      'ID of the [connected account](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials#connected-accounts) to which the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials) belongs.',
+                      'ID of the [connected account](https://docs.seam.co/capability-guides/access-systems/managing-credentials#connected-accounts) to which the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials) belongs.',
                     format: 'uuid',
                     type: 'string',
                   },
                   created_at: {
                     description:
-                      'Date and time at which the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials) was created.',
+                      'Date and time at which the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials) was created.',
                     format: 'date-time',
                     type: 'string',
                   },
                   display_name: {
                     description:
-                      'Display name that corresponds to the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials) type.',
+                      'Display name that corresponds to the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials) type.',
                     minLength: 1,
                     type: 'string',
                   },
                   ends_at: {
                     description:
-                      'Date and time at which the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials) validity ends, in [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) format. Must be a time in the future and after `starts_at`.',
+                      'Date and time at which the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials) validity ends, in [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) format. Must be a time in the future and after `starts_at`.',
                     type: 'string',
                   },
                   errors: {
                     description:
-                      'Errors associated with the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials).',
+                      'Errors associated with the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials).',
                     items: {
                       properties: {
                         error_code: { type: 'string' },
@@ -9186,7 +9186,7 @@ const openapi: OpenAPISpec = {
                   },
                   external_type: {
                     description:
-                      'Brand-specific terminology for the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials) type. Supported values: `pti_card`, `brivo_credential`, `hid_credential`, `visionline_card`.',
+                      'Brand-specific terminology for the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials) type. Supported values: `pti_card`, `brivo_credential`, `hid_credential`, `visionline_card`.',
                     enum: [
                       'pti_card',
                       'brivo_credential',
@@ -9205,65 +9205,65 @@ const openapi: OpenAPISpec = {
                   },
                   external_type_display_name: {
                     description:
-                      'Display name that corresponds to the brand-specific terminology for the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials) type.',
+                      'Display name that corresponds to the brand-specific terminology for the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials) type.',
                     type: 'string',
                   },
                   is_issued: {
                     description:
-                      'Indicates whether the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials) has been encoded onto a card.',
+                      'Indicates whether the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials) has been encoded onto a card.',
                     type: 'boolean',
                   },
                   is_latest_desired_state_synced_with_provider: {
                     description:
-                      'Indicates whether the latest state of the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials) has been synced from Seam to the provider.',
+                      'Indicates whether the latest state of the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials) has been synced from Seam to the provider.',
                     nullable: true,
                     type: 'boolean',
                   },
                   is_managed: { enum: [true], type: 'boolean' },
                   is_multi_phone_sync_credential: {
                     description:
-                      'Indicates whether the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials) is a [multi-phone sync credential](https://docs.seam.co/latest/capability-guides/mobile-access/issuing-mobile-credentials-from-an-access-control-system#what-are-multi-phone-sync-credentials).',
+                      'Indicates whether the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials) is a [multi-phone sync credential](https://docs.seam.co/capability-guides/mobile-access/issuing-mobile-credentials-from-an-access-control-system#what-are-multi-phone-sync-credentials).',
                     type: 'boolean',
                   },
                   is_one_time_use: {
                     description:
-                      'Indicates whether the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials) can only be used once. If `true`, the code becomes invalid after the first use.',
+                      'Indicates whether the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials) can only be used once. If `true`, the code becomes invalid after the first use.',
                     type: 'boolean',
                   },
                   issued_at: {
                     description:
-                      'Date and time at which the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials) was encoded onto a card.',
+                      'Date and time at which the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials) was encoded onto a card.',
                     format: 'date-time',
                     nullable: true,
                     type: 'string',
                   },
                   latest_desired_state_synced_with_provider_at: {
                     description:
-                      'Date and time at which the state of the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials) was most recently synced from Seam to the provider.',
+                      'Date and time at which the state of the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials) was most recently synced from Seam to the provider.',
                     format: 'date-time',
                     nullable: true,
                     type: 'string',
                   },
                   parent_acs_credential_id: {
                     description:
-                      'ID of the parent [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials).',
+                      'ID of the parent [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials).',
                     format: 'uuid',
                     type: 'string',
                   },
                   starts_at: {
                     description:
-                      'Date and time at which the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials) validity starts, in [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) format.',
+                      'Date and time at which the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials) validity starts, in [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) format.',
                     type: 'string',
                   },
                   user_identity_id: {
                     description:
-                      'ID of the [user identity](https://docs.seam.co/latest/api/user_identities) to whom the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials) belongs.',
+                      'ID of the [user identity](https://docs.seam.co/api/user_identities) to whom the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials) belongs.',
                     format: 'uuid',
                     type: 'string',
                   },
                   visionline_metadata: {
                     description:
-                      'Visionline-specific metadata for the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials).',
+                      'Visionline-specific metadata for the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials).',
                     properties: {
                       auto_join: {
                         description:
@@ -9315,15 +9315,15 @@ const openapi: OpenAPISpec = {
                   },
                   warnings: {
                     description:
-                      'Warnings associated with the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials).',
+                      'Warnings associated with the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials).',
                     items: {
                       description:
-                        'Warning associated with the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials).',
+                        'Warning associated with the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials).',
                       discriminator: { propertyName: 'warning_code' },
                       oneOf: [
                         {
                           description:
-                            'Indicates that the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials) is waiting to be issued.',
+                            'Indicates that the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials) is waiting to be issued.',
                           properties: {
                             created_at: {
                               description:
@@ -9348,7 +9348,7 @@ const openapi: OpenAPISpec = {
                         },
                         {
                           description:
-                            "Indicates that the schedule of one of the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials)'s children was modified externally.",
+                            "Indicates that the schedule of one of the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials)'s children was modified externally.",
                           properties: {
                             created_at: {
                               description:
@@ -9373,7 +9373,7 @@ const openapi: OpenAPISpec = {
                         },
                         {
                           description:
-                            'Indicates that the schedule of the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials) was modified to avoid creating a credential with a start date in the past.',
+                            'Indicates that the schedule of the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials) was modified to avoid creating a credential with a start date in the past.',
                           properties: {
                             created_at: {
                               description:
@@ -9398,7 +9398,7 @@ const openapi: OpenAPISpec = {
                         },
                         {
                           description:
-                            'Indicates that the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials) is being deleted.',
+                            'Indicates that the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials) is being deleted.',
                           properties: {
                             created_at: {
                               description:
@@ -9423,7 +9423,7 @@ const openapi: OpenAPISpec = {
                         },
                         {
                           description:
-                            'An unknown issue occurred while syncing the state of the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials) with the provider. This issue may affect the proper functioning of the credential.',
+                            'An unknown issue occurred while syncing the state of the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials) with the provider. This issue may affect the proper functioning of the credential.',
                           properties: {
                             created_at: {
                               description:
@@ -9448,7 +9448,7 @@ const openapi: OpenAPISpec = {
                         },
                         {
                           description:
-                            'Access permissions for the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials) have changed. [Reissue](https://docs.seam.co/latest/capability-guides/access-systems/working-with-card-encoders-and-scanners/creating-and-encoding-card-based-credentials) (re-encode) the credential. This issue may affect the proper functioning of the credential.',
+                            'Access permissions for the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials) have changed. [Reissue](https://docs.seam.co/capability-guides/access-systems/working-with-card-encoders-and-scanners/creating-and-encoding-card-based-credentials) (re-encode) the credential. This issue may affect the proper functioning of the credential.',
                           properties: {
                             created_at: {
                               description:
@@ -9477,7 +9477,7 @@ const openapi: OpenAPISpec = {
                   },
                   workspace_id: {
                     description:
-                      'ID of the [workspace](https://docs.seam.co/latest/core-concepts/workspaces) that contains the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials).',
+                      'ID of the [workspace](https://docs.seam.co/core-concepts/workspaces) that contains the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials).',
                     format: 'uuid',
                     type: 'string',
                   },
@@ -11386,7 +11386,7 @@ const openapi: OpenAPISpec = {
       },
       bridge_client_session: {
         description:
-          'Represents a [Seam Bridge](https://docs.seam.co/latest/capability-guides/seam-bridge) client session.',
+          'Represents a [Seam Bridge](https://docs.seam.co/capability-guides/seam-bridge) client session.',
         properties: {
           bridge_client_machine_identifier_key: {
             description:
@@ -11579,16 +11579,16 @@ const openapi: OpenAPISpec = {
       },
       bridge_connected_systems: {
         description:
-          'Represents an access system connected to [Seam Bridge](https://docs.seam.co/latest/capability-guides/seam-bridge).',
+          'Represents an access system connected to [Seam Bridge](https://docs.seam.co/capability-guides/seam-bridge).',
         properties: {
           acs_system_display_name: {
             description:
-              'Display name for the [access system](https://docs.seam.co/latest/capability-guides/access-systems) associated with Seam Bridge.',
+              'Display name for the [access system](https://docs.seam.co/capability-guides/access-systems) associated with Seam Bridge.',
             type: 'string',
           },
           acs_system_id: {
             description:
-              'ID of the [access system](https://docs.seam.co/latest/capability-guides/access-systems) associated with Seam Bridge.',
+              'ID of the [access system](https://docs.seam.co/capability-guides/access-systems) associated with Seam Bridge.',
             format: 'uuid',
             type: 'string',
           },
@@ -11616,12 +11616,12 @@ const openapi: OpenAPISpec = {
           },
           workspace_display_name: {
             description:
-              'Display name for the [workspace](https://docs.seam.co/latest/core-concepts/workspaces) with which Seam Bridge is paired.',
+              'Display name for the [workspace](https://docs.seam.co/core-concepts/workspaces) with which Seam Bridge is paired.',
             type: 'string',
           },
           workspace_id: {
             description:
-              'ID of the [workspace](https://docs.seam.co/latest/core-concepts/workspaces) with which Seam Bridge is paired.',
+              'ID of the [workspace](https://docs.seam.co/core-concepts/workspaces) with which Seam Bridge is paired.',
             format: 'uuid',
             type: 'string',
           },
@@ -11642,77 +11642,77 @@ const openapi: OpenAPISpec = {
       },
       client_session: {
         description:
-          "Represents a [client session](https://docs.seam.co/latest/core-concepts/authentication/client-session-tokens). If you want to restrict your users' access to their own devices, use client sessions.\n\nYou create each client session with a custom `user_identifier_key`. Normally, the `user_identifier_key` is a user ID that your application provides.\n\nWhen calling the Seam API from your backend using an API key, you can pass the `user_identifier_key` as a parameter to limit results to the associated client session. For example, `/devices/list?user_identifier_key=123` only returns devices associated with the client session created with the `user_identifier_key` `123`.\n\nA client session has a token that you can use with the Seam JavaScript SDK to make requests from the client (browser) directly to the Seam API. The token restricts the user's access to only the devices that they own.\n\nSee also [Get Started with React](https://docs.seam.co/latest/ui-components/overview/getting-started-with-seam-components/get-started-with-react-components-and-client-session-tokens).",
+          "Represents a [client session](https://docs.seam.co/core-concepts/authentication/client-session-tokens). If you want to restrict your users' access to their own devices, use client sessions.\n\nYou create each client session with a custom `user_identifier_key`. Normally, the `user_identifier_key` is a user ID that your application provides.\n\nWhen calling the Seam API from your backend using an API key, you can pass the `user_identifier_key` as a parameter to limit results to the associated client session. For example, `/devices/list?user_identifier_key=123` only returns devices associated with the client session created with the `user_identifier_key` `123`.\n\nA client session has a token that you can use with the Seam JavaScript SDK to make requests from the client (browser) directly to the Seam API. The token restricts the user's access to only the devices that they own.\n\nSee also [Get Started with React](https://docs.seam.co/ui-components/overview/getting-started-with-seam-components/get-started-with-react-components-and-client-session-tokens).",
         properties: {
           client_session_id: {
             description:
-              'ID of the [client session](https://docs.seam.co/latest/core-concepts/authentication/client-session-tokens).',
+              'ID of the [client session](https://docs.seam.co/core-concepts/authentication/client-session-tokens).',
             format: 'uuid',
             type: 'string',
           },
           connect_webview_ids: {
             description:
-              'IDs of the [Connect Webviews](https://docs.seam.co/latest/core-concepts/connect-webviews) associated with the [client session](https://docs.seam.co/latest/core-concepts/authentication/client-session-tokens).',
+              'IDs of the [Connect Webviews](https://docs.seam.co/core-concepts/connect-webviews) associated with the [client session](https://docs.seam.co/core-concepts/authentication/client-session-tokens).',
             items: { format: 'uuid', type: 'string' },
             type: 'array',
           },
           connected_account_ids: {
             description:
-              'IDs of the [connected accounts](https://docs.seam.co/latest/core-concepts/connected-accounts) associated with the [client session](https://docs.seam.co/latest/core-concepts/authentication/client-session-tokens).',
+              'IDs of the [connected accounts](https://docs.seam.co/core-concepts/connected-accounts) associated with the [client session](https://docs.seam.co/core-concepts/authentication/client-session-tokens).',
             items: { format: 'uuid', type: 'string' },
             type: 'array',
           },
           created_at: {
             description:
-              'Date and time at which the [client session](https://docs.seam.co/latest/core-concepts/authentication/client-session-tokens) was created.',
+              'Date and time at which the [client session](https://docs.seam.co/core-concepts/authentication/client-session-tokens) was created.',
             format: 'date-time',
             type: 'string',
           },
           customer_key: {
             description:
-              'Customer key associated with the [client session](https://docs.seam.co/latest/core-concepts/authentication/client-session-tokens).',
+              'Customer key associated with the [client session](https://docs.seam.co/core-concepts/authentication/client-session-tokens).',
             type: 'string',
           },
           device_count: {
             description:
-              'Number of devices associated with the [client session](https://docs.seam.co/latest/core-concepts/authentication/client-session-tokens).',
+              'Number of devices associated with the [client session](https://docs.seam.co/core-concepts/authentication/client-session-tokens).',
             format: 'float',
             type: 'number',
           },
           expires_at: {
             description:
-              'Date and time at which the [client session](https://docs.seam.co/latest/core-concepts/authentication/client-session-tokens) expires.',
+              'Date and time at which the [client session](https://docs.seam.co/core-concepts/authentication/client-session-tokens) expires.',
             format: 'date-time',
             type: 'string',
           },
           token: {
             description:
-              'Client session token associated with the [client session](https://docs.seam.co/latest/core-concepts/authentication/client-session-tokens).',
+              'Client session token associated with the [client session](https://docs.seam.co/core-concepts/authentication/client-session-tokens).',
             type: 'string',
           },
           user_identifier_key: {
             description:
-              'Your user ID for the user associated with the [client session](https://docs.seam.co/latest/core-concepts/authentication/client-session-tokens).',
+              'Your user ID for the user associated with the [client session](https://docs.seam.co/core-concepts/authentication/client-session-tokens).',
             nullable: true,
             type: 'string',
           },
           user_identity_id: {
             description:
-              'ID of the [user identity](https://docs.seam.co/latest/capability-guides/mobile-access/managing-mobile-app-user-accounts-with-user-identities#what-is-a-user-identity) associated with the client session.',
+              'ID of the [user identity](https://docs.seam.co/capability-guides/mobile-access/managing-mobile-app-user-accounts-with-user-identities#what-is-a-user-identity) associated with the client session.',
             format: 'uuid',
             type: 'string',
           },
           user_identity_ids: {
             deprecated: true,
             description:
-              'IDs of the [user identities](https://docs.seam.co/latest/capability-guides/mobile-access/managing-mobile-app-user-accounts-with-user-identities#what-is-a-user-identity) associated with the client session.',
+              'IDs of the [user identities](https://docs.seam.co/capability-guides/mobile-access/managing-mobile-app-user-accounts-with-user-identities#what-is-a-user-identity) associated with the client session.',
             items: { format: 'uuid', type: 'string' },
             type: 'array',
             'x-deprecated': 'Use `user_identity_id` instead.',
           },
           workspace_id: {
             description:
-              'ID of the [workspace](https://docs.seam.co/latest/core-concepts/workspaces) associated with the [client session](https://docs.seam.co/latest/core-concepts/authentication/client-session-tokens).',
+              'ID of the [workspace](https://docs.seam.co/core-concepts/workspaces) associated with the [client session](https://docs.seam.co/core-concepts/authentication/client-session-tokens).',
             format: 'uuid',
             type: 'string',
           },
@@ -11734,7 +11734,7 @@ const openapi: OpenAPISpec = {
       },
       connect_webview: {
         description:
-          'Represents a [Connect Webview](https://docs.seam.co/latest/core-concepts/connect-webviews).\n\nConnect Webviews are fully-embedded client-side components that you add to your app. Your users interact with your embedded Connect Webviews to link their IoT device or system accounts to Seam. That is, Connect Webviews walk your users through the process of logging in to their device or system accounts. Seam handles all the authentication steps, and—once your user has completed the authorization through your app—you can access and control their devices or systems using the Seam API.\n\nConnect Webviews perform credential validation, multifactor authentication (when applicable), and error handling for each brand that Seam supports. Further, Connect Webviews work across all modern browsers and platforms, including Chrome, Safari, and Firefox.\n\nTo enable a user to connect their device or system account to Seam through your app, first create a `connect_webview`. Once created, this `connect_webview` includes a URL that you can use to open an [iframe](https://www.w3schools.com/html/html_iframe.asp) or new window containing the Connect Webview for your user.\n\nWhen you create a Connect Webview, specify the desired provider category key in the `provider_category` parameter. Alternately, to specify a list of providers explicitly, use the `accepted_providers` parameter with a list of device provider keys.\n\nTo list all providers within a category, use `/devices/list_device_providers` with the desired `provider_category` filter. To list all provider keys, use `/devices/list_device_providers` with no filters.',
+          'Represents a [Connect Webview](https://docs.seam.co/core-concepts/connect-webviews).\n\nConnect Webviews are fully-embedded client-side components that you add to your app. Your users interact with your embedded Connect Webviews to link their IoT device or system accounts to Seam. That is, Connect Webviews walk your users through the process of logging in to their device or system accounts. Seam handles all the authentication steps, and—once your user has completed the authorization through your app—you can access and control their devices or systems using the Seam API.\n\nConnect Webviews perform credential validation, multifactor authentication (when applicable), and error handling for each brand that Seam supports. Further, Connect Webviews work across all modern browsers and platforms, including Chrome, Safari, and Firefox.\n\nTo enable a user to connect their device or system account to Seam through your app, first create a `connect_webview`. Once created, this `connect_webview` includes a URL that you can use to open an [iframe](https://www.w3schools.com/html/html_iframe.asp) or new window containing the Connect Webview for your user.\n\nWhen you create a Connect Webview, specify the desired provider category key in the `provider_category` parameter. Alternately, to specify a list of providers explicitly, use the `accepted_providers` parameter with a list of device provider keys.\n\nTo list all providers within a category, use `/devices/list_device_providers` with the desired `provider_category` filter. To list all provider keys, use `/devices/list_device_providers` with no filters.',
         properties: {
           accepted_capabilities: {
             description:
@@ -11762,7 +11762,7 @@ const openapi: OpenAPISpec = {
           },
           accepted_providers: {
             description:
-              'List of accepted [provider keys](https://docs.seam.co/latest/core-concepts/connect-webviews/customizing-connect-webviews#customize-the-brands-to-display-in-your-connect-webviews).',
+              'List of accepted [provider keys](https://docs.seam.co/core-concepts/connect-webviews/customizing-connect-webviews#customize-the-brands-to-display-in-your-connect-webviews).',
             items: { type: 'string' },
             type: 'array',
           },
@@ -11785,7 +11785,7 @@ const openapi: OpenAPISpec = {
           },
           automatically_manage_new_devices: {
             description:
-              'Indicates whether Seam should [import all new devices](https://docs.seam.co/latest/core-concepts/connect-webviews/customizing-connect-webviews#automatically_manage_new_devices) for the connected account to make these devices available for use and management by the Seam API.',
+              'Indicates whether Seam should [import all new devices](https://docs.seam.co/core-concepts/connect-webviews/customizing-connect-webviews#automatically_manage_new_devices) for the connected account to make these devices available for use and management by the Seam API.',
             type: 'boolean',
           },
           connect_webview_id: {
@@ -11795,7 +11795,7 @@ const openapi: OpenAPISpec = {
           },
           connected_account_id: {
             description:
-              'ID of the [connected account](https://docs.seam.co/latest/core-concepts/connected-accounts) associated with the Connect Webview.',
+              'ID of the [connected account](https://docs.seam.co/core-concepts/connected-accounts) associated with the Connect Webview.',
             format: 'uuid',
             nullable: true,
             type: 'string',
@@ -11811,7 +11811,7 @@ const openapi: OpenAPISpec = {
               oneOf: [{ type: 'string' }, { type: 'boolean' }],
             },
             description:
-              'Set of key:value pairs. Adding custom metadata to a resource, such as a [Connect Webview](https://docs.seam.co/latest/core-concepts/connect-webviews/attaching-custom-data-to-the-connect-webview), [connected account](https://docs.seam.co/latest/core-concepts/connected-accounts/adding-custom-metadata-to-a-connected-account), or [device](https://docs.seam.co/latest/core-concepts/devices/adding-custom-metadata-to-a-device), enables you to store custom information, like customer details or internal IDs from your application.',
+              'Set of key:value pairs. Adding custom metadata to a resource, such as a [Connect Webview](https://docs.seam.co/core-concepts/connect-webviews/attaching-custom-data-to-the-connect-webview), [connected account](https://docs.seam.co/core-concepts/connected-accounts/adding-custom-metadata-to-a-connected-account), or [device](https://docs.seam.co/core-concepts/devices/adding-custom-metadata-to-a-device), enables you to store custom information, like customer details or internal IDs from your application.',
             type: 'object',
           },
           custom_redirect_failure_url: {
@@ -11844,7 +11844,7 @@ const openapi: OpenAPISpec = {
           },
           selected_provider: {
             description:
-              'Selected provider of the Connect Webview, one of the [provider keys](https://docs.seam.co/latest/core-concepts/connect-webviews/customizing-connect-webviews#customize-the-brands-to-display-in-your-connect-webviews).',
+              'Selected provider of the Connect Webview, one of the [provider keys](https://docs.seam.co/core-concepts/connect-webviews/customizing-connect-webviews#customize-the-brands-to-display-in-your-connect-webviews).',
             nullable: true,
             type: 'string',
           },
@@ -11862,12 +11862,12 @@ const openapi: OpenAPISpec = {
           },
           wait_for_device_creation: {
             description:
-              'Indicates whether Seam should [finish syncing all devices](https://docs.seam.co/latest/core-concepts/connect-webviews/customizing-connect-webviews#wait_for_device_creation) in a newly-connected account before completing the associated Connect Webview.',
+              'Indicates whether Seam should [finish syncing all devices](https://docs.seam.co/core-concepts/connect-webviews/customizing-connect-webviews#wait_for_device_creation) in a newly-connected account before completing the associated Connect Webview.',
             type: 'boolean',
           },
           workspace_id: {
             description:
-              'ID of the [workspace](https://docs.seam.co/latest/core-concepts/workspaces) that contains the Connect Webview.',
+              'ID of the [workspace](https://docs.seam.co/core-concepts/workspaces) that contains the Connect Webview.',
             format: 'uuid',
             type: 'string',
           },
@@ -11899,7 +11899,7 @@ const openapi: OpenAPISpec = {
       },
       connected_account: {
         description:
-          'Represents a [connected account](https://docs.seam.co/latest/core-concepts/connected-accounts). A connected account is an external third-party account to which your user has authorized Seam to get access, for example, an August account with a list of door locks.',
+          'Represents a [connected account](https://docs.seam.co/core-concepts/connected-accounts). A connected account is an external third-party account to which your user has authorized Seam to get access, for example, an August account with a list of door locks.',
         properties: {
           accepted_capabilities: {
             description:
@@ -11928,7 +11928,7 @@ const openapi: OpenAPISpec = {
           },
           automatically_manage_new_devices: {
             description:
-              'Indicates whether Seam should [import all new devices](https://docs.seam.co/latest/core-concepts/connect-webviews/customizing-connect-webviews#automatically_manage_new_devices) for the connected account to make these devices available for management by the Seam API.',
+              'Indicates whether Seam should [import all new devices](https://docs.seam.co/core-concepts/connect-webviews/customizing-connect-webviews#automatically_manage_new_devices) for the connected account to make these devices available for management by the Seam API.',
             type: 'boolean',
           },
           connected_account_id: {
@@ -11947,7 +11947,7 @@ const openapi: OpenAPISpec = {
               oneOf: [{ type: 'string' }, { type: 'boolean' }],
             },
             description:
-              'Set of key:value pairs. Adding custom metadata to a resource, such as a [Connect Webview](https://docs.seam.co/latest/core-concepts/connect-webviews/attaching-custom-data-to-the-connect-webview), [connected account](https://docs.seam.co/latest/core-concepts/connected-accounts/adding-custom-metadata-to-a-connected-account), or [device](https://docs.seam.co/latest/core-concepts/devices/adding-custom-metadata-to-a-device), enables you to store custom information, like customer details or internal IDs from your application.',
+              'Set of key:value pairs. Adding custom metadata to a resource, such as a [Connect Webview](https://docs.seam.co/core-concepts/connect-webviews/attaching-custom-data-to-the-connect-webview), [connected account](https://docs.seam.co/core-concepts/connected-accounts/adding-custom-metadata-to-a-connected-account), or [device](https://docs.seam.co/core-concepts/devices/adding-custom-metadata-to-a-device), enables you to store custom information, like customer details or internal IDs from your application.',
             type: 'object',
           },
           customer_key: {
@@ -11991,7 +11991,7 @@ const openapi: OpenAPISpec = {
                     },
                     is_bridge_error: {
                       description:
-                        'Indicates whether the error is related to [Seam Bridge](https://docs.seam.co/latest/capability-guides/seam-bridge).',
+                        'Indicates whether the error is related to [Seam Bridge](https://docs.seam.co/capability-guides/seam-bridge).',
                       type: 'boolean',
                     },
                     is_connected_account_error: {
@@ -12010,7 +12010,7 @@ const openapi: OpenAPISpec = {
                 },
                 {
                   description:
-                    'Indicates that the Seam API cannot communicate with [Seam Bridge](https://docs.seam.co/latest/capability-guides/seam-bridge), for example, if the Seam Bridge executable has stopped or if the computer running the Seam Bridge executable is offline. See also [Troubleshooting Your Access Control System](https://docs.seam.co/latest/capability-guides/access-systems/troubleshooting-your-access-control-system#acs_system.errors.seam_bridge_disconnected).',
+                    'Indicates that the Seam API cannot communicate with [Seam Bridge](https://docs.seam.co/capability-guides/seam-bridge), for example, if the Seam Bridge executable has stopped or if the computer running the Seam Bridge executable is offline. See also [Troubleshooting Your Access Control System](https://docs.seam.co/capability-guides/access-systems/troubleshooting-your-access-control-system#acs_system.errors.seam_bridge_disconnected).',
                   properties: {
                     created_at: {
                       description:
@@ -12026,7 +12026,7 @@ const openapi: OpenAPISpec = {
                     },
                     is_bridge_error: {
                       description:
-                        'Indicates whether the error is related to [Seam Bridge](https://docs.seam.co/latest/capability-guides/seam-bridge).',
+                        'Indicates whether the error is related to [Seam Bridge](https://docs.seam.co/capability-guides/seam-bridge).',
                       type: 'boolean',
                     },
                     is_connected_account_error: {
@@ -12061,7 +12061,7 @@ const openapi: OpenAPISpec = {
                     },
                     is_bridge_error: {
                       description:
-                        'Indicates whether the error is related to [Seam Bridge](https://docs.seam.co/latest/capability-guides/seam-bridge).',
+                        'Indicates whether the error is related to [Seam Bridge](https://docs.seam.co/capability-guides/seam-bridge).',
                       type: 'boolean',
                     },
                     is_connected_account_error: {
@@ -12431,7 +12431,7 @@ const openapi: OpenAPISpec = {
           },
           workspace_id: {
             description:
-              'ID of the [workspace](https://docs.seam.co/latest/core-concepts/workspaces) associated with the customer.',
+              'ID of the [workspace](https://docs.seam.co/core-concepts/workspaces) associated with the customer.',
             format: 'uuid',
             type: 'string',
           },
@@ -12468,7 +12468,7 @@ const openapi: OpenAPISpec = {
           },
           workspace_id: {
             description:
-              'ID of the [workspace](https://docs.seam.co/latest/core-concepts/workspaces) associated with the customer portal.',
+              'ID of the [workspace](https://docs.seam.co/core-concepts/workspaces) associated with the customer portal.',
             format: 'uuid',
             type: 'string',
           },
@@ -12516,7 +12516,7 @@ const openapi: OpenAPISpec = {
       },
       device: {
         description:
-          'Represents a [device](https://docs.seam.co/latest/core-concepts/devices) that has been connected to Seam.',
+          'Represents a [device](https://docs.seam.co/core-concepts/devices) that has been connected to Seam.',
         properties: {
           can_configure_auto_lock: { type: 'boolean' },
           can_hvac_cool: { type: 'boolean' },
@@ -12544,10 +12544,10 @@ const openapi: OpenAPISpec = {
           can_unlock_with_code: { type: 'boolean' },
           capabilities_supported: {
             description:
-              '\n        Collection of capabilities that the device supports when connected to Seam. Values are `access_code`, which indicates that the device can manage and utilize digital PIN codes for secure access; `lock`, which indicates that the device controls a door locking mechanism, enabling the remote opening and closing of doors and other entry points; `noise_detection`, which indicates that the device supports monitoring and responding to ambient noise levels; `thermostat`, which indicates that the device can regulate and adjust indoor temperatures; `battery`, which indicates that the device can manage battery life and health; and `phone`, which indicates that the device is a mobile device, such as a smartphone. **Important:** Superseded by [capability flags](https://docs.seam.co/latest/capability-guides/device-and-system-capabilities#capability-flags).\n        ',
+              '\n        Collection of capabilities that the device supports when connected to Seam. Values are `access_code`, which indicates that the device can manage and utilize digital PIN codes for secure access; `lock`, which indicates that the device controls a door locking mechanism, enabling the remote opening and closing of doors and other entry points; `noise_detection`, which indicates that the device supports monitoring and responding to ambient noise levels; `thermostat`, which indicates that the device can regulate and adjust indoor temperatures; `battery`, which indicates that the device can manage battery life and health; and `phone`, which indicates that the device is a mobile device, such as a smartphone. **Important:** Superseded by [capability flags](https://docs.seam.co/capability-guides/device-and-system-capabilities#capability-flags).\n        ',
             items: {
               description:
-                '\n        Collection of capabilities that the device supports when connected to Seam. **Important:** Superseded by [capability flags](https://docs.seam.co/latest/capability-guides/device-and-system-capabilities#capability-flags).\n        ',
+                '\n        Collection of capabilities that the device supports when connected to Seam. **Important:** Superseded by [capability flags](https://docs.seam.co/capability-guides/device-and-system-capabilities#capability-flags).\n        ',
               enum: [
                 'access_code',
                 'lock',
@@ -12577,7 +12577,7 @@ const openapi: OpenAPISpec = {
               oneOf: [{ type: 'string' }, { type: 'boolean' }],
             },
             description:
-              'Set of key:value pairs. Adding custom metadata to a resource, such as a [Connect Webview](https://docs.seam.co/latest/core-concepts/connect-webviews/attaching-custom-data-to-the-connect-webview), [connected account](https://docs.seam.co/latest/core-concepts/connected-accounts/adding-custom-metadata-to-a-connected-account), or [device](https://docs.seam.co/latest/core-concepts/devices/adding-custom-metadata-to-a-device), enables you to store custom information, like customer details or internal IDs from your application.',
+              'Set of key:value pairs. Adding custom metadata to a resource, such as a [Connect Webview](https://docs.seam.co/core-concepts/connect-webviews/attaching-custom-data-to-the-connect-webview), [connected account](https://docs.seam.co/core-concepts/connected-accounts/adding-custom-metadata-to-a-connected-account), or [device](https://docs.seam.co/core-concepts/devices/adding-custom-metadata-to-a-device), enables you to store custom information, like customer details or internal IDs from your application.',
             type: 'object',
           },
           device_id: {
@@ -12740,7 +12740,7 @@ const openapi: OpenAPISpec = {
                     },
                     is_connected_account_error: {
                       description:
-                        'Indicates that the error is a [connected account](https://docs.seam.co/latest/api/connected_accounts) error.',
+                        'Indicates that the error is a [connected account](https://docs.seam.co/api/connected_accounts) error.',
                       enum: [true],
                       type: 'boolean',
                     },
@@ -12783,7 +12783,7 @@ const openapi: OpenAPISpec = {
                     },
                     is_connected_account_error: {
                       description:
-                        'Indicates that the error is a [connected account](https://docs.seam.co/latest/api/connected_accounts) error.',
+                        'Indicates that the error is a [connected account](https://docs.seam.co/api/connected_accounts) error.',
                       enum: [true],
                       type: 'boolean',
                     },
@@ -12953,7 +12953,7 @@ const openapi: OpenAPISpec = {
                 },
                 {
                   description:
-                    'Indicates that the [backup access code pool](https://docs.seam.co/latest/capability-guides/smart-locks/access-codes/backup-access-codes) is empty.',
+                    'Indicates that the [backup access code pool](https://docs.seam.co/capability-guides/smart-locks/access-codes/backup-access-codes) is empty.',
                   properties: {
                     created_at: {
                       description:
@@ -13249,7 +13249,7 @@ const openapi: OpenAPISpec = {
                 },
                 {
                   description:
-                    'Indicates that the Seam API cannot communicate with [Seam Bridge](https://docs.seam.co/latest/capability-guides/seam-bridge), for example, if the Seam Bridge executable has stopped or if the computer running the Seam Bridge executable is offline. See also [Troubleshooting Your Access Control System](https://docs.seam.co/latest/capability-guides/access-systems/troubleshooting-your-access-control-system#acs_system.errors.seam_bridge_disconnected).',
+                    'Indicates that the Seam API cannot communicate with [Seam Bridge](https://docs.seam.co/capability-guides/seam-bridge), for example, if the Seam Bridge executable has stopped or if the computer running the Seam Bridge executable is offline. See also [Troubleshooting Your Access Control System](https://docs.seam.co/capability-guides/access-systems/troubleshooting-your-access-control-system#acs_system.errors.seam_bridge_disconnected).',
                   properties: {
                     created_at: {
                       description:
@@ -13265,7 +13265,7 @@ const openapi: OpenAPISpec = {
                     },
                     is_bridge_error: {
                       description:
-                        'Indicates whether the error is related to [Seam Bridge](https://docs.seam.co/latest/capability-guides/seam-bridge).',
+                        'Indicates whether the error is related to [Seam Bridge](https://docs.seam.co/capability-guides/seam-bridge).',
                       type: 'boolean',
                     },
                     is_connected_account_error: {
@@ -13297,7 +13297,7 @@ const openapi: OpenAPISpec = {
           },
           is_managed: {
             description:
-              'Indicates whether Seam manages the device. See also [Managed and Unmanaged Devices](https://docs.seam.co/latest/core-concepts/devices/managed-and-unmanaged-devices).',
+              'Indicates whether Seam manages the device. See also [Managed and Unmanaged Devices](https://docs.seam.co/core-concepts/devices/managed-and-unmanaged-devices).',
             enum: [true],
             type: 'boolean',
           },
@@ -15114,7 +15114,7 @@ const openapi: OpenAPISpec = {
                       },
                       supports_backup_access_code_pool: {
                         description:
-                          'Indicates whether the device supports a [backup access code pool](https://docs.seam.co/latest/capability-guides/smart-locks/access-codes/backup-access-codes).',
+                          'Indicates whether the device supports a [backup access code pool](https://docs.seam.co/capability-guides/smart-locks/access-codes/backup-access-codes).',
                         type: 'boolean',
                         'x-property-group-key': 'access_codes',
                       },
@@ -15126,35 +15126,35 @@ const openapi: OpenAPISpec = {
                       active_thermostat_schedule: {
                         deprecated: true,
                         description:
-                          'Active [thermostat schedule](https://docs.seam.co/latest/capability-guides/thermostats/creating-and-managing-thermostat-schedules).',
+                          'Active [thermostat schedule](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-thermostat-schedules).',
                         nullable: true,
                         properties: {
                           climate_preset_key: {
                             description:
-                              'Key of the [climate preset](https://docs.seam.co/latest/capability-guides/thermostats/creating-and-managing-climate-presets) to use for the [thermostat schedule](https://docs.seam.co/latest/capability-guides/thermostats/creating-and-managing-thermostat-schedules).',
+                              'Key of the [climate preset](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-climate-presets) to use for the [thermostat schedule](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-thermostat-schedules).',
                             type: 'string',
                           },
                           created_at: {
                             description:
-                              'Date and time at which the [thermostat schedule](https://docs.seam.co/latest/capability-guides/thermostats/creating-and-managing-thermostat-schedules) was created.',
+                              'Date and time at which the [thermostat schedule](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-thermostat-schedules) was created.',
                             format: 'date-time',
                             type: 'string',
                           },
                           device_id: {
                             description:
-                              'ID of the desired [thermostat](https://docs.seam.co/latest/capability-guides/thermostats) device.',
+                              'ID of the desired [thermostat](https://docs.seam.co/capability-guides/thermostats) device.',
                             format: 'uuid',
                             type: 'string',
                           },
                           ends_at: {
                             description:
-                              'Date and time at which the [thermostat schedule](https://docs.seam.co/latest/capability-guides/thermostats/creating-and-managing-thermostat-schedules) ends, in [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) format.',
+                              'Date and time at which the [thermostat schedule](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-thermostat-schedules) ends, in [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) format.',
                             format: 'date-time',
                             type: 'string',
                           },
                           errors: {
                             description:
-                              'Errors associated with the [thermostat schedule](https://docs.seam.co/latest/capability-guides/thermostats/creating-and-managing-thermostat-schedules).',
+                              'Errors associated with the [thermostat schedule](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-thermostat-schedules).',
                             items: {
                               properties: {
                                 error_code: {
@@ -15175,12 +15175,12 @@ const openapi: OpenAPISpec = {
                           },
                           is_override_allowed: {
                             description:
-                              "Indicates whether a person at the thermostat can change the thermostat's settings after the [thermostat schedule](https://docs.seam.co/latest/capability-guides/thermostats/creating-and-managing-thermostat-schedules) starts.",
+                              "Indicates whether a person at the thermostat can change the thermostat's settings after the [thermostat schedule](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-thermostat-schedules) starts.",
                             type: 'boolean',
                           },
                           max_override_period_minutes: {
                             description:
-                              "Number of minutes for which a person at the thermostat can change the thermostat's settings after the activation of the scheduled [climate preset](https://docs.seam.co/latest/capability-guides/thermostats/creating-and-managing-climate-presets). See also [Specifying Manual Override Permissions](https://docs.seam.co/latest/capability-guides/thermostats/creating-and-managing-thermostat-schedules#specifying-manual-override-permissions).",
+                              "Number of minutes for which a person at the thermostat can change the thermostat's settings after the activation of the scheduled [climate preset](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-climate-presets). See also [Specifying Manual Override Permissions](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-thermostat-schedules#specifying-manual-override-permissions).",
                             exclusiveMinimum: true,
                             minimum: 0,
                             nullable: true,
@@ -15188,25 +15188,25 @@ const openapi: OpenAPISpec = {
                           },
                           name: {
                             description:
-                              'User-friendly name to identify the [thermostat schedule](https://docs.seam.co/latest/capability-guides/thermostats/creating-and-managing-thermostat-schedules).',
+                              'User-friendly name to identify the [thermostat schedule](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-thermostat-schedules).',
                             nullable: true,
                             type: 'string',
                           },
                           starts_at: {
                             description:
-                              'Date and time at which the [thermostat schedule](https://docs.seam.co/latest/capability-guides/thermostats/creating-and-managing-thermostat-schedules) starts, in [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) format.',
+                              'Date and time at which the [thermostat schedule](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-thermostat-schedules) starts, in [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) format.',
                             format: 'date-time',
                             type: 'string',
                           },
                           thermostat_schedule_id: {
                             description:
-                              'ID of the [thermostat schedule](https://docs.seam.co/latest/capability-guides/thermostats/creating-and-managing-thermostat-schedules).',
+                              'ID of the [thermostat schedule](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-thermostat-schedules).',
                             format: 'uuid',
                             type: 'string',
                           },
                           workspace_id: {
                             description:
-                              'ID of the [workspace](https://docs.seam.co/latest/core-concepts/workspaces) that contains the thermostat schedule.',
+                              'ID of the [workspace](https://docs.seam.co/core-concepts/workspaces) that contains the thermostat schedule.',
                             format: 'uuid',
                             type: 'string',
                           },
@@ -15230,7 +15230,7 @@ const openapi: OpenAPISpec = {
                       },
                       active_thermostat_schedule_id: {
                         description:
-                          'ID of the active [thermostat schedule](https://docs.seam.co/latest/capability-guides/thermostats/creating-and-managing-thermostat-schedules).',
+                          'ID of the active [thermostat schedule](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-thermostat-schedules).',
                         format: 'uuid',
                         nullable: true,
                         type: 'string',
@@ -15256,27 +15256,27 @@ const openapi: OpenAPISpec = {
                       },
                       available_climate_presets: {
                         description:
-                          'Available [climate presets](https://docs.seam.co/latest/capability-guides/thermostats/creating-and-managing-climate-presets) for the thermostat.',
+                          'Available [climate presets](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-climate-presets) for the thermostat.',
                         items: {
                           properties: {
                             can_delete: {
                               description:
-                                'Indicates whether the [climate preset](https://docs.seam.co/latest/capability-guides/thermostats/creating-and-managing-climate-presets) key can be deleted.',
+                                'Indicates whether the [climate preset](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-climate-presets) key can be deleted.',
                               type: 'boolean',
                             },
                             can_edit: {
                               description:
-                                'Indicates whether the [climate preset](https://docs.seam.co/latest/capability-guides/thermostats/creating-and-managing-climate-presets) key can be edited.',
+                                'Indicates whether the [climate preset](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-climate-presets) key can be edited.',
                               type: 'boolean',
                             },
                             can_use_with_thermostat_daily_programs: {
                               description:
-                                'Indicates whether the [climate preset](https://docs.seam.co/latest/capability-guides/thermostats/creating-and-managing-climate-presets) key can be programmed in a thermostat daily program.',
+                                'Indicates whether the [climate preset](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-climate-presets) key can be programmed in a thermostat daily program.',
                               type: 'boolean',
                             },
                             climate_preset_key: {
                               description:
-                                'Unique key to identify the [climate preset](https://docs.seam.co/latest/capability-guides/thermostats/creating-and-managing-climate-presets).',
+                                'Unique key to identify the [climate preset](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-climate-presets).',
                               type: 'string',
                             },
                             climate_preset_mode: {
@@ -15294,19 +15294,19 @@ const openapi: OpenAPISpec = {
                             },
                             cooling_set_point_celsius: {
                               description:
-                                'Temperature to which the thermostat should cool (in °C). See also [Set Points](https://docs.seam.co/latest/capability-guides/thermostats/understanding-thermostat-concepts/set-points).',
+                                'Temperature to which the thermostat should cool (in °C). See also [Set Points](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/set-points).',
                               format: 'float',
                               type: 'number',
                             },
                             cooling_set_point_fahrenheit: {
                               description:
-                                'Temperature to which the thermostat should cool (in °F). See also [Set Points](https://docs.seam.co/latest/capability-guides/thermostats/understanding-thermostat-concepts/set-points).',
+                                'Temperature to which the thermostat should cool (in °F). See also [Set Points](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/set-points).',
                               format: 'float',
                               type: 'number',
                             },
                             display_name: {
                               description:
-                                'Display name for the [climate preset](https://docs.seam.co/latest/capability-guides/thermostats/creating-and-managing-climate-presets).',
+                                'Display name for the [climate preset](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-climate-presets).',
                               type: 'string',
                             },
                             ecobee_metadata: {
@@ -15339,32 +15339,32 @@ const openapi: OpenAPISpec = {
                             },
                             fan_mode_setting: {
                               description:
-                                'Desired [fan mode setting](https://docs.seam.co/latest/capability-guides/thermostats/configure-current-climate-settings#fan-mode-settings), such as `on`, `auto`, or `circulate`.',
+                                'Desired [fan mode setting](https://docs.seam.co/capability-guides/thermostats/configure-current-climate-settings#fan-mode-settings), such as `on`, `auto`, or `circulate`.',
                               enum: ['auto', 'on', 'circulate'],
                               type: 'string',
                             },
                             heating_set_point_celsius: {
                               description:
-                                'Temperature to which the thermostat should heat (in °C). See also [Set Points](https://docs.seam.co/latest/capability-guides/thermostats/understanding-thermostat-concepts/set-points).',
+                                'Temperature to which the thermostat should heat (in °C). See also [Set Points](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/set-points).',
                               format: 'float',
                               type: 'number',
                             },
                             heating_set_point_fahrenheit: {
                               description:
-                                'Temperature to which the thermostat should heat (in °F). See also [Set Points](https://docs.seam.co/latest/capability-guides/thermostats/understanding-thermostat-concepts/set-points).',
+                                'Temperature to which the thermostat should heat (in °F). See also [Set Points](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/set-points).',
                               format: 'float',
                               type: 'number',
                             },
                             hvac_mode_setting: {
                               description:
-                                'Desired [HVAC mode](https://docs.seam.co/latest/capability-guides/thermostats/understanding-thermostat-concepts/hvac-mode) setting, such as `heat`, `cool`, `heat_cool`, or `off`.',
+                                'Desired [HVAC mode](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/hvac-mode) setting, such as `heat`, `cool`, `heat_cool`, or `off`.',
                               enum: ['off', 'heat', 'cool', 'heat_cool', 'eco'],
                               type: 'string',
                             },
                             manual_override_allowed: {
                               deprecated: true,
                               description:
-                                "Indicates whether a person at the thermostat can change the thermostat's settings. See [Specifying Manual Override Permissions](https://docs.seam.co/latest/capability-guides/thermostats/creating-and-managing-thermostat-schedules#specifying-manual-override-permissions).",
+                                "Indicates whether a person at the thermostat can change the thermostat's settings. See [Specifying Manual Override Permissions](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-thermostat-schedules#specifying-manual-override-permissions).",
                               type: 'boolean',
                               'x-deprecated':
                                 "Use 'thermostat_schedule.is_override_allowed'",
@@ -15372,7 +15372,7 @@ const openapi: OpenAPISpec = {
                             name: {
                               default: null,
                               description:
-                                'User-friendly name to identify the [climate preset](https://docs.seam.co/latest/capability-guides/thermostats/creating-and-managing-climate-presets).',
+                                'User-friendly name to identify the [climate preset](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-climate-presets).',
                               nullable: true,
                               type: 'string',
                             },
@@ -15415,22 +15415,22 @@ const openapi: OpenAPISpec = {
                         properties: {
                           can_delete: {
                             description:
-                              'Indicates whether the [climate preset](https://docs.seam.co/latest/capability-guides/thermostats/creating-and-managing-climate-presets) key can be deleted.',
+                              'Indicates whether the [climate preset](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-climate-presets) key can be deleted.',
                             type: 'boolean',
                           },
                           can_edit: {
                             description:
-                              'Indicates whether the [climate preset](https://docs.seam.co/latest/capability-guides/thermostats/creating-and-managing-climate-presets) key can be edited.',
+                              'Indicates whether the [climate preset](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-climate-presets) key can be edited.',
                             type: 'boolean',
                           },
                           can_use_with_thermostat_daily_programs: {
                             description:
-                              'Indicates whether the [climate preset](https://docs.seam.co/latest/capability-guides/thermostats/creating-and-managing-climate-presets) key can be programmed in a thermostat daily program.',
+                              'Indicates whether the [climate preset](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-climate-presets) key can be programmed in a thermostat daily program.',
                             type: 'boolean',
                           },
                           climate_preset_key: {
                             description:
-                              'Unique key to identify the [climate preset](https://docs.seam.co/latest/capability-guides/thermostats/creating-and-managing-climate-presets).',
+                              'Unique key to identify the [climate preset](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-climate-presets).',
                             type: 'string',
                           },
                           climate_preset_mode: {
@@ -15448,19 +15448,19 @@ const openapi: OpenAPISpec = {
                           },
                           cooling_set_point_celsius: {
                             description:
-                              'Temperature to which the thermostat should cool (in °C). See also [Set Points](https://docs.seam.co/latest/capability-guides/thermostats/understanding-thermostat-concepts/set-points).',
+                              'Temperature to which the thermostat should cool (in °C). See also [Set Points](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/set-points).',
                             format: 'float',
                             type: 'number',
                           },
                           cooling_set_point_fahrenheit: {
                             description:
-                              'Temperature to which the thermostat should cool (in °F). See also [Set Points](https://docs.seam.co/latest/capability-guides/thermostats/understanding-thermostat-concepts/set-points).',
+                              'Temperature to which the thermostat should cool (in °F). See also [Set Points](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/set-points).',
                             format: 'float',
                             type: 'number',
                           },
                           display_name: {
                             description:
-                              'Display name for the [climate preset](https://docs.seam.co/latest/capability-guides/thermostats/creating-and-managing-climate-presets).',
+                              'Display name for the [climate preset](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-climate-presets).',
                             type: 'string',
                           },
                           ecobee_metadata: {
@@ -15489,32 +15489,32 @@ const openapi: OpenAPISpec = {
                           },
                           fan_mode_setting: {
                             description:
-                              'Desired [fan mode setting](https://docs.seam.co/latest/capability-guides/thermostats/configure-current-climate-settings#fan-mode-settings), such as `on`, `auto`, or `circulate`.',
+                              'Desired [fan mode setting](https://docs.seam.co/capability-guides/thermostats/configure-current-climate-settings#fan-mode-settings), such as `on`, `auto`, or `circulate`.',
                             enum: ['auto', 'on', 'circulate'],
                             type: 'string',
                           },
                           heating_set_point_celsius: {
                             description:
-                              'Temperature to which the thermostat should heat (in °C). See also [Set Points](https://docs.seam.co/latest/capability-guides/thermostats/understanding-thermostat-concepts/set-points).',
+                              'Temperature to which the thermostat should heat (in °C). See also [Set Points](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/set-points).',
                             format: 'float',
                             type: 'number',
                           },
                           heating_set_point_fahrenheit: {
                             description:
-                              'Temperature to which the thermostat should heat (in °F). See also [Set Points](https://docs.seam.co/latest/capability-guides/thermostats/understanding-thermostat-concepts/set-points).',
+                              'Temperature to which the thermostat should heat (in °F). See also [Set Points](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/set-points).',
                             format: 'float',
                             type: 'number',
                           },
                           hvac_mode_setting: {
                             description:
-                              'Desired [HVAC mode](https://docs.seam.co/latest/capability-guides/thermostats/understanding-thermostat-concepts/hvac-mode) setting, such as `heat`, `cool`, `heat_cool`, or `off`.',
+                              'Desired [HVAC mode](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/hvac-mode) setting, such as `heat`, `cool`, `heat_cool`, or `off`.',
                             enum: ['off', 'heat', 'cool', 'heat_cool', 'eco'],
                             type: 'string',
                           },
                           manual_override_allowed: {
                             deprecated: true,
                             description:
-                              "Indicates whether a person at the thermostat can change the thermostat's settings. See [Specifying Manual Override Permissions](https://docs.seam.co/latest/capability-guides/thermostats/creating-and-managing-thermostat-schedules#specifying-manual-override-permissions).",
+                              "Indicates whether a person at the thermostat can change the thermostat's settings. See [Specifying Manual Override Permissions](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-thermostat-schedules#specifying-manual-override-permissions).",
                             type: 'boolean',
                             'x-deprecated':
                               "Use 'thermostat_schedule.is_override_allowed'",
@@ -15522,7 +15522,7 @@ const openapi: OpenAPISpec = {
                           name: {
                             default: null,
                             description:
-                              'User-friendly name to identify the [climate preset](https://docs.seam.co/latest/capability-guides/thermostats/creating-and-managing-climate-presets).',
+                              'User-friendly name to identify the [climate preset](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-climate-presets).',
                             nullable: true,
                             type: 'string',
                           },
@@ -15535,22 +15535,22 @@ const openapi: OpenAPISpec = {
                         properties: {
                           can_delete: {
                             description:
-                              'Indicates whether the [climate preset](https://docs.seam.co/latest/capability-guides/thermostats/creating-and-managing-climate-presets) key can be deleted.',
+                              'Indicates whether the [climate preset](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-climate-presets) key can be deleted.',
                             type: 'boolean',
                           },
                           can_edit: {
                             description:
-                              'Indicates whether the [climate preset](https://docs.seam.co/latest/capability-guides/thermostats/creating-and-managing-climate-presets) key can be edited.',
+                              'Indicates whether the [climate preset](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-climate-presets) key can be edited.',
                             type: 'boolean',
                           },
                           can_use_with_thermostat_daily_programs: {
                             description:
-                              'Indicates whether the [climate preset](https://docs.seam.co/latest/capability-guides/thermostats/creating-and-managing-climate-presets) key can be programmed in a thermostat daily program.',
+                              'Indicates whether the [climate preset](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-climate-presets) key can be programmed in a thermostat daily program.',
                             type: 'boolean',
                           },
                           climate_preset_key: {
                             description:
-                              'Unique key to identify the [climate preset](https://docs.seam.co/latest/capability-guides/thermostats/creating-and-managing-climate-presets).',
+                              'Unique key to identify the [climate preset](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-climate-presets).',
                             type: 'string',
                           },
                           climate_preset_mode: {
@@ -15568,19 +15568,19 @@ const openapi: OpenAPISpec = {
                           },
                           cooling_set_point_celsius: {
                             description:
-                              'Temperature to which the thermostat should cool (in °C). See also [Set Points](https://docs.seam.co/latest/capability-guides/thermostats/understanding-thermostat-concepts/set-points).',
+                              'Temperature to which the thermostat should cool (in °C). See also [Set Points](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/set-points).',
                             format: 'float',
                             type: 'number',
                           },
                           cooling_set_point_fahrenheit: {
                             description:
-                              'Temperature to which the thermostat should cool (in °F). See also [Set Points](https://docs.seam.co/latest/capability-guides/thermostats/understanding-thermostat-concepts/set-points).',
+                              'Temperature to which the thermostat should cool (in °F). See also [Set Points](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/set-points).',
                             format: 'float',
                             type: 'number',
                           },
                           display_name: {
                             description:
-                              'Display name for the [climate preset](https://docs.seam.co/latest/capability-guides/thermostats/creating-and-managing-climate-presets).',
+                              'Display name for the [climate preset](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-climate-presets).',
                             type: 'string',
                           },
                           ecobee_metadata: {
@@ -15609,32 +15609,32 @@ const openapi: OpenAPISpec = {
                           },
                           fan_mode_setting: {
                             description:
-                              'Desired [fan mode setting](https://docs.seam.co/latest/capability-guides/thermostats/configure-current-climate-settings#fan-mode-settings), such as `on`, `auto`, or `circulate`.',
+                              'Desired [fan mode setting](https://docs.seam.co/capability-guides/thermostats/configure-current-climate-settings#fan-mode-settings), such as `on`, `auto`, or `circulate`.',
                             enum: ['auto', 'on', 'circulate'],
                             type: 'string',
                           },
                           heating_set_point_celsius: {
                             description:
-                              'Temperature to which the thermostat should heat (in °C). See also [Set Points](https://docs.seam.co/latest/capability-guides/thermostats/understanding-thermostat-concepts/set-points).',
+                              'Temperature to which the thermostat should heat (in °C). See also [Set Points](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/set-points).',
                             format: 'float',
                             type: 'number',
                           },
                           heating_set_point_fahrenheit: {
                             description:
-                              'Temperature to which the thermostat should heat (in °F). See also [Set Points](https://docs.seam.co/latest/capability-guides/thermostats/understanding-thermostat-concepts/set-points).',
+                              'Temperature to which the thermostat should heat (in °F). See also [Set Points](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/set-points).',
                             format: 'float',
                             type: 'number',
                           },
                           hvac_mode_setting: {
                             description:
-                              'Desired [HVAC mode](https://docs.seam.co/latest/capability-guides/thermostats/understanding-thermostat-concepts/hvac-mode) setting, such as `heat`, `cool`, `heat_cool`, or `off`.',
+                              'Desired [HVAC mode](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/hvac-mode) setting, such as `heat`, `cool`, `heat_cool`, or `off`.',
                             enum: ['off', 'heat', 'cool', 'heat_cool', 'eco'],
                             type: 'string',
                           },
                           manual_override_allowed: {
                             deprecated: true,
                             description:
-                              "Indicates whether a person at the thermostat can change the thermostat's settings. See [Specifying Manual Override Permissions](https://docs.seam.co/latest/capability-guides/thermostats/creating-and-managing-thermostat-schedules#specifying-manual-override-permissions).",
+                              "Indicates whether a person at the thermostat can change the thermostat's settings. See [Specifying Manual Override Permissions](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-thermostat-schedules#specifying-manual-override-permissions).",
                             type: 'boolean',
                             'x-deprecated':
                               "Use 'thermostat_schedule.is_override_allowed'",
@@ -15642,7 +15642,7 @@ const openapi: OpenAPISpec = {
                           name: {
                             default: null,
                             description:
-                              'User-friendly name to identify the [climate preset](https://docs.seam.co/latest/capability-guides/thermostats/creating-and-managing-climate-presets).',
+                              'User-friendly name to identify the [climate preset](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-climate-presets).',
                             nullable: true,
                             type: 'string',
                           },
@@ -15654,7 +15654,7 @@ const openapi: OpenAPISpec = {
                       },
                       fallback_climate_preset_key: {
                         description:
-                          'Key of the [fallback climate preset](https://docs.seam.co/latest/capability-guides/thermostats/creating-and-managing-climate-presets/setting-the-fallback-climate-preset) for the thermostat.',
+                          'Key of the [fallback climate preset](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-climate-presets/setting-the-fallback-climate-preset) for the thermostat.',
                         minLength: 1,
                         nullable: true,
                         type: 'string',
@@ -15694,28 +15694,28 @@ const openapi: OpenAPISpec = {
                       },
                       max_cooling_set_point_celsius: {
                         description:
-                          'Maximum [cooling set point](https://docs.seam.co/latest/capability-guides/thermostats/understanding-thermostat-concepts/set-points#cooling-set-point) in °C.',
+                          'Maximum [cooling set point](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/set-points#cooling-set-point) in °C.',
                         format: 'float',
                         type: 'number',
                         'x-property-group-key': 'thermostats',
                       },
                       max_cooling_set_point_fahrenheit: {
                         description:
-                          'Maximum [cooling set point](https://docs.seam.co/latest/capability-guides/thermostats/understanding-thermostat-concepts/set-points#cooling-set-point) in °F.',
+                          'Maximum [cooling set point](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/set-points#cooling-set-point) in °F.',
                         format: 'float',
                         type: 'number',
                         'x-property-group-key': 'thermostats',
                       },
                       max_heating_set_point_celsius: {
                         description:
-                          'Maximum [heating set point](https://docs.seam.co/latest/capability-guides/thermostats/understanding-thermostat-concepts/set-points#heating-set-point) in °C.',
+                          'Maximum [heating set point](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/set-points#heating-set-point) in °C.',
                         format: 'float',
                         type: 'number',
                         'x-property-group-key': 'thermostats',
                       },
                       max_heating_set_point_fahrenheit: {
                         description:
-                          'Maximum [heating set point](https://docs.seam.co/latest/capability-guides/thermostats/understanding-thermostat-concepts/set-points#heating-set-point) in °F.',
+                          'Maximum [heating set point](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/set-points#heating-set-point) in °F.',
                         format: 'float',
                         type: 'number',
                         'x-property-group-key': 'thermostats',
@@ -15737,42 +15737,42 @@ const openapi: OpenAPISpec = {
                         },
                       min_cooling_set_point_celsius: {
                         description:
-                          'Minimum [cooling set point](https://docs.seam.co/latest/capability-guides/thermostats/understanding-thermostat-concepts/set-points#cooling-set-point) in °C.',
+                          'Minimum [cooling set point](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/set-points#cooling-set-point) in °C.',
                         format: 'float',
                         type: 'number',
                         'x-property-group-key': 'thermostats',
                       },
                       min_cooling_set_point_fahrenheit: {
                         description:
-                          'Minimum [cooling set point](https://docs.seam.co/latest/capability-guides/thermostats/understanding-thermostat-concepts/set-points#cooling-set-point) in °F.',
+                          'Minimum [cooling set point](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/set-points#cooling-set-point) in °F.',
                         format: 'float',
                         type: 'number',
                         'x-property-group-key': 'thermostats',
                       },
                       min_heating_cooling_delta_celsius: {
                         description:
-                          'Minimum [temperature difference](https://docs.seam.co/latest/capability-guides/thermostats/understanding-thermostat-concepts/set-points#minimum-heating-cooling-temperature-delta) in °C between the cooling and heating set points when in heat-cool (auto) mode.',
+                          'Minimum [temperature difference](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/set-points#minimum-heating-cooling-temperature-delta) in °C between the cooling and heating set points when in heat-cool (auto) mode.',
                         format: 'float',
                         type: 'number',
                         'x-property-group-key': 'thermostats',
                       },
                       min_heating_cooling_delta_fahrenheit: {
                         description:
-                          'Minimum [temperature difference](https://docs.seam.co/latest/capability-guides/thermostats/understanding-thermostat-concepts/set-points#minimum-heating-cooling-temperature-delta) in °F between the cooling and heating set points when in heat-cool (auto) mode.',
+                          'Minimum [temperature difference](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/set-points#minimum-heating-cooling-temperature-delta) in °F between the cooling and heating set points when in heat-cool (auto) mode.',
                         format: 'float',
                         type: 'number',
                         'x-property-group-key': 'thermostats',
                       },
                       min_heating_set_point_celsius: {
                         description:
-                          'Minimum [heating set point](https://docs.seam.co/latest/capability-guides/thermostats/understanding-thermostat-concepts/set-points#heating-set-point) in °C.',
+                          'Minimum [heating set point](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/set-points#heating-set-point) in °C.',
                         format: 'float',
                         type: 'number',
                         'x-property-group-key': 'thermostats',
                       },
                       min_heating_set_point_fahrenheit: {
                         description:
-                          'Minimum [heating set point](https://docs.seam.co/latest/capability-guides/thermostats/understanding-thermostat-concepts/set-points#heating-set-point) in °F.',
+                          'Minimum [heating set point](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/set-points#heating-set-point) in °F.',
                         format: 'float',
                         type: 'number',
                         'x-property-group-key': 'thermostats',
@@ -15800,32 +15800,32 @@ const openapi: OpenAPISpec = {
                       },
                       temperature_threshold: {
                         description:
-                          'Current [temperature threshold](https://docs.seam.co/latest/capability-guides/thermostats/setting-and-monitoring-temperature-thresholds) set for the thermostat.',
+                          'Current [temperature threshold](https://docs.seam.co/capability-guides/thermostats/setting-and-monitoring-temperature-thresholds) set for the thermostat.',
                         properties: {
                           lower_limit_celsius: {
                             description:
-                              'Lower limit in °C within the current [temperature threshold](https://docs.seam.co/latest/capability-guides/thermostats/setting-and-monitoring-temperature-thresholds) set for the thermostat.\n          ',
+                              'Lower limit in °C within the current [temperature threshold](https://docs.seam.co/capability-guides/thermostats/setting-and-monitoring-temperature-thresholds) set for the thermostat.\n          ',
                             format: 'float',
                             nullable: true,
                             type: 'number',
                           },
                           lower_limit_fahrenheit: {
                             description:
-                              'Lower limit in °F within the current [temperature threshold](https://docs.seam.co/latest/capability-guides/thermostats/setting-and-monitoring-temperature-thresholds) set for the thermostat.\n          ',
+                              'Lower limit in °F within the current [temperature threshold](https://docs.seam.co/capability-guides/thermostats/setting-and-monitoring-temperature-thresholds) set for the thermostat.\n          ',
                             format: 'float',
                             nullable: true,
                             type: 'number',
                           },
                           upper_limit_celsius: {
                             description:
-                              'Upper limit in °C within the current [temperature threshold](https://docs.seam.co/latest/capability-guides/thermostats/setting-and-monitoring-temperature-thresholds) set for the thermostat.\n          ',
+                              'Upper limit in °C within the current [temperature threshold](https://docs.seam.co/capability-guides/thermostats/setting-and-monitoring-temperature-thresholds) set for the thermostat.\n          ',
                             format: 'float',
                             nullable: true,
                             type: 'number',
                           },
                           upper_limit_fahrenheit: {
                             description:
-                              'Upper limit in °F within the current [temperature threshold](https://docs.seam.co/latest/capability-guides/thermostats/setting-and-monitoring-temperature-thresholds) set for the thermostat.\n          ',
+                              'Upper limit in °F within the current [temperature threshold](https://docs.seam.co/capability-guides/thermostats/setting-and-monitoring-temperature-thresholds) set for the thermostat.\n          ',
                             format: 'float',
                             nullable: true,
                             type: 'number',
@@ -15849,7 +15849,7 @@ const openapi: OpenAPISpec = {
                       },
                       thermostat_daily_programs: {
                         description:
-                          'Configured [daily programs](https://docs.seam.co/latest/capability-guides/thermostats/creating-and-managing-thermostat-programs) for the thermostat.',
+                          'Configured [daily programs](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-thermostat-programs) for the thermostat.',
                         items: {
                           description:
                             'Represents a thermostat daily program, consisting of a set of periods, each of which has a starting time and the key that identifies the climate preset to apply at the starting time.',
@@ -15881,7 +15881,7 @@ const openapi: OpenAPISpec = {
                                 properties: {
                                   climate_preset_key: {
                                     description:
-                                      'Key of the [climate preset](https://docs.seam.co/latest/capability-guides/thermostats/creating-and-managing-climate-presets) to activate at the `starts_at_time`.',
+                                      'Key of the [climate preset](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-climate-presets) to activate at the `starts_at_time`.',
                                     type: 'string',
                                   },
                                   starts_at_time: {
@@ -15908,7 +15908,7 @@ const openapi: OpenAPISpec = {
                             },
                             workspace_id: {
                               description:
-                                'ID of the [workspace](https://docs.seam.co/latest/core-concepts/workspaces) that contains the thermostat daily program.',
+                                'ID of the [workspace](https://docs.seam.co/core-concepts/workspaces) that contains the thermostat daily program.',
                               format: 'uuid',
                               type: 'string',
                             },
@@ -15929,7 +15929,7 @@ const openapi: OpenAPISpec = {
                       },
                       thermostat_weekly_program: {
                         description:
-                          'Current [weekly program](https://docs.seam.co/latest/capability-guides/thermostats/creating-and-managing-thermostat-programs) for the thermostat.',
+                          'Current [weekly program](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-thermostat-programs) for the thermostat.',
                         nullable: true,
                         properties: {
                           created_at: {
@@ -16852,7 +16852,7 @@ const openapi: OpenAPISpec = {
       },
       enrollment_automation: {
         description:
-          'Represents an [enrollment automation](https://docs.seam.co/latest/capability-guides/mobile-access/issuing-mobile-credentials-from-an-access-control-system) within the [Seam mobile access solution](https://docs.seam.co/latest/capability-guides/mobile-access/).',
+          'Represents an [enrollment automation](https://docs.seam.co/capability-guides/mobile-access/issuing-mobile-credentials-from-an-access-control-system) within the [Seam mobile access solution](https://docs.seam.co/capability-guides/mobile-access/).',
         properties: {
           created_at: {
             description:
@@ -16862,7 +16862,7 @@ const openapi: OpenAPISpec = {
           },
           credential_manager_acs_system_id: {
             description:
-              'ID of the associated [ACS system](https://docs.seam.co/latest/capability-guides/access-systems) that serves as the credential manager.',
+              'ID of the associated [ACS system](https://docs.seam.co/capability-guides/access-systems) that serves as the credential manager.',
             format: 'uuid',
             type: 'string',
           },
@@ -16873,13 +16873,13 @@ const openapi: OpenAPISpec = {
           },
           user_identity_id: {
             description:
-              'ID of the associated [user identity](https://docs.seam.co/latest/capability-guides/mobile-access/managing-mobile-app-user-accounts-with-user-identities#what-is-a-user-identity).',
+              'ID of the associated [user identity](https://docs.seam.co/capability-guides/mobile-access/managing-mobile-app-user-accounts-with-user-identities#what-is-a-user-identity).',
             format: 'uuid',
             type: 'string',
           },
           workspace_id: {
             description:
-              'ID of the [workspace](https://docs.seam.co/latest/core-concepts/workspaces) that contains the enrollment automation.',
+              'ID of the [workspace](https://docs.seam.co/core-concepts/workspaces) that contains the enrollment automation.',
             format: 'uuid',
             type: 'string',
           },
@@ -16897,12 +16897,12 @@ const openapi: OpenAPISpec = {
       },
       event: {
         description:
-          "Represents an event. Events let you know when something interesting happens in your workspace. For example, when a lock is unlocked, Seam creates a `lock.unlocked` event. When a device's battery level is low, Seam creates a `device.battery_low` event.\n\nAs with other API resources, you can retrieve an individual event or a list of events. Seam also provides a separate [webhook](https://docs.seam.co/latest/developer-tools/webhooks) system for sending the event objects directly to an endpoint on your sever. Manage webhooks through [Seam Console](https://console.seam.co). You can also use the webhooks sandbox in Seam Console to see the different payloads for each event and test them against your own endpoints.",
+          "Represents an event. Events let you know when something interesting happens in your workspace. For example, when a lock is unlocked, Seam creates a `lock.unlocked` event. When a device's battery level is low, Seam creates a `device.battery_low` event.\n\nAs with other API resources, you can retrieve an individual event or a list of events. Seam also provides a separate [webhook](https://docs.seam.co/developer-tools/webhooks) system for sending the event objects directly to an endpoint on your sever. Manage webhooks through [Seam Console](https://console.seam.co). You can also use the webhooks sandbox in Seam Console to see the different payloads for each event and test them against your own endpoints.",
         discriminator: { propertyName: 'event_type' },
         oneOf: [
           {
             description:
-              'An [access code](https://docs.seam.co/latest/capability-guides/smart-locks/access-codes) was created.',
+              'An [access code](https://docs.seam.co/capability-guides/smart-locks/access-codes) was created.',
             properties: {
               access_code_id: {
                 description: 'ID of the affected access code.',
@@ -16919,7 +16919,7 @@ const openapi: OpenAPISpec = {
               },
               connected_account_id: {
                 description:
-                  'ID of the [connected account](https://docs.seam.co/latest/core-concepts/connected-accounts) associated with the affected access code.',
+                  'ID of the [connected account](https://docs.seam.co/core-concepts/connected-accounts) associated with the affected access code.',
                 format: 'uuid',
                 type: 'string',
               },
@@ -16955,7 +16955,7 @@ const openapi: OpenAPISpec = {
               },
               workspace_id: {
                 description:
-                  'ID of the [workspace](https://docs.seam.co/latest/core-concepts/workspaces) associated with the event.',
+                  'ID of the [workspace](https://docs.seam.co/core-concepts/workspaces) associated with the event.',
                 format: 'uuid',
                 type: 'string',
               },
@@ -16975,7 +16975,7 @@ const openapi: OpenAPISpec = {
           },
           {
             description:
-              'An [access code](https://docs.seam.co/latest/capability-guides/smart-locks/access-codes) was changed.',
+              'An [access code](https://docs.seam.co/capability-guides/smart-locks/access-codes) was changed.',
             properties: {
               access_code_id: {
                 description: 'ID of the affected access code.',
@@ -16992,7 +16992,7 @@ const openapi: OpenAPISpec = {
               },
               connected_account_id: {
                 description:
-                  'ID of the [connected account](https://docs.seam.co/latest/core-concepts/connected-accounts) associated with the affected access code.',
+                  'ID of the [connected account](https://docs.seam.co/core-concepts/connected-accounts) associated with the affected access code.',
                 format: 'uuid',
                 type: 'string',
               },
@@ -17028,7 +17028,7 @@ const openapi: OpenAPISpec = {
               },
               workspace_id: {
                 description:
-                  'ID of the [workspace](https://docs.seam.co/latest/core-concepts/workspaces) associated with the event.',
+                  'ID of the [workspace](https://docs.seam.co/core-concepts/workspaces) associated with the event.',
                 format: 'uuid',
                 type: 'string',
               },
@@ -17048,7 +17048,7 @@ const openapi: OpenAPISpec = {
           },
           {
             description:
-              'An [access code](https://docs.seam.co/latest/capability-guides/smart-locks/access-codes) was [scheduled natively](https://docs.seam.co/latest/capability-guides/smart-locks/access-codes#native-scheduling) on a device.',
+              'An [access code](https://docs.seam.co/capability-guides/smart-locks/access-codes) was [scheduled natively](https://docs.seam.co/capability-guides/smart-locks/access-codes#native-scheduling) on a device.',
             properties: {
               access_code_id: {
                 description: 'ID of the affected access code.',
@@ -17069,7 +17069,7 @@ const openapi: OpenAPISpec = {
               },
               connected_account_id: {
                 description:
-                  'ID of the [connected account](https://docs.seam.co/latest/core-concepts/connected-accounts) associated with the affected access code.',
+                  'ID of the [connected account](https://docs.seam.co/core-concepts/connected-accounts) associated with the affected access code.',
                 format: 'uuid',
                 type: 'string',
               },
@@ -17108,7 +17108,7 @@ const openapi: OpenAPISpec = {
               },
               workspace_id: {
                 description:
-                  'ID of the [workspace](https://docs.seam.co/latest/core-concepts/workspaces) associated with the event.',
+                  'ID of the [workspace](https://docs.seam.co/core-concepts/workspaces) associated with the event.',
                 format: 'uuid',
                 type: 'string',
               },
@@ -17129,7 +17129,7 @@ const openapi: OpenAPISpec = {
           },
           {
             description:
-              'An [access code](https://docs.seam.co/latest/capability-guides/smart-locks/access-codes) was set on a device.',
+              'An [access code](https://docs.seam.co/capability-guides/smart-locks/access-codes) was set on a device.',
             properties: {
               access_code_id: {
                 description: 'ID of the affected access code.',
@@ -17150,7 +17150,7 @@ const openapi: OpenAPISpec = {
               },
               connected_account_id: {
                 description:
-                  'ID of the [connected account](https://docs.seam.co/latest/core-concepts/connected-accounts) associated with the affected access code.',
+                  'ID of the [connected account](https://docs.seam.co/core-concepts/connected-accounts) associated with the affected access code.',
                 format: 'uuid',
                 type: 'string',
               },
@@ -17189,7 +17189,7 @@ const openapi: OpenAPISpec = {
               },
               workspace_id: {
                 description:
-                  'ID of the [workspace](https://docs.seam.co/latest/core-concepts/workspaces) associated with the event.',
+                  'ID of the [workspace](https://docs.seam.co/core-concepts/workspaces) associated with the event.',
                 format: 'uuid',
                 type: 'string',
               },
@@ -17210,7 +17210,7 @@ const openapi: OpenAPISpec = {
           },
           {
             description:
-              'An [access code](https://docs.seam.co/latest/capability-guides/smart-locks/access-codes) was removed from a device.',
+              'An [access code](https://docs.seam.co/capability-guides/smart-locks/access-codes) was removed from a device.',
             properties: {
               access_code_id: {
                 description: 'ID of the affected access code.',
@@ -17227,7 +17227,7 @@ const openapi: OpenAPISpec = {
               },
               connected_account_id: {
                 description:
-                  'ID of the [connected account](https://docs.seam.co/latest/core-concepts/connected-accounts) associated with the affected access code.',
+                  'ID of the [connected account](https://docs.seam.co/core-concepts/connected-accounts) associated with the affected access code.',
                 format: 'uuid',
                 type: 'string',
               },
@@ -17266,7 +17266,7 @@ const openapi: OpenAPISpec = {
               },
               workspace_id: {
                 description:
-                  'ID of the [workspace](https://docs.seam.co/latest/core-concepts/workspaces) associated with the event.',
+                  'ID of the [workspace](https://docs.seam.co/core-concepts/workspaces) associated with the event.',
                 format: 'uuid',
                 type: 'string',
               },
@@ -17286,7 +17286,7 @@ const openapi: OpenAPISpec = {
           },
           {
             description:
-              'There was an unusually long delay in setting an [access code](https://docs.seam.co/latest/capability-guides/smart-locks/access-codes) on a device.',
+              'There was an unusually long delay in setting an [access code](https://docs.seam.co/capability-guides/smart-locks/access-codes) on a device.',
             properties: {
               access_code_errors: {
                 description: 'Errors associated with the access code.',
@@ -17381,7 +17381,7 @@ const openapi: OpenAPISpec = {
               },
               connected_account_id: {
                 description:
-                  'ID of the [connected account](https://docs.seam.co/latest/core-concepts/connected-accounts) associated with the affected access code.',
+                  'ID of the [connected account](https://docs.seam.co/core-concepts/connected-accounts) associated with the affected access code.',
                 format: 'uuid',
                 type: 'string',
               },
@@ -17498,7 +17498,7 @@ const openapi: OpenAPISpec = {
               },
               workspace_id: {
                 description:
-                  'ID of the [workspace](https://docs.seam.co/latest/core-concepts/workspaces) associated with the event.',
+                  'ID of the [workspace](https://docs.seam.co/core-concepts/workspaces) associated with the event.',
                 format: 'uuid',
                 type: 'string',
               },
@@ -17524,7 +17524,7 @@ const openapi: OpenAPISpec = {
           },
           {
             description:
-              'An [access code](https://docs.seam.co/latest/capability-guides/smart-locks/access-codes) failed to be set on a device.',
+              'An [access code](https://docs.seam.co/capability-guides/smart-locks/access-codes) failed to be set on a device.',
             properties: {
               access_code_errors: {
                 description: 'Errors associated with the access code.',
@@ -17619,7 +17619,7 @@ const openapi: OpenAPISpec = {
               },
               connected_account_id: {
                 description:
-                  'ID of the [connected account](https://docs.seam.co/latest/core-concepts/connected-accounts) associated with the affected access code.',
+                  'ID of the [connected account](https://docs.seam.co/core-concepts/connected-accounts) associated with the affected access code.',
                 format: 'uuid',
                 type: 'string',
               },
@@ -17736,7 +17736,7 @@ const openapi: OpenAPISpec = {
               },
               workspace_id: {
                 description:
-                  'ID of the [workspace](https://docs.seam.co/latest/core-concepts/workspaces) associated with the event.',
+                  'ID of the [workspace](https://docs.seam.co/core-concepts/workspaces) associated with the event.',
                 format: 'uuid',
                 type: 'string',
               },
@@ -17762,7 +17762,7 @@ const openapi: OpenAPISpec = {
           },
           {
             description:
-              'An [access code](https://docs.seam.co/latest/capability-guides/smart-locks/access-codes) was deleted.',
+              'An [access code](https://docs.seam.co/capability-guides/smart-locks/access-codes) was deleted.',
             properties: {
               access_code_id: {
                 description: 'ID of the affected access code.',
@@ -17784,7 +17784,7 @@ const openapi: OpenAPISpec = {
               },
               connected_account_id: {
                 description:
-                  'ID of the [connected account](https://docs.seam.co/latest/core-concepts/connected-accounts) associated with the affected access code.',
+                  'ID of the [connected account](https://docs.seam.co/core-concepts/connected-accounts) associated with the affected access code.',
                 format: 'uuid',
                 type: 'string',
               },
@@ -17820,7 +17820,7 @@ const openapi: OpenAPISpec = {
               },
               workspace_id: {
                 description:
-                  'ID of the [workspace](https://docs.seam.co/latest/core-concepts/workspaces) associated with the event.',
+                  'ID of the [workspace](https://docs.seam.co/core-concepts/workspaces) associated with the event.',
                 format: 'uuid',
                 type: 'string',
               },
@@ -17841,7 +17841,7 @@ const openapi: OpenAPISpec = {
           },
           {
             description:
-              'There was an unusually long delay in removing an [access code](https://docs.seam.co/latest/capability-guides/smart-locks/access-codes) from a device.',
+              'There was an unusually long delay in removing an [access code](https://docs.seam.co/capability-guides/smart-locks/access-codes) from a device.',
             properties: {
               access_code_errors: {
                 description: 'Errors associated with the access code.',
@@ -17936,7 +17936,7 @@ const openapi: OpenAPISpec = {
               },
               connected_account_id: {
                 description:
-                  'ID of the [connected account](https://docs.seam.co/latest/core-concepts/connected-accounts) associated with the affected access code.',
+                  'ID of the [connected account](https://docs.seam.co/core-concepts/connected-accounts) associated with the affected access code.',
                 format: 'uuid',
                 type: 'string',
               },
@@ -18053,7 +18053,7 @@ const openapi: OpenAPISpec = {
               },
               workspace_id: {
                 description:
-                  'ID of the [workspace](https://docs.seam.co/latest/core-concepts/workspaces) associated with the event.',
+                  'ID of the [workspace](https://docs.seam.co/core-concepts/workspaces) associated with the event.',
                 format: 'uuid',
                 type: 'string',
               },
@@ -18079,7 +18079,7 @@ const openapi: OpenAPISpec = {
           },
           {
             description:
-              'An [access code](https://docs.seam.co/latest/capability-guides/smart-locks/access-codes) failed to be removed from a device.',
+              'An [access code](https://docs.seam.co/capability-guides/smart-locks/access-codes) failed to be removed from a device.',
             properties: {
               access_code_errors: {
                 description: 'Errors associated with the access code.',
@@ -18174,7 +18174,7 @@ const openapi: OpenAPISpec = {
               },
               connected_account_id: {
                 description:
-                  'ID of the [connected account](https://docs.seam.co/latest/core-concepts/connected-accounts) associated with the affected access code.',
+                  'ID of the [connected account](https://docs.seam.co/core-concepts/connected-accounts) associated with the affected access code.',
                 format: 'uuid',
                 type: 'string',
               },
@@ -18291,7 +18291,7 @@ const openapi: OpenAPISpec = {
               },
               workspace_id: {
                 description:
-                  'ID of the [workspace](https://docs.seam.co/latest/core-concepts/workspaces) associated with the event.',
+                  'ID of the [workspace](https://docs.seam.co/core-concepts/workspaces) associated with the event.',
                 format: 'uuid',
                 type: 'string',
               },
@@ -18317,7 +18317,7 @@ const openapi: OpenAPISpec = {
           },
           {
             description:
-              'An [access code](https://docs.seam.co/latest/capability-guides/smart-locks/access-codes) was modified outside of Seam.',
+              'An [access code](https://docs.seam.co/capability-guides/smart-locks/access-codes) was modified outside of Seam.',
             properties: {
               access_code_id: {
                 description: 'ID of the affected access code.',
@@ -18334,7 +18334,7 @@ const openapi: OpenAPISpec = {
               },
               connected_account_id: {
                 description:
-                  'ID of the [connected account](https://docs.seam.co/latest/core-concepts/connected-accounts) associated with the affected access code.',
+                  'ID of the [connected account](https://docs.seam.co/core-concepts/connected-accounts) associated with the affected access code.',
                 format: 'uuid',
                 type: 'string',
               },
@@ -18373,7 +18373,7 @@ const openapi: OpenAPISpec = {
               },
               workspace_id: {
                 description:
-                  'ID of the [workspace](https://docs.seam.co/latest/core-concepts/workspaces) associated with the event.',
+                  'ID of the [workspace](https://docs.seam.co/core-concepts/workspaces) associated with the event.',
                 format: 'uuid',
                 type: 'string',
               },
@@ -18393,7 +18393,7 @@ const openapi: OpenAPISpec = {
           },
           {
             description:
-              'An [access code](https://docs.seam.co/latest/capability-guides/smart-locks/access-codes) was deleted outside of Seam.',
+              'An [access code](https://docs.seam.co/capability-guides/smart-locks/access-codes) was deleted outside of Seam.',
             properties: {
               access_code_id: {
                 description: 'ID of the affected access code.',
@@ -18410,7 +18410,7 @@ const openapi: OpenAPISpec = {
               },
               connected_account_id: {
                 description:
-                  'ID of the [connected account](https://docs.seam.co/latest/core-concepts/connected-accounts) associated with the affected access code.',
+                  'ID of the [connected account](https://docs.seam.co/core-concepts/connected-accounts) associated with the affected access code.',
                 format: 'uuid',
                 type: 'string',
               },
@@ -18449,7 +18449,7 @@ const openapi: OpenAPISpec = {
               },
               workspace_id: {
                 description:
-                  'ID of the [workspace](https://docs.seam.co/latest/core-concepts/workspaces) associated with the event.',
+                  'ID of the [workspace](https://docs.seam.co/core-concepts/workspaces) associated with the event.',
                 format: 'uuid',
                 type: 'string',
               },
@@ -18469,7 +18469,7 @@ const openapi: OpenAPISpec = {
           },
           {
             description:
-              'A [backup access code](https://docs.seam.co/latest/capability-guides/smart-locks/access-codes/backup-access-codes) was pulled from the backup access code pool and set on a device.',
+              'A [backup access code](https://docs.seam.co/capability-guides/smart-locks/access-codes/backup-access-codes) was pulled from the backup access code pool and set on a device.',
             properties: {
               access_code_id: {
                 description: 'ID of the affected access code.',
@@ -18487,7 +18487,7 @@ const openapi: OpenAPISpec = {
               },
               connected_account_id: {
                 description:
-                  'ID of the [connected account](https://docs.seam.co/latest/core-concepts/connected-accounts) associated with the affected access code.',
+                  'ID of the [connected account](https://docs.seam.co/core-concepts/connected-accounts) associated with the affected access code.',
                 format: 'uuid',
                 type: 'string',
               },
@@ -18526,7 +18526,7 @@ const openapi: OpenAPISpec = {
               },
               workspace_id: {
                 description:
-                  'ID of the [workspace](https://docs.seam.co/latest/core-concepts/workspaces) associated with the event.',
+                  'ID of the [workspace](https://docs.seam.co/core-concepts/workspaces) associated with the event.',
                 format: 'uuid',
                 type: 'string',
               },
@@ -18547,7 +18547,7 @@ const openapi: OpenAPISpec = {
           },
           {
             description:
-              'An [unmanaged access code](https://docs.seam.co/latest/capability-guides/smart-locks/access-codes/migrating-existing-access-codes) was converted successfully to a managed access code.',
+              'An [unmanaged access code](https://docs.seam.co/capability-guides/smart-locks/access-codes/migrating-existing-access-codes) was converted successfully to a managed access code.',
             properties: {
               access_code_id: {
                 description: 'ID of the affected access code.',
@@ -18564,7 +18564,7 @@ const openapi: OpenAPISpec = {
               },
               connected_account_id: {
                 description:
-                  'ID of the [connected account](https://docs.seam.co/latest/core-concepts/connected-accounts) associated with the affected access code.',
+                  'ID of the [connected account](https://docs.seam.co/core-concepts/connected-accounts) associated with the affected access code.',
                 format: 'uuid',
                 type: 'string',
               },
@@ -18603,7 +18603,7 @@ const openapi: OpenAPISpec = {
               },
               workspace_id: {
                 description:
-                  'ID of the [workspace](https://docs.seam.co/latest/core-concepts/workspaces) associated with the event.',
+                  'ID of the [workspace](https://docs.seam.co/core-concepts/workspaces) associated with the event.',
                 format: 'uuid',
                 type: 'string',
               },
@@ -18623,7 +18623,7 @@ const openapi: OpenAPISpec = {
           },
           {
             description:
-              'An [unmanaged access code](https://docs.seam.co/latest/capability-guides/smart-locks/access-codes/migrating-existing-access-codes) failed to be converted to a managed access code.',
+              'An [unmanaged access code](https://docs.seam.co/capability-guides/smart-locks/access-codes/migrating-existing-access-codes) failed to be converted to a managed access code.',
             properties: {
               access_code_errors: {
                 description: 'Errors associated with the access code.',
@@ -18718,7 +18718,7 @@ const openapi: OpenAPISpec = {
               },
               connected_account_id: {
                 description:
-                  'ID of the [connected account](https://docs.seam.co/latest/core-concepts/connected-accounts) associated with the affected access code.',
+                  'ID of the [connected account](https://docs.seam.co/core-concepts/connected-accounts) associated with the affected access code.',
                 format: 'uuid',
                 type: 'string',
               },
@@ -18835,7 +18835,7 @@ const openapi: OpenAPISpec = {
               },
               workspace_id: {
                 description:
-                  'ID of the [workspace](https://docs.seam.co/latest/core-concepts/workspaces) associated with the event.',
+                  'ID of the [workspace](https://docs.seam.co/core-concepts/workspaces) associated with the event.',
                 format: 'uuid',
                 type: 'string',
               },
@@ -18861,7 +18861,7 @@ const openapi: OpenAPISpec = {
           },
           {
             description:
-              'An [unmanaged access code](https://docs.seam.co/latest/capability-guides/smart-locks/access-codes/migrating-existing-access-codes) was created on a device.',
+              'An [unmanaged access code](https://docs.seam.co/capability-guides/smart-locks/access-codes/migrating-existing-access-codes) was created on a device.',
             properties: {
               access_code_id: {
                 description: 'ID of the affected access code.',
@@ -18878,7 +18878,7 @@ const openapi: OpenAPISpec = {
               },
               connected_account_id: {
                 description:
-                  'ID of the [connected account](https://docs.seam.co/latest/core-concepts/connected-accounts) associated with the affected access code.',
+                  'ID of the [connected account](https://docs.seam.co/core-concepts/connected-accounts) associated with the affected access code.',
                 format: 'uuid',
                 type: 'string',
               },
@@ -18917,7 +18917,7 @@ const openapi: OpenAPISpec = {
               },
               workspace_id: {
                 description:
-                  'ID of the [workspace](https://docs.seam.co/latest/core-concepts/workspaces) associated with the event.',
+                  'ID of the [workspace](https://docs.seam.co/core-concepts/workspaces) associated with the event.',
                 format: 'uuid',
                 type: 'string',
               },
@@ -18937,7 +18937,7 @@ const openapi: OpenAPISpec = {
           },
           {
             description:
-              'An [unmanaged access code](https://docs.seam.co/latest/capability-guides/smart-locks/access-codes/migrating-existing-access-codes) was removed from a device.',
+              'An [unmanaged access code](https://docs.seam.co/capability-guides/smart-locks/access-codes/migrating-existing-access-codes) was removed from a device.',
             properties: {
               access_code_id: {
                 description: 'ID of the affected access code.',
@@ -18954,7 +18954,7 @@ const openapi: OpenAPISpec = {
               },
               connected_account_id: {
                 description:
-                  'ID of the [connected account](https://docs.seam.co/latest/core-concepts/connected-accounts) associated with the affected access code.',
+                  'ID of the [connected account](https://docs.seam.co/core-concepts/connected-accounts) associated with the affected access code.',
                 format: 'uuid',
                 type: 'string',
               },
@@ -18993,7 +18993,7 @@ const openapi: OpenAPISpec = {
               },
               workspace_id: {
                 description:
-                  'ID of the [workspace](https://docs.seam.co/latest/core-concepts/workspaces) associated with the event.',
+                  'ID of the [workspace](https://docs.seam.co/core-concepts/workspaces) associated with the event.',
                 format: 'uuid',
                 type: 'string',
               },
@@ -19037,7 +19037,7 @@ const openapi: OpenAPISpec = {
               },
               workspace_id: {
                 description:
-                  'ID of the [workspace](https://docs.seam.co/latest/core-concepts/workspaces) associated with the event.',
+                  'ID of the [workspace](https://docs.seam.co/core-concepts/workspaces) associated with the event.',
                 format: 'uuid',
                 type: 'string',
               },
@@ -19079,7 +19079,7 @@ const openapi: OpenAPISpec = {
               },
               workspace_id: {
                 description:
-                  'ID of the [workspace](https://docs.seam.co/latest/core-concepts/workspaces) associated with the event.',
+                  'ID of the [workspace](https://docs.seam.co/core-concepts/workspaces) associated with the event.',
                 format: 'uuid',
                 type: 'string',
               },
@@ -19125,7 +19125,7 @@ const openapi: OpenAPISpec = {
               },
               workspace_id: {
                 description:
-                  'ID of the [workspace](https://docs.seam.co/latest/core-concepts/workspaces) associated with the event.',
+                  'ID of the [workspace](https://docs.seam.co/core-concepts/workspaces) associated with the event.',
                 format: 'uuid',
                 type: 'string',
               },
@@ -19152,7 +19152,7 @@ const openapi: OpenAPISpec = {
               },
               acs_entrance_id: {
                 description:
-                  'ID of the affected [entrance](https://docs.seam.co/latest/capability-guides/access-systems/retrieving-entrance-details).',
+                  'ID of the affected [entrance](https://docs.seam.co/capability-guides/access-systems/retrieving-entrance-details).',
                 format: 'uuid',
                 type: 'string',
               },
@@ -19177,7 +19177,7 @@ const openapi: OpenAPISpec = {
               },
               workspace_id: {
                 description:
-                  'ID of the [workspace](https://docs.seam.co/latest/core-concepts/workspaces) associated with the event.',
+                  'ID of the [workspace](https://docs.seam.co/core-concepts/workspaces) associated with the event.',
                 format: 'uuid',
                 type: 'string',
               },
@@ -19205,7 +19205,7 @@ const openapi: OpenAPISpec = {
               },
               acs_entrance_id: {
                 description:
-                  'ID of the affected [entrance](https://docs.seam.co/latest/capability-guides/access-systems/retrieving-entrance-details).',
+                  'ID of the affected [entrance](https://docs.seam.co/capability-guides/access-systems/retrieving-entrance-details).',
                 format: 'uuid',
                 type: 'string',
               },
@@ -19230,7 +19230,7 @@ const openapi: OpenAPISpec = {
               },
               workspace_id: {
                 description:
-                  'ID of the [workspace](https://docs.seam.co/latest/core-concepts/workspaces) associated with the event.',
+                  'ID of the [workspace](https://docs.seam.co/core-concepts/workspaces) associated with the event.',
                 format: 'uuid',
                 type: 'string',
               },
@@ -19288,7 +19288,7 @@ const openapi: OpenAPISpec = {
               },
               workspace_id: {
                 description:
-                  'ID of the [workspace](https://docs.seam.co/latest/core-concepts/workspaces) associated with the event.',
+                  'ID of the [workspace](https://docs.seam.co/core-concepts/workspaces) associated with the event.',
                 format: 'uuid',
                 type: 'string',
               },
@@ -19347,7 +19347,7 @@ const openapi: OpenAPISpec = {
               },
               workspace_id: {
                 description:
-                  'ID of the [workspace](https://docs.seam.co/latest/core-concepts/workspaces) associated with the event.',
+                  'ID of the [workspace](https://docs.seam.co/core-concepts/workspaces) associated with the event.',
                 format: 'uuid',
                 type: 'string',
               },
@@ -19412,7 +19412,7 @@ const openapi: OpenAPISpec = {
               },
               workspace_id: {
                 description:
-                  'ID of the [workspace](https://docs.seam.co/latest/core-concepts/workspaces) associated with the event.',
+                  'ID of the [workspace](https://docs.seam.co/core-concepts/workspaces) associated with the event.',
                 format: 'uuid',
                 type: 'string',
               },
@@ -19467,7 +19467,7 @@ const openapi: OpenAPISpec = {
               },
               workspace_id: {
                 description:
-                  'ID of the [workspace](https://docs.seam.co/latest/core-concepts/workspaces) associated with the event.',
+                  'ID of the [workspace](https://docs.seam.co/core-concepts/workspaces) associated with the event.',
                 format: 'uuid',
                 type: 'string',
               },
@@ -19526,7 +19526,7 @@ const openapi: OpenAPISpec = {
               },
               workspace_id: {
                 description:
-                  'ID of the [workspace](https://docs.seam.co/latest/core-concepts/workspaces) associated with the event.',
+                  'ID of the [workspace](https://docs.seam.co/core-concepts/workspaces) associated with the event.',
                 format: 'uuid',
                 type: 'string',
               },
@@ -19581,7 +19581,7 @@ const openapi: OpenAPISpec = {
               },
               workspace_id: {
                 description:
-                  'ID of the [workspace](https://docs.seam.co/latest/core-concepts/workspaces) associated with the event.',
+                  'ID of the [workspace](https://docs.seam.co/core-concepts/workspaces) associated with the event.',
                 format: 'uuid',
                 type: 'string',
               },
@@ -19646,7 +19646,7 @@ const openapi: OpenAPISpec = {
               },
               workspace_id: {
                 description:
-                  'ID of the [workspace](https://docs.seam.co/latest/core-concepts/workspaces) associated with the event.',
+                  'ID of the [workspace](https://docs.seam.co/core-concepts/workspaces) associated with the event.',
                 format: 'uuid',
                 type: 'string',
               },
@@ -19701,7 +19701,7 @@ const openapi: OpenAPISpec = {
               },
               workspace_id: {
                 description:
-                  'ID of the [workspace](https://docs.seam.co/latest/core-concepts/workspaces) associated with the event.',
+                  'ID of the [workspace](https://docs.seam.co/core-concepts/workspaces) associated with the event.',
                 format: 'uuid',
                 type: 'string',
               },
@@ -19720,7 +19720,7 @@ const openapi: OpenAPISpec = {
           },
           {
             description:
-              'An [access system](https://docs.seam.co/latest/capability-guides/access-systems) was connected.',
+              'An [access system](https://docs.seam.co/capability-guides/access-systems) was connected.',
             properties: {
               acs_system_id: {
                 description: 'ID of the access system.',
@@ -19750,7 +19750,7 @@ const openapi: OpenAPISpec = {
               },
               workspace_id: {
                 description:
-                  'ID of the [workspace](https://docs.seam.co/latest/core-concepts/workspaces) associated with the event.',
+                  'ID of the [workspace](https://docs.seam.co/core-concepts/workspaces) associated with the event.',
                 format: 'uuid',
                 type: 'string',
               },
@@ -19768,7 +19768,7 @@ const openapi: OpenAPISpec = {
           },
           {
             description:
-              'An [access system](https://docs.seam.co/latest/capability-guides/access-systems) was added.',
+              'An [access system](https://docs.seam.co/capability-guides/access-systems) was added.',
             properties: {
               acs_system_id: {
                 description: 'ID of the access system.',
@@ -19798,7 +19798,7 @@ const openapi: OpenAPISpec = {
               },
               workspace_id: {
                 description:
-                  'ID of the [workspace](https://docs.seam.co/latest/core-concepts/workspaces) associated with the event.',
+                  'ID of the [workspace](https://docs.seam.co/core-concepts/workspaces) associated with the event.',
                 format: 'uuid',
                 type: 'string',
               },
@@ -19816,7 +19816,7 @@ const openapi: OpenAPISpec = {
           },
           {
             description:
-              'An [access system](https://docs.seam.co/latest/capability-guides/access-systems) was disconnected.',
+              'An [access system](https://docs.seam.co/capability-guides/access-systems) was disconnected.',
             properties: {
               acs_system_errors: {
                 description:
@@ -19952,7 +19952,7 @@ const openapi: OpenAPISpec = {
               },
               workspace_id: {
                 description:
-                  'ID of the [workspace](https://docs.seam.co/latest/core-concepts/workspaces) associated with the event.',
+                  'ID of the [workspace](https://docs.seam.co/core-concepts/workspaces) associated with the event.',
                 format: 'uuid',
                 type: 'string',
               },
@@ -19974,7 +19974,7 @@ const openapi: OpenAPISpec = {
           },
           {
             description:
-              'An [access system credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials) was deleted.',
+              'An [access system credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials) was deleted.',
             properties: {
               acs_credential_id: {
                 description: 'ID of the affected credential.',
@@ -20009,7 +20009,7 @@ const openapi: OpenAPISpec = {
               },
               workspace_id: {
                 description:
-                  'ID of the [workspace](https://docs.seam.co/latest/core-concepts/workspaces) associated with the event.',
+                  'ID of the [workspace](https://docs.seam.co/core-concepts/workspaces) associated with the event.',
                 format: 'uuid',
                 type: 'string',
               },
@@ -20028,7 +20028,7 @@ const openapi: OpenAPISpec = {
           },
           {
             description:
-              'An [access system credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials) was issued.',
+              'An [access system credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials) was issued.',
             properties: {
               acs_credential_id: {
                 description: 'ID of the affected credential.',
@@ -20063,7 +20063,7 @@ const openapi: OpenAPISpec = {
               },
               workspace_id: {
                 description:
-                  'ID of the [workspace](https://docs.seam.co/latest/core-concepts/workspaces) associated with the event.',
+                  'ID of the [workspace](https://docs.seam.co/core-concepts/workspaces) associated with the event.',
                 format: 'uuid',
                 type: 'string',
               },
@@ -20082,7 +20082,7 @@ const openapi: OpenAPISpec = {
           },
           {
             description:
-              'An [access system credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials) was reissued.',
+              'An [access system credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials) was reissued.',
             properties: {
               acs_credential_id: {
                 description: 'ID of the affected credential.',
@@ -20117,7 +20117,7 @@ const openapi: OpenAPISpec = {
               },
               workspace_id: {
                 description:
-                  'ID of the [workspace](https://docs.seam.co/latest/core-concepts/workspaces) associated with the event.',
+                  'ID of the [workspace](https://docs.seam.co/core-concepts/workspaces) associated with the event.',
                 format: 'uuid',
                 type: 'string',
               },
@@ -20136,7 +20136,7 @@ const openapi: OpenAPISpec = {
           },
           {
             description:
-              'An [access system credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials) was invalidated. That is, the credential cannot be used anymore.',
+              'An [access system credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials) was invalidated. That is, the credential cannot be used anymore.',
             properties: {
               acs_credential_id: {
                 description: 'ID of the affected credential.',
@@ -20174,7 +20174,7 @@ const openapi: OpenAPISpec = {
               },
               workspace_id: {
                 description:
-                  'ID of the [workspace](https://docs.seam.co/latest/core-concepts/workspaces) associated with the event.',
+                  'ID of the [workspace](https://docs.seam.co/core-concepts/workspaces) associated with the event.',
                 format: 'uuid',
                 type: 'string',
               },
@@ -20193,7 +20193,7 @@ const openapi: OpenAPISpec = {
           },
           {
             description:
-              'An [access system user](https://docs.seam.co/latest/capability-guides/access-systems/user-management) was created.',
+              'An [access system user](https://docs.seam.co/capability-guides/access-systems/user-management) was created.',
             properties: {
               acs_system_id: {
                 description: 'ID of the access system.',
@@ -20224,7 +20224,7 @@ const openapi: OpenAPISpec = {
               },
               workspace_id: {
                 description:
-                  'ID of the [workspace](https://docs.seam.co/latest/core-concepts/workspaces) associated with the event.',
+                  'ID of the [workspace](https://docs.seam.co/core-concepts/workspaces) associated with the event.',
                 format: 'uuid',
                 type: 'string',
               },
@@ -20243,7 +20243,7 @@ const openapi: OpenAPISpec = {
           },
           {
             description:
-              'An [access system user](https://docs.seam.co/latest/capability-guides/access-systems/user-management) was deleted.',
+              'An [access system user](https://docs.seam.co/capability-guides/access-systems/user-management) was deleted.',
             properties: {
               acs_system_id: {
                 description: 'ID of the access system.',
@@ -20274,7 +20274,7 @@ const openapi: OpenAPISpec = {
               },
               workspace_id: {
                 description:
-                  'ID of the [workspace](https://docs.seam.co/latest/core-concepts/workspaces) associated with the event.',
+                  'ID of the [workspace](https://docs.seam.co/core-concepts/workspaces) associated with the event.',
                 format: 'uuid',
                 type: 'string',
               },
@@ -20293,7 +20293,7 @@ const openapi: OpenAPISpec = {
           },
           {
             description:
-              'An [access system encoder](https://docs.seam.co/latest/capability-guides/access-systems/working-with-card-encoders-and-scanners) was added.',
+              'An [access system encoder](https://docs.seam.co/capability-guides/access-systems/working-with-card-encoders-and-scanners) was added.',
             properties: {
               acs_encoder_id: {
                 description: 'ID of the affected encoder.',
@@ -20328,7 +20328,7 @@ const openapi: OpenAPISpec = {
               },
               workspace_id: {
                 description:
-                  'ID of the [workspace](https://docs.seam.co/latest/core-concepts/workspaces) associated with the event.',
+                  'ID of the [workspace](https://docs.seam.co/core-concepts/workspaces) associated with the event.',
                 format: 'uuid',
                 type: 'string',
               },
@@ -20347,7 +20347,7 @@ const openapi: OpenAPISpec = {
           },
           {
             description:
-              'An [access system encoder](https://docs.seam.co/latest/capability-guides/access-systems/working-with-card-encoders-and-scanners) was removed.',
+              'An [access system encoder](https://docs.seam.co/capability-guides/access-systems/working-with-card-encoders-and-scanners) was removed.',
             properties: {
               acs_encoder_id: {
                 description: 'ID of the affected encoder.',
@@ -20382,7 +20382,7 @@ const openapi: OpenAPISpec = {
               },
               workspace_id: {
                 description:
-                  'ID of the [workspace](https://docs.seam.co/latest/core-concepts/workspaces) associated with the event.',
+                  'ID of the [workspace](https://docs.seam.co/core-concepts/workspaces) associated with the event.',
                 format: 'uuid',
                 type: 'string',
               },
@@ -20438,7 +20438,7 @@ const openapi: OpenAPISpec = {
               },
               workspace_id: {
                 description:
-                  'ID of the [workspace](https://docs.seam.co/latest/core-concepts/workspaces) associated with the event.',
+                  'ID of the [workspace](https://docs.seam.co/core-concepts/workspaces) associated with the event.',
                 format: 'uuid',
                 type: 'string',
               },
@@ -20457,7 +20457,7 @@ const openapi: OpenAPISpec = {
           },
           {
             description:
-              'An [access system entrance](https://docs.seam.co/latest/capability-guides/access-systems/retrieving-entrance-details) was added.',
+              'An [access system entrance](https://docs.seam.co/capability-guides/access-systems/retrieving-entrance-details) was added.',
             properties: {
               acs_entrance_id: { format: 'uuid', type: 'string' },
               acs_system_id: {
@@ -20488,7 +20488,7 @@ const openapi: OpenAPISpec = {
               },
               workspace_id: {
                 description:
-                  'ID of the [workspace](https://docs.seam.co/latest/core-concepts/workspaces) associated with the event.',
+                  'ID of the [workspace](https://docs.seam.co/core-concepts/workspaces) associated with the event.',
                 format: 'uuid',
                 type: 'string',
               },
@@ -20507,7 +20507,7 @@ const openapi: OpenAPISpec = {
           },
           {
             description:
-              'An [access system entrance](https://docs.seam.co/latest/capability-guides/access-systems/retrieving-entrance-details) was removed.',
+              'An [access system entrance](https://docs.seam.co/capability-guides/access-systems/retrieving-entrance-details) was removed.',
             properties: {
               acs_entrance_id: { format: 'uuid', type: 'string' },
               acs_system_id: {
@@ -20538,7 +20538,7 @@ const openapi: OpenAPISpec = {
               },
               workspace_id: {
                 description:
-                  'ID of the [workspace](https://docs.seam.co/latest/core-concepts/workspaces) associated with the event.',
+                  'ID of the [workspace](https://docs.seam.co/core-concepts/workspaces) associated with the event.',
                 format: 'uuid',
                 type: 'string',
               },
@@ -20557,7 +20557,7 @@ const openapi: OpenAPISpec = {
           },
           {
             description:
-              'A [client session](https://docs.seam.co/latest/core-concepts/authentication/client-session-tokens) was deleted.',
+              'A [client session](https://docs.seam.co/core-concepts/authentication/client-session-tokens) was deleted.',
             properties: {
               client_session_id: {
                 description: 'ID of the affected client session.',
@@ -20582,7 +20582,7 @@ const openapi: OpenAPISpec = {
               },
               workspace_id: {
                 description:
-                  'ID of the [workspace](https://docs.seam.co/latest/core-concepts/workspaces) associated with the event.',
+                  'ID of the [workspace](https://docs.seam.co/core-concepts/workspaces) associated with the event.',
                 format: 'uuid',
                 type: 'string',
               },
@@ -20600,11 +20600,11 @@ const openapi: OpenAPISpec = {
           },
           {
             description:
-              'A [connected account](https://docs.seam.co/latest/core-concepts/connected-accounts) was connected for the first time or was reconnected after being disconnected.',
+              'A [connected account](https://docs.seam.co/core-concepts/connected-accounts) was connected for the first time or was reconnected after being disconnected.',
             properties: {
               connect_webview_id: {
                 description:
-                  'ID of the [Connect Webview](https://docs.seam.co/latest/core-concepts/connect-webviews) associated with the event.',
+                  'ID of the [Connect Webview](https://docs.seam.co/core-concepts/connect-webviews) associated with the event.',
                 format: 'uuid',
                 type: 'string',
               },
@@ -20618,7 +20618,7 @@ const openapi: OpenAPISpec = {
               },
               connected_account_id: {
                 description:
-                  'ID of the affected [connected account](https://docs.seam.co/latest/core-concepts/connected-accounts).',
+                  'ID of the affected [connected account](https://docs.seam.co/core-concepts/connected-accounts).',
                 format: 'uuid',
                 type: 'string',
               },
@@ -20648,7 +20648,7 @@ const openapi: OpenAPISpec = {
               },
               workspace_id: {
                 description:
-                  'ID of the [workspace](https://docs.seam.co/latest/core-concepts/workspaces) associated with the event.',
+                  'ID of the [workspace](https://docs.seam.co/core-concepts/workspaces) associated with the event.',
                 format: 'uuid',
                 type: 'string',
               },
@@ -20666,11 +20666,11 @@ const openapi: OpenAPISpec = {
           },
           {
             description:
-              'A [connected account](https://docs.seam.co/latest/core-concepts/connected-accounts) was created.',
+              'A [connected account](https://docs.seam.co/core-concepts/connected-accounts) was created.',
             properties: {
               connect_webview_id: {
                 description:
-                  'ID of the [Connect Webview](https://docs.seam.co/latest/core-concepts/connect-webviews) associated with the event.',
+                  'ID of the [Connect Webview](https://docs.seam.co/core-concepts/connect-webviews) associated with the event.',
                 format: 'uuid',
                 type: 'string',
               },
@@ -20684,7 +20684,7 @@ const openapi: OpenAPISpec = {
               },
               connected_account_id: {
                 description:
-                  'ID of the affected [connected account](https://docs.seam.co/latest/core-concepts/connected-accounts).',
+                  'ID of the affected [connected account](https://docs.seam.co/core-concepts/connected-accounts).',
                 format: 'uuid',
                 type: 'string',
               },
@@ -20709,7 +20709,7 @@ const openapi: OpenAPISpec = {
               },
               workspace_id: {
                 description:
-                  'ID of the [workspace](https://docs.seam.co/latest/core-concepts/workspaces) associated with the event.',
+                  'ID of the [workspace](https://docs.seam.co/core-concepts/workspaces) associated with the event.',
                 format: 'uuid',
                 type: 'string',
               },
@@ -20729,11 +20729,11 @@ const openapi: OpenAPISpec = {
           {
             deprecated: true,
             description:
-              'A [connected account](https://docs.seam.co/latest/core-concepts/connected-accounts) had a successful login using a [Connect Webview](https://docs.seam.co/latest/core-concepts/connect-webviews).',
+              'A [connected account](https://docs.seam.co/core-concepts/connected-accounts) had a successful login using a [Connect Webview](https://docs.seam.co/core-concepts/connect-webviews).',
             properties: {
               connect_webview_id: {
                 description:
-                  'ID of the [Connect Webview](https://docs.seam.co/latest/core-concepts/connect-webviews) associated with the event.',
+                  'ID of the [Connect Webview](https://docs.seam.co/core-concepts/connect-webviews) associated with the event.',
                 format: 'uuid',
                 type: 'string',
               },
@@ -20747,7 +20747,7 @@ const openapi: OpenAPISpec = {
               },
               connected_account_id: {
                 description:
-                  'ID of the affected [connected account](https://docs.seam.co/latest/core-concepts/connected-accounts).',
+                  'ID of the affected [connected account](https://docs.seam.co/core-concepts/connected-accounts).',
                 format: 'uuid',
                 type: 'string',
               },
@@ -20772,7 +20772,7 @@ const openapi: OpenAPISpec = {
               },
               workspace_id: {
                 description:
-                  'ID of the [workspace](https://docs.seam.co/latest/core-concepts/workspaces) associated with the event.',
+                  'ID of the [workspace](https://docs.seam.co/core-concepts/workspaces) associated with the event.',
                 format: 'uuid',
                 type: 'string',
               },
@@ -20792,7 +20792,7 @@ const openapi: OpenAPISpec = {
           },
           {
             description:
-              'A [connected account](https://docs.seam.co/latest/core-concepts/connected-accounts) was disconnected.',
+              'A [connected account](https://docs.seam.co/core-concepts/connected-accounts) was disconnected.',
             properties: {
               connected_account_custom_metadata: {
                 additionalProperties: {
@@ -20830,7 +20830,7 @@ const openapi: OpenAPISpec = {
               },
               connected_account_id: {
                 description:
-                  'ID of the affected [connected account](https://docs.seam.co/latest/core-concepts/connected-accounts).',
+                  'ID of the affected [connected account](https://docs.seam.co/core-concepts/connected-accounts).',
                 format: 'uuid',
                 type: 'string',
               },
@@ -20881,7 +20881,7 @@ const openapi: OpenAPISpec = {
               },
               workspace_id: {
                 description:
-                  'ID of the [workspace](https://docs.seam.co/latest/core-concepts/workspaces) associated with the event.',
+                  'ID of the [workspace](https://docs.seam.co/core-concepts/workspaces) associated with the event.',
                 format: 'uuid',
                 type: 'string',
               },
@@ -20901,7 +20901,7 @@ const openapi: OpenAPISpec = {
           },
           {
             description:
-              'A [connected account](https://docs.seam.co/latest/core-concepts/connected-accounts) completed the first sync with Seam, and the corresponding devices or systems are now available.',
+              'A [connected account](https://docs.seam.co/core-concepts/connected-accounts) completed the first sync with Seam, and the corresponding devices or systems are now available.',
             properties: {
               connected_account_custom_metadata: {
                 additionalProperties: {
@@ -20913,7 +20913,7 @@ const openapi: OpenAPISpec = {
               },
               connected_account_id: {
                 description:
-                  'ID of the affected [connected account](https://docs.seam.co/latest/core-concepts/connected-accounts).',
+                  'ID of the affected [connected account](https://docs.seam.co/core-concepts/connected-accounts).',
                 format: 'uuid',
                 type: 'string',
               },
@@ -20938,7 +20938,7 @@ const openapi: OpenAPISpec = {
               },
               workspace_id: {
                 description:
-                  'ID of the [workspace](https://docs.seam.co/latest/core-concepts/workspaces) associated with the event.',
+                  'ID of the [workspace](https://docs.seam.co/core-concepts/workspaces) associated with the event.',
                 format: 'uuid',
                 type: 'string',
               },
@@ -20956,7 +20956,7 @@ const openapi: OpenAPISpec = {
           },
           {
             description:
-              'A [connected account](https://docs.seam.co/latest/core-concepts/connected-accounts) was deleted.',
+              'A [connected account](https://docs.seam.co/core-concepts/connected-accounts) was deleted.',
             properties: {
               connected_account_custom_metadata: {
                 additionalProperties: {
@@ -20968,7 +20968,7 @@ const openapi: OpenAPISpec = {
               },
               connected_account_id: {
                 description:
-                  'ID of the affected [connected account](https://docs.seam.co/latest/core-concepts/connected-accounts).',
+                  'ID of the affected [connected account](https://docs.seam.co/core-concepts/connected-accounts).',
                 format: 'uuid',
                 type: 'string',
               },
@@ -21002,7 +21002,7 @@ const openapi: OpenAPISpec = {
               },
               workspace_id: {
                 description:
-                  'ID of the [workspace](https://docs.seam.co/latest/core-concepts/workspaces) associated with the event.',
+                  'ID of the [workspace](https://docs.seam.co/core-concepts/workspaces) associated with the event.',
                 format: 'uuid',
                 type: 'string',
               },
@@ -21020,7 +21020,7 @@ const openapi: OpenAPISpec = {
           },
           {
             description:
-              'A [connected account](https://docs.seam.co/latest/core-concepts/connected-accounts) completed the first sync after reconnection with Seam, and the corresponding devices or systems are now available.',
+              'A [connected account](https://docs.seam.co/core-concepts/connected-accounts) completed the first sync after reconnection with Seam, and the corresponding devices or systems are now available.',
             properties: {
               connected_account_custom_metadata: {
                 additionalProperties: {
@@ -21032,7 +21032,7 @@ const openapi: OpenAPISpec = {
               },
               connected_account_id: {
                 description:
-                  'ID of the affected [connected account](https://docs.seam.co/latest/core-concepts/connected-accounts).',
+                  'ID of the affected [connected account](https://docs.seam.co/core-concepts/connected-accounts).',
                 format: 'uuid',
                 type: 'string',
               },
@@ -21059,7 +21059,7 @@ const openapi: OpenAPISpec = {
               },
               workspace_id: {
                 description:
-                  'ID of the [workspace](https://docs.seam.co/latest/core-concepts/workspaces) associated with the event.',
+                  'ID of the [workspace](https://docs.seam.co/core-concepts/workspaces) associated with the event.',
                 format: 'uuid',
                 type: 'string',
               },
@@ -21077,7 +21077,7 @@ const openapi: OpenAPISpec = {
           },
           {
             description:
-              'A [connected account](https://docs.seam.co/latest/core-concepts/connected-accounts) requires reauthorization using a new Connect Webview. The account is still connected, but cannot access new features. Delaying reauthorization too long will eventually cause the Connected Account to become disconnected.',
+              'A [connected account](https://docs.seam.co/core-concepts/connected-accounts) requires reauthorization using a new Connect Webview. The account is still connected, but cannot access new features. Delaying reauthorization too long will eventually cause the Connected Account to become disconnected.',
             properties: {
               connected_account_custom_metadata: {
                 additionalProperties: {
@@ -21115,7 +21115,7 @@ const openapi: OpenAPISpec = {
               },
               connected_account_id: {
                 description:
-                  'ID of the affected [connected account](https://docs.seam.co/latest/core-concepts/connected-accounts).',
+                  'ID of the affected [connected account](https://docs.seam.co/core-concepts/connected-accounts).',
                 format: 'uuid',
                 type: 'string',
               },
@@ -21166,7 +21166,7 @@ const openapi: OpenAPISpec = {
               },
               workspace_id: {
                 description:
-                  'ID of the [workspace](https://docs.seam.co/latest/core-concepts/workspaces) associated with the event.',
+                  'ID of the [workspace](https://docs.seam.co/core-concepts/workspaces) associated with the event.',
                 format: 'uuid',
                 type: 'string',
               },
@@ -21186,7 +21186,7 @@ const openapi: OpenAPISpec = {
           },
           {
             description:
-              'A lock door [action attempt](https://docs.seam.co/latest/core-concepts/action-attempts) succeeded.',
+              'A lock door [action attempt](https://docs.seam.co/core-concepts/action-attempts) succeeded.',
             properties: {
               action_attempt_id: {
                 description: 'ID of the affected action attempt.',
@@ -21231,7 +21231,7 @@ const openapi: OpenAPISpec = {
               status: { description: 'Status of the action.', type: 'string' },
               workspace_id: {
                 description:
-                  'ID of the [workspace](https://docs.seam.co/latest/core-concepts/workspaces) associated with the event.',
+                  'ID of the [workspace](https://docs.seam.co/core-concepts/workspaces) associated with the event.',
                 format: 'uuid',
                 type: 'string',
               },
@@ -21251,7 +21251,7 @@ const openapi: OpenAPISpec = {
           },
           {
             description:
-              'A lock door [action attempt](https://docs.seam.co/latest/core-concepts/action-attempts) failed.',
+              'A lock door [action attempt](https://docs.seam.co/core-concepts/action-attempts) failed.',
             properties: {
               action_attempt_id: {
                 description: 'ID of the affected action attempt.',
@@ -21296,7 +21296,7 @@ const openapi: OpenAPISpec = {
               status: { description: 'Status of the action.', type: 'string' },
               workspace_id: {
                 description:
-                  'ID of the [workspace](https://docs.seam.co/latest/core-concepts/workspaces) associated with the event.',
+                  'ID of the [workspace](https://docs.seam.co/core-concepts/workspaces) associated with the event.',
                 format: 'uuid',
                 type: 'string',
               },
@@ -21316,7 +21316,7 @@ const openapi: OpenAPISpec = {
           },
           {
             description:
-              'An unlock door [action attempt](https://docs.seam.co/latest/core-concepts/action-attempts) succeeded.',
+              'An unlock door [action attempt](https://docs.seam.co/core-concepts/action-attempts) succeeded.',
             properties: {
               action_attempt_id: {
                 description: 'ID of the affected action attempt.',
@@ -21361,7 +21361,7 @@ const openapi: OpenAPISpec = {
               status: { description: 'Status of the action.', type: 'string' },
               workspace_id: {
                 description:
-                  'ID of the [workspace](https://docs.seam.co/latest/core-concepts/workspaces) associated with the event.',
+                  'ID of the [workspace](https://docs.seam.co/core-concepts/workspaces) associated with the event.',
                 format: 'uuid',
                 type: 'string',
               },
@@ -21381,7 +21381,7 @@ const openapi: OpenAPISpec = {
           },
           {
             description:
-              'An unlock door [action attempt](https://docs.seam.co/latest/core-concepts/action-attempts) failed.',
+              'An unlock door [action attempt](https://docs.seam.co/core-concepts/action-attempts) failed.',
             properties: {
               action_attempt_id: {
                 description: 'ID of the affected action attempt.',
@@ -21426,7 +21426,7 @@ const openapi: OpenAPISpec = {
               status: { description: 'Status of the action.', type: 'string' },
               workspace_id: {
                 description:
-                  'ID of the [workspace](https://docs.seam.co/latest/core-concepts/workspaces) associated with the event.',
+                  'ID of the [workspace](https://docs.seam.co/core-concepts/workspaces) associated with the event.',
                 format: 'uuid',
                 type: 'string',
               },
@@ -21446,7 +21446,7 @@ const openapi: OpenAPISpec = {
           },
           {
             description:
-              'A simulate keypad code entry [action attempt](https://docs.seam.co/latest/core-concepts/action-attempts) succeeded.',
+              'A simulate keypad code entry [action attempt](https://docs.seam.co/core-concepts/action-attempts) succeeded.',
             properties: {
               action_attempt_id: {
                 description: 'ID of the affected action attempt.',
@@ -21491,7 +21491,7 @@ const openapi: OpenAPISpec = {
               status: { description: 'Status of the action.', type: 'string' },
               workspace_id: {
                 description:
-                  'ID of the [workspace](https://docs.seam.co/latest/core-concepts/workspaces) associated with the event.',
+                  'ID of the [workspace](https://docs.seam.co/core-concepts/workspaces) associated with the event.',
                 format: 'uuid',
                 type: 'string',
               },
@@ -21511,7 +21511,7 @@ const openapi: OpenAPISpec = {
           },
           {
             description:
-              'A simulate keypad code entry [action attempt](https://docs.seam.co/latest/core-concepts/action-attempts) failed.',
+              'A simulate keypad code entry [action attempt](https://docs.seam.co/core-concepts/action-attempts) failed.',
             properties: {
               action_attempt_id: {
                 description: 'ID of the affected action attempt.',
@@ -21556,7 +21556,7 @@ const openapi: OpenAPISpec = {
               status: { description: 'Status of the action.', type: 'string' },
               workspace_id: {
                 description:
-                  'ID of the [workspace](https://docs.seam.co/latest/core-concepts/workspaces) associated with the event.',
+                  'ID of the [workspace](https://docs.seam.co/core-concepts/workspaces) associated with the event.',
                 format: 'uuid',
                 type: 'string',
               },
@@ -21576,7 +21576,7 @@ const openapi: OpenAPISpec = {
           },
           {
             description:
-              'A simulate manual lock via keypad [action attempt](https://docs.seam.co/latest/core-concepts/action-attempts) succeeded.',
+              'A simulate manual lock via keypad [action attempt](https://docs.seam.co/core-concepts/action-attempts) succeeded.',
             properties: {
               action_attempt_id: {
                 description: 'ID of the affected action attempt.',
@@ -21623,7 +21623,7 @@ const openapi: OpenAPISpec = {
               status: { description: 'Status of the action.', type: 'string' },
               workspace_id: {
                 description:
-                  'ID of the [workspace](https://docs.seam.co/latest/core-concepts/workspaces) associated with the event.',
+                  'ID of the [workspace](https://docs.seam.co/core-concepts/workspaces) associated with the event.',
                 format: 'uuid',
                 type: 'string',
               },
@@ -21643,7 +21643,7 @@ const openapi: OpenAPISpec = {
           },
           {
             description:
-              'A simulate manual lock via keypad [action attempt](https://docs.seam.co/latest/core-concepts/action-attempts) failed.',
+              'A simulate manual lock via keypad [action attempt](https://docs.seam.co/core-concepts/action-attempts) failed.',
             properties: {
               action_attempt_id: {
                 description: 'ID of the affected action attempt.',
@@ -21688,7 +21688,7 @@ const openapi: OpenAPISpec = {
               status: { description: 'Status of the action.', type: 'string' },
               workspace_id: {
                 description:
-                  'ID of the [workspace](https://docs.seam.co/latest/core-concepts/workspaces) associated with the event.',
+                  'ID of the [workspace](https://docs.seam.co/core-concepts/workspaces) associated with the event.',
                 format: 'uuid',
                 type: 'string',
               },
@@ -21708,11 +21708,11 @@ const openapi: OpenAPISpec = {
           },
           {
             description:
-              'A [Connect Webview](https://docs.seam.co/latest/core-concepts/connect-webviews) login succeeded.',
+              'A [Connect Webview](https://docs.seam.co/core-concepts/connect-webviews) login succeeded.',
             properties: {
               connect_webview_id: {
                 description:
-                  'ID of the affected [Connect Webview](https://docs.seam.co/latest/core-concepts/connect-webviews).',
+                  'ID of the affected [Connect Webview](https://docs.seam.co/core-concepts/connect-webviews).',
                 format: 'uuid',
                 type: 'string',
               },
@@ -21726,7 +21726,7 @@ const openapi: OpenAPISpec = {
               },
               connected_account_id: {
                 description:
-                  'ID of the [connected account](https://docs.seam.co/latest/core-concepts/connected-accounts) associated with the event.',
+                  'ID of the [connected account](https://docs.seam.co/core-concepts/connected-accounts) associated with the event.',
                 format: 'uuid',
                 type: 'string',
               },
@@ -21756,7 +21756,7 @@ const openapi: OpenAPISpec = {
               },
               workspace_id: {
                 description:
-                  'ID of the [workspace](https://docs.seam.co/latest/core-concepts/workspaces) associated with the event.',
+                  'ID of the [workspace](https://docs.seam.co/core-concepts/workspaces) associated with the event.',
                 format: 'uuid',
                 type: 'string',
               },
@@ -21775,11 +21775,11 @@ const openapi: OpenAPISpec = {
           },
           {
             description:
-              'A [Connect Webview](https://docs.seam.co/latest/core-concepts/connect-webviews) login failed.',
+              'A [Connect Webview](https://docs.seam.co/core-concepts/connect-webviews) login failed.',
             properties: {
               connect_webview_id: {
                 description:
-                  'ID of the affected [Connect Webview](https://docs.seam.co/latest/core-concepts/connect-webviews).',
+                  'ID of the affected [Connect Webview](https://docs.seam.co/core-concepts/connect-webviews).',
                 format: 'uuid',
                 type: 'string',
               },
@@ -21804,7 +21804,7 @@ const openapi: OpenAPISpec = {
               },
               workspace_id: {
                 description:
-                  'ID of the [workspace](https://docs.seam.co/latest/core-concepts/workspaces) associated with the event.',
+                  'ID of the [workspace](https://docs.seam.co/core-concepts/workspaces) associated with the event.',
                 format: 'uuid',
                 type: 'string',
               },
@@ -21822,7 +21822,7 @@ const openapi: OpenAPISpec = {
           },
           {
             description:
-              'The status of a [device](https://docs.seam.co/latest/core-concepts/devices) changed from offline to online. That is, the `device.properties.online` property changed from `false` to `true`. Note that some devices operate entirely in offline mode, so Seam never emits a `device.connected` event for these devices.',
+              'The status of a [device](https://docs.seam.co/core-concepts/devices) changed from offline to online. That is, the `device.properties.online` property changed from `false` to `true`. Note that some devices operate entirely in offline mode, so Seam never emits a `device.connected` event for these devices.',
             properties: {
               connected_account_custom_metadata: {
                 additionalProperties: {
@@ -21834,7 +21834,7 @@ const openapi: OpenAPISpec = {
               },
               connected_account_id: {
                 description:
-                  'ID of the [connected account](https://docs.seam.co/latest/core-concepts/connected-accounts) associated with the event.',
+                  'ID of the [connected account](https://docs.seam.co/core-concepts/connected-accounts) associated with the event.',
                 format: 'uuid',
                 type: 'string',
               },
@@ -21874,7 +21874,7 @@ const openapi: OpenAPISpec = {
               },
               workspace_id: {
                 description:
-                  'ID of the [workspace](https://docs.seam.co/latest/core-concepts/workspaces) associated with the event.',
+                  'ID of the [workspace](https://docs.seam.co/core-concepts/workspaces) associated with the event.',
                 format: 'uuid',
                 type: 'string',
               },
@@ -21893,7 +21893,7 @@ const openapi: OpenAPISpec = {
           },
           {
             description:
-              'A [device](https://docs.seam.co/latest/core-concepts/devices) was added to Seam or was re-added to Seam after having been removed.',
+              'A [device](https://docs.seam.co/core-concepts/devices) was added to Seam or was re-added to Seam after having been removed.',
             properties: {
               connected_account_custom_metadata: {
                 additionalProperties: {
@@ -21905,7 +21905,7 @@ const openapi: OpenAPISpec = {
               },
               connected_account_id: {
                 description:
-                  'ID of the [connected account](https://docs.seam.co/latest/core-concepts/connected-accounts) associated with the event.',
+                  'ID of the [connected account](https://docs.seam.co/core-concepts/connected-accounts) associated with the event.',
                 format: 'uuid',
                 type: 'string',
               },
@@ -21945,7 +21945,7 @@ const openapi: OpenAPISpec = {
               },
               workspace_id: {
                 description:
-                  'ID of the [workspace](https://docs.seam.co/latest/core-concepts/workspaces) associated with the event.',
+                  'ID of the [workspace](https://docs.seam.co/core-concepts/workspaces) associated with the event.',
                 format: 'uuid',
                 type: 'string',
               },
@@ -21964,7 +21964,7 @@ const openapi: OpenAPISpec = {
           },
           {
             description:
-              'A managed device was successfully converted to an [unmanaged device](https://docs.seam.co/latest/core-concepts/devices/managed-and-unmanaged-devices).',
+              'A managed device was successfully converted to an [unmanaged device](https://docs.seam.co/core-concepts/devices/managed-and-unmanaged-devices).',
             properties: {
               connected_account_custom_metadata: {
                 additionalProperties: {
@@ -21976,7 +21976,7 @@ const openapi: OpenAPISpec = {
               },
               connected_account_id: {
                 description:
-                  'ID of the [connected account](https://docs.seam.co/latest/core-concepts/connected-accounts) associated with the event.',
+                  'ID of the [connected account](https://docs.seam.co/core-concepts/connected-accounts) associated with the event.',
                 format: 'uuid',
                 type: 'string',
               },
@@ -22019,7 +22019,7 @@ const openapi: OpenAPISpec = {
               },
               workspace_id: {
                 description:
-                  'ID of the [workspace](https://docs.seam.co/latest/core-concepts/workspaces) associated with the event.',
+                  'ID of the [workspace](https://docs.seam.co/core-concepts/workspaces) associated with the event.',
                 format: 'uuid',
                 type: 'string',
               },
@@ -22038,7 +22038,7 @@ const openapi: OpenAPISpec = {
           },
           {
             description:
-              'An [unmanaged device](https://docs.seam.co/latest/core-concepts/devices/managed-and-unmanaged-devices) was successfully converted to a managed device.',
+              'An [unmanaged device](https://docs.seam.co/core-concepts/devices/managed-and-unmanaged-devices) was successfully converted to a managed device.',
             properties: {
               connected_account_custom_metadata: {
                 additionalProperties: {
@@ -22050,7 +22050,7 @@ const openapi: OpenAPISpec = {
               },
               connected_account_id: {
                 description:
-                  'ID of the [connected account](https://docs.seam.co/latest/core-concepts/connected-accounts) associated with the event.',
+                  'ID of the [connected account](https://docs.seam.co/core-concepts/connected-accounts) associated with the event.',
                 format: 'uuid',
                 type: 'string',
               },
@@ -22093,7 +22093,7 @@ const openapi: OpenAPISpec = {
               },
               workspace_id: {
                 description:
-                  'ID of the [workspace](https://docs.seam.co/latest/core-concepts/workspaces) associated with the event.',
+                  'ID of the [workspace](https://docs.seam.co/core-concepts/workspaces) associated with the event.',
                 format: 'uuid',
                 type: 'string',
               },
@@ -22112,7 +22112,7 @@ const openapi: OpenAPISpec = {
           },
           {
             description:
-              'The status of an [unmanaged device](https://docs.seam.co/latest/core-concepts/devices/managed-and-unmanaged-devices) changed from offline to online. That is, the `device.properties.online` property changed from `false` to `true`.',
+              'The status of an [unmanaged device](https://docs.seam.co/core-concepts/devices/managed-and-unmanaged-devices) changed from offline to online. That is, the `device.properties.online` property changed from `false` to `true`.',
             properties: {
               connected_account_custom_metadata: {
                 additionalProperties: {
@@ -22124,7 +22124,7 @@ const openapi: OpenAPISpec = {
               },
               connected_account_id: {
                 description:
-                  'ID of the [connected account](https://docs.seam.co/latest/core-concepts/connected-accounts) associated with the event.',
+                  'ID of the [connected account](https://docs.seam.co/core-concepts/connected-accounts) associated with the event.',
                 format: 'uuid',
                 type: 'string',
               },
@@ -22167,7 +22167,7 @@ const openapi: OpenAPISpec = {
               },
               workspace_id: {
                 description:
-                  'ID of the [workspace](https://docs.seam.co/latest/core-concepts/workspaces) associated with the event.',
+                  'ID of the [workspace](https://docs.seam.co/core-concepts/workspaces) associated with the event.',
                 format: 'uuid',
                 type: 'string',
               },
@@ -22186,7 +22186,7 @@ const openapi: OpenAPISpec = {
           },
           {
             description:
-              'The status of a [device](https://docs.seam.co/latest/core-concepts/devices) changed from online to offline. That is, the `device.properties.online` property changed from `true` to `false`.',
+              'The status of a [device](https://docs.seam.co/core-concepts/devices) changed from online to offline. That is, the `device.properties.online` property changed from `true` to `false`.',
             properties: {
               connected_account_custom_metadata: {
                 additionalProperties: {
@@ -22224,7 +22224,7 @@ const openapi: OpenAPISpec = {
               },
               connected_account_id: {
                 description:
-                  'ID of the [connected account](https://docs.seam.co/latest/core-concepts/connected-accounts) associated with the event.',
+                  'ID of the [connected account](https://docs.seam.co/core-concepts/connected-accounts) associated with the event.',
                 format: 'uuid',
                 type: 'string',
               },
@@ -22352,7 +22352,7 @@ const openapi: OpenAPISpec = {
               },
               workspace_id: {
                 description:
-                  'ID of the [workspace](https://docs.seam.co/latest/core-concepts/workspaces) associated with the event.',
+                  'ID of the [workspace](https://docs.seam.co/core-concepts/workspaces) associated with the event.',
                 format: 'uuid',
                 type: 'string',
               },
@@ -22376,7 +22376,7 @@ const openapi: OpenAPISpec = {
           },
           {
             description:
-              'The status of an [unmanaged device](https://docs.seam.co/latest/core-concepts/devices/managed-and-unmanaged-devices) changed from online to offline. That is, the `device.properties.online` property changed from `true` to `false`.',
+              'The status of an [unmanaged device](https://docs.seam.co/core-concepts/devices/managed-and-unmanaged-devices) changed from online to offline. That is, the `device.properties.online` property changed from `true` to `false`.',
             properties: {
               connected_account_custom_metadata: {
                 additionalProperties: {
@@ -22414,7 +22414,7 @@ const openapi: OpenAPISpec = {
               },
               connected_account_id: {
                 description:
-                  'ID of the [connected account](https://docs.seam.co/latest/core-concepts/connected-accounts) associated with the event.',
+                  'ID of the [connected account](https://docs.seam.co/core-concepts/connected-accounts) associated with the event.',
                 format: 'uuid',
                 type: 'string',
               },
@@ -22545,7 +22545,7 @@ const openapi: OpenAPISpec = {
               },
               workspace_id: {
                 description:
-                  'ID of the [workspace](https://docs.seam.co/latest/core-concepts/workspaces) associated with the event.',
+                  'ID of the [workspace](https://docs.seam.co/core-concepts/workspaces) associated with the event.',
                 format: 'uuid',
                 type: 'string',
               },
@@ -22569,7 +22569,7 @@ const openapi: OpenAPISpec = {
           },
           {
             description:
-              'A [device](https://docs.seam.co/latest/core-concepts/devices) detected that it was tampered with, for example, opened or moved.',
+              'A [device](https://docs.seam.co/core-concepts/devices) detected that it was tampered with, for example, opened or moved.',
             properties: {
               connected_account_custom_metadata: {
                 additionalProperties: {
@@ -22581,7 +22581,7 @@ const openapi: OpenAPISpec = {
               },
               connected_account_id: {
                 description:
-                  'ID of the [connected account](https://docs.seam.co/latest/core-concepts/connected-accounts) associated with the event.',
+                  'ID of the [connected account](https://docs.seam.co/core-concepts/connected-accounts) associated with the event.',
                 format: 'uuid',
                 type: 'string',
               },
@@ -22621,7 +22621,7 @@ const openapi: OpenAPISpec = {
               },
               workspace_id: {
                 description:
-                  'ID of the [workspace](https://docs.seam.co/latest/core-concepts/workspaces) associated with the event.',
+                  'ID of the [workspace](https://docs.seam.co/core-concepts/workspaces) associated with the event.',
                 format: 'uuid',
                 type: 'string',
               },
@@ -22640,7 +22640,7 @@ const openapi: OpenAPISpec = {
           },
           {
             description:
-              'A [device](https://docs.seam.co/latest/core-concepts/devices) battery level dropped below the low threshold.',
+              'A [device](https://docs.seam.co/core-concepts/devices) battery level dropped below the low threshold.',
             properties: {
               battery_level: {
                 description:
@@ -22660,7 +22660,7 @@ const openapi: OpenAPISpec = {
               },
               connected_account_id: {
                 description:
-                  'ID of the [connected account](https://docs.seam.co/latest/core-concepts/connected-accounts) associated with the event.',
+                  'ID of the [connected account](https://docs.seam.co/core-concepts/connected-accounts) associated with the event.',
                 format: 'uuid',
                 type: 'string',
               },
@@ -22700,7 +22700,7 @@ const openapi: OpenAPISpec = {
               },
               workspace_id: {
                 description:
-                  'ID of the [workspace](https://docs.seam.co/latest/core-concepts/workspaces) associated with the event.',
+                  'ID of the [workspace](https://docs.seam.co/core-concepts/workspaces) associated with the event.',
                 format: 'uuid',
                 type: 'string',
               },
@@ -22720,7 +22720,7 @@ const openapi: OpenAPISpec = {
           },
           {
             description:
-              'A [device](https://docs.seam.co/latest/core-concepts/devices) battery status changed since the last `battery_status_changed` event.',
+              'A [device](https://docs.seam.co/core-concepts/devices) battery status changed since the last `battery_status_changed` event.',
             properties: {
               battery_level: {
                 description:
@@ -22746,7 +22746,7 @@ const openapi: OpenAPISpec = {
               },
               connected_account_id: {
                 description:
-                  'ID of the [connected account](https://docs.seam.co/latest/core-concepts/connected-accounts) associated with the event.',
+                  'ID of the [connected account](https://docs.seam.co/core-concepts/connected-accounts) associated with the event.',
                 format: 'uuid',
                 type: 'string',
               },
@@ -22789,7 +22789,7 @@ const openapi: OpenAPISpec = {
               },
               workspace_id: {
                 description:
-                  'ID of the [workspace](https://docs.seam.co/latest/core-concepts/workspaces) associated with the event.',
+                  'ID of the [workspace](https://docs.seam.co/core-concepts/workspaces) associated with the event.',
                 format: 'uuid',
                 type: 'string',
               },
@@ -22810,7 +22810,7 @@ const openapi: OpenAPISpec = {
           },
           {
             description:
-              'A [device](https://docs.seam.co/latest/core-concepts/devices) was removed externally from the [connected account](https://docs.seam.co/latest/core-concepts/connected-accounts).',
+              'A [device](https://docs.seam.co/core-concepts/devices) was removed externally from the [connected account](https://docs.seam.co/core-concepts/connected-accounts).',
             properties: {
               connected_account_custom_metadata: {
                 additionalProperties: {
@@ -22822,7 +22822,7 @@ const openapi: OpenAPISpec = {
               },
               connected_account_id: {
                 description:
-                  'ID of the [connected account](https://docs.seam.co/latest/core-concepts/connected-accounts) associated with the event.',
+                  'ID of the [connected account](https://docs.seam.co/core-concepts/connected-accounts) associated with the event.',
                 format: 'uuid',
                 type: 'string',
               },
@@ -22862,7 +22862,7 @@ const openapi: OpenAPISpec = {
               },
               workspace_id: {
                 description:
-                  'ID of the [workspace](https://docs.seam.co/latest/core-concepts/workspaces) associated with the event.',
+                  'ID of the [workspace](https://docs.seam.co/core-concepts/workspaces) associated with the event.',
                 format: 'uuid',
                 type: 'string',
               },
@@ -22881,7 +22881,7 @@ const openapi: OpenAPISpec = {
           },
           {
             description:
-              'A [device](https://docs.seam.co/latest/core-concepts/devices) was deleted.',
+              'A [device](https://docs.seam.co/core-concepts/devices) was deleted.',
             properties: {
               connected_account_custom_metadata: {
                 additionalProperties: {
@@ -22893,7 +22893,7 @@ const openapi: OpenAPISpec = {
               },
               connected_account_id: {
                 description:
-                  'ID of the [connected account](https://docs.seam.co/latest/core-concepts/connected-accounts) associated with the event.',
+                  'ID of the [connected account](https://docs.seam.co/core-concepts/connected-accounts) associated with the event.',
                 format: 'uuid',
                 type: 'string',
               },
@@ -22933,7 +22933,7 @@ const openapi: OpenAPISpec = {
               },
               workspace_id: {
                 description:
-                  'ID of the [workspace](https://docs.seam.co/latest/core-concepts/workspaces) associated with the event.',
+                  'ID of the [workspace](https://docs.seam.co/core-concepts/workspaces) associated with the event.',
                 format: 'uuid',
                 type: 'string',
               },
@@ -22952,7 +22952,7 @@ const openapi: OpenAPISpec = {
           },
           {
             description:
-              'Seam detected that a [device](https://docs.seam.co/latest/core-concepts/devices) is using a third-party integration that will interfere with Seam device management.',
+              'Seam detected that a [device](https://docs.seam.co/core-concepts/devices) is using a third-party integration that will interfere with Seam device management.',
             properties: {
               connected_account_custom_metadata: {
                 additionalProperties: {
@@ -22964,7 +22964,7 @@ const openapi: OpenAPISpec = {
               },
               connected_account_id: {
                 description:
-                  'ID of the [connected account](https://docs.seam.co/latest/core-concepts/connected-accounts) associated with the event.',
+                  'ID of the [connected account](https://docs.seam.co/core-concepts/connected-accounts) associated with the event.',
                 format: 'uuid',
                 type: 'string',
               },
@@ -23007,7 +23007,7 @@ const openapi: OpenAPISpec = {
               },
               workspace_id: {
                 description:
-                  'ID of the [workspace](https://docs.seam.co/latest/core-concepts/workspaces) associated with the event.',
+                  'ID of the [workspace](https://docs.seam.co/core-concepts/workspaces) associated with the event.',
                 format: 'uuid',
                 type: 'string',
               },
@@ -23026,7 +23026,7 @@ const openapi: OpenAPISpec = {
           },
           {
             description:
-              'Seam detected that a [device](https://docs.seam.co/latest/core-concepts/devices) is no longer using a third-party integration that was interfering with Seam device management.',
+              'Seam detected that a [device](https://docs.seam.co/core-concepts/devices) is no longer using a third-party integration that was interfering with Seam device management.',
             properties: {
               connected_account_custom_metadata: {
                 additionalProperties: {
@@ -23038,7 +23038,7 @@ const openapi: OpenAPISpec = {
               },
               connected_account_id: {
                 description:
-                  'ID of the [connected account](https://docs.seam.co/latest/core-concepts/connected-accounts) associated with the event.',
+                  'ID of the [connected account](https://docs.seam.co/core-concepts/connected-accounts) associated with the event.',
                 format: 'uuid',
                 type: 'string',
               },
@@ -23081,7 +23081,7 @@ const openapi: OpenAPISpec = {
               },
               workspace_id: {
                 description:
-                  'ID of the [workspace](https://docs.seam.co/latest/core-concepts/workspaces) associated with the event.',
+                  'ID of the [workspace](https://docs.seam.co/core-concepts/workspaces) associated with the event.',
                 format: 'uuid',
                 type: 'string',
               },
@@ -23100,7 +23100,7 @@ const openapi: OpenAPISpec = {
           },
           {
             description:
-              'A [Salto device](https://docs.seam.co/latest/device-and-system-integration-guides/salto-locks) activated privacy mode.',
+              'A [Salto device](https://docs.seam.co/device-and-system-integration-guides/salto-locks) activated privacy mode.',
             properties: {
               connected_account_custom_metadata: {
                 additionalProperties: {
@@ -23112,7 +23112,7 @@ const openapi: OpenAPISpec = {
               },
               connected_account_id: {
                 description:
-                  'ID of the [connected account](https://docs.seam.co/latest/core-concepts/connected-accounts) associated with the event.',
+                  'ID of the [connected account](https://docs.seam.co/core-concepts/connected-accounts) associated with the event.',
                 format: 'uuid',
                 type: 'string',
               },
@@ -23155,7 +23155,7 @@ const openapi: OpenAPISpec = {
               },
               workspace_id: {
                 description:
-                  'ID of the [workspace](https://docs.seam.co/latest/core-concepts/workspaces) associated with the event.',
+                  'ID of the [workspace](https://docs.seam.co/core-concepts/workspaces) associated with the event.',
                 format: 'uuid',
                 type: 'string',
               },
@@ -23174,7 +23174,7 @@ const openapi: OpenAPISpec = {
           },
           {
             description:
-              'A [Salto device](https://docs.seam.co/latest/device-and-system-integration-guides/salto-locks) deactivated privacy mode.',
+              'A [Salto device](https://docs.seam.co/device-and-system-integration-guides/salto-locks) deactivated privacy mode.',
             properties: {
               connected_account_custom_metadata: {
                 additionalProperties: {
@@ -23186,7 +23186,7 @@ const openapi: OpenAPISpec = {
               },
               connected_account_id: {
                 description:
-                  'ID of the [connected account](https://docs.seam.co/latest/core-concepts/connected-accounts) associated with the event.',
+                  'ID of the [connected account](https://docs.seam.co/core-concepts/connected-accounts) associated with the event.',
                 format: 'uuid',
                 type: 'string',
               },
@@ -23229,7 +23229,7 @@ const openapi: OpenAPISpec = {
               },
               workspace_id: {
                 description:
-                  'ID of the [workspace](https://docs.seam.co/latest/core-concepts/workspaces) associated with the event.',
+                  'ID of the [workspace](https://docs.seam.co/core-concepts/workspaces) associated with the event.',
                 format: 'uuid',
                 type: 'string',
               },
@@ -23248,7 +23248,7 @@ const openapi: OpenAPISpec = {
           },
           {
             description:
-              'Seam detected a flaky [device](https://docs.seam.co/latest/core-concepts/devices) connection.',
+              'Seam detected a flaky [device](https://docs.seam.co/core-concepts/devices) connection.',
             properties: {
               connected_account_custom_metadata: {
                 additionalProperties: {
@@ -23286,7 +23286,7 @@ const openapi: OpenAPISpec = {
               },
               connected_account_id: {
                 description:
-                  'ID of the [connected account](https://docs.seam.co/latest/core-concepts/connected-accounts) associated with the event.',
+                  'ID of the [connected account](https://docs.seam.co/core-concepts/connected-accounts) associated with the event.',
                 format: 'uuid',
                 type: 'string',
               },
@@ -23407,7 +23407,7 @@ const openapi: OpenAPISpec = {
               },
               workspace_id: {
                 description:
-                  'ID of the [workspace](https://docs.seam.co/latest/core-concepts/workspaces) associated with the event.',
+                  'ID of the [workspace](https://docs.seam.co/core-concepts/workspaces) associated with the event.',
                 format: 'uuid',
                 type: 'string',
               },
@@ -23430,7 +23430,7 @@ const openapi: OpenAPISpec = {
           },
           {
             description:
-              'Seam detected that a previously-flaky [device](https://docs.seam.co/latest/core-concepts/devices) connection stabilized.',
+              'Seam detected that a previously-flaky [device](https://docs.seam.co/core-concepts/devices) connection stabilized.',
             properties: {
               connected_account_custom_metadata: {
                 additionalProperties: {
@@ -23442,7 +23442,7 @@ const openapi: OpenAPISpec = {
               },
               connected_account_id: {
                 description:
-                  'ID of the [connected account](https://docs.seam.co/latest/core-concepts/connected-accounts) associated with the event.',
+                  'ID of the [connected account](https://docs.seam.co/core-concepts/connected-accounts) associated with the event.',
                 format: 'uuid',
                 type: 'string',
               },
@@ -23485,7 +23485,7 @@ const openapi: OpenAPISpec = {
               },
               workspace_id: {
                 description:
-                  'ID of the [workspace](https://docs.seam.co/latest/core-concepts/workspaces) associated with the event.',
+                  'ID of the [workspace](https://docs.seam.co/core-concepts/workspaces) associated with the event.',
                 format: 'uuid',
                 type: 'string',
               },
@@ -23504,7 +23504,7 @@ const openapi: OpenAPISpec = {
           },
           {
             description:
-              'A third-party subscription is required to use all [device](https://docs.seam.co/latest/core-concepts/devices) features.',
+              'A third-party subscription is required to use all [device](https://docs.seam.co/core-concepts/devices) features.',
             properties: {
               connected_account_custom_metadata: {
                 additionalProperties: {
@@ -23542,7 +23542,7 @@ const openapi: OpenAPISpec = {
               },
               connected_account_id: {
                 description:
-                  'ID of the [connected account](https://docs.seam.co/latest/core-concepts/connected-accounts) associated with the event.',
+                  'ID of the [connected account](https://docs.seam.co/core-concepts/connected-accounts) associated with the event.',
                 format: 'uuid',
                 type: 'string',
               },
@@ -23663,7 +23663,7 @@ const openapi: OpenAPISpec = {
               },
               workspace_id: {
                 description:
-                  'ID of the [workspace](https://docs.seam.co/latest/core-concepts/workspaces) associated with the event.',
+                  'ID of the [workspace](https://docs.seam.co/core-concepts/workspaces) associated with the event.',
                 format: 'uuid',
                 type: 'string',
               },
@@ -23686,7 +23686,7 @@ const openapi: OpenAPISpec = {
           },
           {
             description:
-              'A third-party subscription is active or no longer required to use all [device](https://docs.seam.co/latest/core-concepts/devices) features.',
+              'A third-party subscription is active or no longer required to use all [device](https://docs.seam.co/core-concepts/devices) features.',
             properties: {
               connected_account_custom_metadata: {
                 additionalProperties: {
@@ -23698,7 +23698,7 @@ const openapi: OpenAPISpec = {
               },
               connected_account_id: {
                 description:
-                  'ID of the [connected account](https://docs.seam.co/latest/core-concepts/connected-accounts) associated with the event.',
+                  'ID of the [connected account](https://docs.seam.co/core-concepts/connected-accounts) associated with the event.',
                 format: 'uuid',
                 type: 'string',
               },
@@ -23741,7 +23741,7 @@ const openapi: OpenAPISpec = {
               },
               workspace_id: {
                 description:
-                  'ID of the [workspace](https://docs.seam.co/latest/core-concepts/workspaces) associated with the event.',
+                  'ID of the [workspace](https://docs.seam.co/core-concepts/workspaces) associated with the event.',
                 format: 'uuid',
                 type: 'string',
               },
@@ -23760,7 +23760,7 @@ const openapi: OpenAPISpec = {
           },
           {
             description:
-              'An accessory keypad was connected to a [device](https://docs.seam.co/latest/core-concepts/devices).',
+              'An accessory keypad was connected to a [device](https://docs.seam.co/core-concepts/devices).',
             properties: {
               connected_account_custom_metadata: {
                 additionalProperties: {
@@ -23772,7 +23772,7 @@ const openapi: OpenAPISpec = {
               },
               connected_account_id: {
                 description:
-                  'ID of the [connected account](https://docs.seam.co/latest/core-concepts/connected-accounts) associated with the event.',
+                  'ID of the [connected account](https://docs.seam.co/core-concepts/connected-accounts) associated with the event.',
                 format: 'uuid',
                 type: 'string',
               },
@@ -23815,7 +23815,7 @@ const openapi: OpenAPISpec = {
               },
               workspace_id: {
                 description:
-                  'ID of the [workspace](https://docs.seam.co/latest/core-concepts/workspaces) associated with the event.',
+                  'ID of the [workspace](https://docs.seam.co/core-concepts/workspaces) associated with the event.',
                 format: 'uuid',
                 type: 'string',
               },
@@ -23834,7 +23834,7 @@ const openapi: OpenAPISpec = {
           },
           {
             description:
-              'An accessory keypad was disconnected from a [device](https://docs.seam.co/latest/core-concepts/devices).',
+              'An accessory keypad was disconnected from a [device](https://docs.seam.co/core-concepts/devices).',
             properties: {
               connected_account_custom_metadata: {
                 additionalProperties: {
@@ -23872,7 +23872,7 @@ const openapi: OpenAPISpec = {
               },
               connected_account_id: {
                 description:
-                  'ID of the [connected account](https://docs.seam.co/latest/core-concepts/connected-accounts) associated with the event.',
+                  'ID of the [connected account](https://docs.seam.co/core-concepts/connected-accounts) associated with the event.',
                 format: 'uuid',
                 type: 'string',
               },
@@ -23993,7 +23993,7 @@ const openapi: OpenAPISpec = {
               },
               workspace_id: {
                 description:
-                  'ID of the [workspace](https://docs.seam.co/latest/core-concepts/workspaces) associated with the event.',
+                  'ID of the [workspace](https://docs.seam.co/core-concepts/workspaces) associated with the event.',
                 format: 'uuid',
                 type: 'string',
               },
@@ -24016,7 +24016,7 @@ const openapi: OpenAPISpec = {
           },
           {
             description:
-              'Extended periods of noise or noise exceeding a [threshold](https://docs.seam.co/latest/capability-guides/noise-sensors#what-is-a-threshold) were detected.',
+              'Extended periods of noise or noise exceeding a [threshold](https://docs.seam.co/capability-guides/noise-sensors#what-is-a-threshold) were detected.',
             properties: {
               connected_account_custom_metadata: {
                 additionalProperties: {
@@ -24028,7 +24028,7 @@ const openapi: OpenAPISpec = {
               },
               connected_account_id: {
                 description:
-                  'ID of the [connected account](https://docs.seam.co/latest/core-concepts/connected-accounts) associated with the event.',
+                  'ID of the [connected account](https://docs.seam.co/core-concepts/connected-accounts) associated with the event.',
                 format: 'uuid',
                 type: 'string',
               },
@@ -24101,7 +24101,7 @@ const openapi: OpenAPISpec = {
               },
               workspace_id: {
                 description:
-                  'ID of the [workspace](https://docs.seam.co/latest/core-concepts/workspaces) associated with the event.',
+                  'ID of the [workspace](https://docs.seam.co/core-concepts/workspaces) associated with the event.',
                 format: 'uuid',
                 type: 'string',
               },
@@ -24120,7 +24120,7 @@ const openapi: OpenAPISpec = {
           },
           {
             description:
-              'A [lock](https://docs.seam.co/latest/capability-guides/smart-locks) was locked.',
+              'A [lock](https://docs.seam.co/capability-guides/smart-locks) was locked.',
             properties: {
               access_code_id: {
                 description:
@@ -24149,7 +24149,7 @@ const openapi: OpenAPISpec = {
               },
               connected_account_id: {
                 description:
-                  'ID of the [connected account](https://docs.seam.co/latest/core-concepts/connected-accounts) associated with the event.',
+                  'ID of the [connected account](https://docs.seam.co/core-concepts/connected-accounts) associated with the event.',
                 format: 'uuid',
                 type: 'string',
               },
@@ -24205,7 +24205,7 @@ const openapi: OpenAPISpec = {
               },
               workspace_id: {
                 description:
-                  'ID of the [workspace](https://docs.seam.co/latest/core-concepts/workspaces) associated with the event.',
+                  'ID of the [workspace](https://docs.seam.co/core-concepts/workspaces) associated with the event.',
                 format: 'uuid',
                 type: 'string',
               },
@@ -24225,7 +24225,7 @@ const openapi: OpenAPISpec = {
           },
           {
             description:
-              'A [lock](https://docs.seam.co/latest/capability-guides/smart-locks) was unlocked.',
+              'A [lock](https://docs.seam.co/capability-guides/smart-locks) was unlocked.',
             properties: {
               access_code_id: {
                 description:
@@ -24272,7 +24272,7 @@ const openapi: OpenAPISpec = {
               },
               connected_account_id: {
                 description:
-                  'ID of the [connected account](https://docs.seam.co/latest/core-concepts/connected-accounts) associated with the event.',
+                  'ID of the [connected account](https://docs.seam.co/core-concepts/connected-accounts) associated with the event.',
                 format: 'uuid',
                 type: 'string',
               },
@@ -24317,7 +24317,7 @@ const openapi: OpenAPISpec = {
               },
               method: {
                 description:
-                  'Method by which the lock was unlocked. `keycode`: an [access code](https://docs.seam.co/latest/capability-guides/smart-locks/access-codes) was used (see `access_code_id`). `manual`: a physical action such as a thumbturn or handle press. `remote`: a remote action via an app, Bluetooth, or the Seam API (see `action_attempt_id` if Seam-initiated; see `is_via_bluetooth` or `is_via_nfc` for the transport). `automatic`: triggered automatically, for example by a time-based schedule. `unknown`: could not be determined.',
+                  'Method by which the lock was unlocked. `keycode`: an [access code](https://docs.seam.co/capability-guides/smart-locks/access-codes) was used (see `access_code_id`). `manual`: a physical action such as a thumbturn or handle press. `remote`: a remote action via an app, Bluetooth, or the Seam API (see `action_attempt_id` if Seam-initiated; see `is_via_bluetooth` or `is_via_nfc` for the transport). `automatic`: triggered automatically, for example by a time-based schedule. `unknown`: could not be determined.',
                 enum: ['keycode', 'manual', 'automatic', 'unknown', 'remote'],
                 type: 'string',
               },
@@ -24334,7 +24334,7 @@ const openapi: OpenAPISpec = {
               },
               workspace_id: {
                 description:
-                  'ID of the [workspace](https://docs.seam.co/latest/core-concepts/workspaces) associated with the event.',
+                  'ID of the [workspace](https://docs.seam.co/core-concepts/workspaces) associated with the event.',
                 format: 'uuid',
                 type: 'string',
               },
@@ -24353,7 +24353,7 @@ const openapi: OpenAPISpec = {
           },
           {
             description:
-              'The [lock](https://docs.seam.co/latest/capability-guides/smart-locks) denied access to a user after one or more consecutive invalid attempts to unlock the device.',
+              'The [lock](https://docs.seam.co/capability-guides/smart-locks) denied access to a user after one or more consecutive invalid attempts to unlock the device.',
             properties: {
               access_code_id: {
                 description:
@@ -24371,7 +24371,7 @@ const openapi: OpenAPISpec = {
               },
               connected_account_id: {
                 description:
-                  'ID of the [connected account](https://docs.seam.co/latest/core-concepts/connected-accounts) associated with the event.',
+                  'ID of the [connected account](https://docs.seam.co/core-concepts/connected-accounts) associated with the event.',
                 format: 'uuid',
                 type: 'string',
               },
@@ -24411,7 +24411,7 @@ const openapi: OpenAPISpec = {
               },
               workspace_id: {
                 description:
-                  'ID of the [workspace](https://docs.seam.co/latest/core-concepts/workspaces) associated with the event.',
+                  'ID of the [workspace](https://docs.seam.co/core-concepts/workspaces) associated with the event.',
                 format: 'uuid',
                 type: 'string',
               },
@@ -24430,7 +24430,7 @@ const openapi: OpenAPISpec = {
           },
           {
             description:
-              'A thermostat [climate preset](https://docs.seam.co/latest/capability-guides/thermostats/creating-and-managing-climate-presets) was activated.',
+              'A thermostat [climate preset](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-climate-presets) was activated.',
             properties: {
               climate_preset_key: {
                 description: 'Key of the climate preset that was activated.',
@@ -24446,7 +24446,7 @@ const openapi: OpenAPISpec = {
               },
               connected_account_id: {
                 description:
-                  'ID of the [connected account](https://docs.seam.co/latest/core-concepts/connected-accounts) associated with the event.',
+                  'ID of the [connected account](https://docs.seam.co/core-concepts/connected-accounts) associated with the event.',
                 format: 'uuid',
                 type: 'string',
               },
@@ -24501,7 +24501,7 @@ const openapi: OpenAPISpec = {
               },
               workspace_id: {
                 description:
-                  'ID of the [workspace](https://docs.seam.co/latest/core-concepts/workspaces) associated with the event.',
+                  'ID of the [workspace](https://docs.seam.co/core-concepts/workspaces) associated with the event.',
                 format: 'uuid',
                 type: 'string',
               },
@@ -24523,7 +24523,7 @@ const openapi: OpenAPISpec = {
           },
           {
             description:
-              'A [thermostat](https://docs.seam.co/latest/capability-guides/thermostats) was adjusted manually.',
+              'A [thermostat](https://docs.seam.co/capability-guides/thermostats) was adjusted manually.',
             properties: {
               connected_account_custom_metadata: {
                 additionalProperties: {
@@ -24535,19 +24535,19 @@ const openapi: OpenAPISpec = {
               },
               connected_account_id: {
                 description:
-                  'ID of the [connected account](https://docs.seam.co/latest/core-concepts/connected-accounts) associated with the event.',
+                  'ID of the [connected account](https://docs.seam.co/core-concepts/connected-accounts) associated with the event.',
                 format: 'uuid',
                 type: 'string',
               },
               cooling_set_point_celsius: {
                 description:
-                  'Temperature to which the thermostat should cool (in °C). See also [Set Points](https://docs.seam.co/latest/capability-guides/thermostats/understanding-thermostat-concepts/set-points).',
+                  'Temperature to which the thermostat should cool (in °C). See also [Set Points](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/set-points).',
                 format: 'float',
                 type: 'number',
               },
               cooling_set_point_fahrenheit: {
                 description:
-                  'Temperature to which the thermostat should cool (in °F). See also [Set Points](https://docs.seam.co/latest/capability-guides/thermostats/understanding-thermostat-concepts/set-points).',
+                  'Temperature to which the thermostat should cool (in °F). See also [Set Points](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/set-points).',
                 format: 'float',
                 type: 'number',
               },
@@ -24585,25 +24585,25 @@ const openapi: OpenAPISpec = {
               },
               fan_mode_setting: {
                 description:
-                  'Desired [fan mode setting](https://docs.seam.co/latest/capability-guides/thermostats/configure-current-climate-settings#fan-mode-settings), such as `on`, `auto`, or `circulate`.',
+                  'Desired [fan mode setting](https://docs.seam.co/capability-guides/thermostats/configure-current-climate-settings#fan-mode-settings), such as `on`, `auto`, or `circulate`.',
                 enum: ['auto', 'on', 'circulate'],
                 type: 'string',
               },
               heating_set_point_celsius: {
                 description:
-                  'Temperature to which the thermostat should heat (in °C). See also [Set Points](https://docs.seam.co/latest/capability-guides/thermostats/understanding-thermostat-concepts/set-points).',
+                  'Temperature to which the thermostat should heat (in °C). See also [Set Points](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/set-points).',
                 format: 'float',
                 type: 'number',
               },
               heating_set_point_fahrenheit: {
                 description:
-                  'Temperature to which the thermostat should heat (in °F). See also [Set Points](https://docs.seam.co/latest/capability-guides/thermostats/understanding-thermostat-concepts/set-points).',
+                  'Temperature to which the thermostat should heat (in °F). See also [Set Points](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/set-points).',
                 format: 'float',
                 type: 'number',
               },
               hvac_mode_setting: {
                 description:
-                  'Desired [HVAC mode](https://docs.seam.co/latest/capability-guides/thermostats/understanding-thermostat-concepts/hvac-mode) setting, such as `heat`, `cool`, `heat_cool`, or `off`.',
+                  'Desired [HVAC mode](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/hvac-mode) setting, such as `heat`, `cool`, `heat_cool`, or `off`.',
                 enum: ['off', 'heat', 'cool', 'heat_cool', 'eco'],
                 type: 'string',
               },
@@ -24620,7 +24620,7 @@ const openapi: OpenAPISpec = {
               },
               workspace_id: {
                 description:
-                  'ID of the [workspace](https://docs.seam.co/latest/core-concepts/workspaces) associated with the event.',
+                  'ID of the [workspace](https://docs.seam.co/core-concepts/workspaces) associated with the event.',
                 format: 'uuid',
                 type: 'string',
               },
@@ -24640,7 +24640,7 @@ const openapi: OpenAPISpec = {
           },
           {
             description:
-              "A [thermostat's](https://docs.seam.co/latest/capability-guides/thermostats) temperature reading exceeded the set [threshold](https://docs.seam.co/latest/capability-guides/thermostats/setting-and-monitoring-temperature-thresholds).",
+              "A [thermostat's](https://docs.seam.co/capability-guides/thermostats) temperature reading exceeded the set [threshold](https://docs.seam.co/capability-guides/thermostats/setting-and-monitoring-temperature-thresholds).",
             properties: {
               connected_account_custom_metadata: {
                 additionalProperties: {
@@ -24652,7 +24652,7 @@ const openapi: OpenAPISpec = {
               },
               connected_account_id: {
                 description:
-                  'ID of the [connected account](https://docs.seam.co/latest/core-concepts/connected-accounts) associated with the event.',
+                  'ID of the [connected account](https://docs.seam.co/core-concepts/connected-accounts) associated with the event.',
                 format: 'uuid',
                 type: 'string',
               },
@@ -24735,7 +24735,7 @@ const openapi: OpenAPISpec = {
               },
               workspace_id: {
                 description:
-                  'ID of the [workspace](https://docs.seam.co/latest/core-concepts/workspaces) associated with the event.',
+                  'ID of the [workspace](https://docs.seam.co/core-concepts/workspaces) associated with the event.',
                 format: 'uuid',
                 type: 'string',
               },
@@ -24760,7 +24760,7 @@ const openapi: OpenAPISpec = {
           },
           {
             description:
-              "A [thermostat's](https://docs.seam.co/latest/capability-guides/thermostats) temperature reading no longer exceeds the set [threshold](https://docs.seam.co/latest/capability-guides/thermostats/setting-and-monitoring-temperature-thresholds).",
+              "A [thermostat's](https://docs.seam.co/capability-guides/thermostats) temperature reading no longer exceeds the set [threshold](https://docs.seam.co/capability-guides/thermostats/setting-and-monitoring-temperature-thresholds).",
             properties: {
               connected_account_custom_metadata: {
                 additionalProperties: {
@@ -24772,7 +24772,7 @@ const openapi: OpenAPISpec = {
               },
               connected_account_id: {
                 description:
-                  'ID of the [connected account](https://docs.seam.co/latest/core-concepts/connected-accounts) associated with the event.',
+                  'ID of the [connected account](https://docs.seam.co/core-concepts/connected-accounts) associated with the event.',
                 format: 'uuid',
                 type: 'string',
               },
@@ -24855,7 +24855,7 @@ const openapi: OpenAPISpec = {
               },
               workspace_id: {
                 description:
-                  'ID of the [workspace](https://docs.seam.co/latest/core-concepts/workspaces) associated with the event.',
+                  'ID of the [workspace](https://docs.seam.co/core-concepts/workspaces) associated with the event.',
                 format: 'uuid',
                 type: 'string',
               },
@@ -24880,7 +24880,7 @@ const openapi: OpenAPISpec = {
           },
           {
             description:
-              "A [thermostat's](https://docs.seam.co/latest/capability-guides/thermostats) temperature reading is within 1 °C of the configured cooling or heating [set point](https://docs.seam.co/latest/capability-guides/thermostats/understanding-thermostat-concepts/set-points).",
+              "A [thermostat's](https://docs.seam.co/capability-guides/thermostats) temperature reading is within 1 °C of the configured cooling or heating [set point](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/set-points).",
             properties: {
               connected_account_custom_metadata: {
                 additionalProperties: {
@@ -24892,7 +24892,7 @@ const openapi: OpenAPISpec = {
               },
               connected_account_id: {
                 description:
-                  'ID of the [connected account](https://docs.seam.co/latest/core-concepts/connected-accounts) associated with the event.',
+                  'ID of the [connected account](https://docs.seam.co/core-concepts/connected-accounts) associated with the event.',
                 format: 'uuid',
                 type: 'string',
               },
@@ -24959,7 +24959,7 @@ const openapi: OpenAPISpec = {
               },
               workspace_id: {
                 description:
-                  'ID of the [workspace](https://docs.seam.co/latest/core-concepts/workspaces) associated with the event.',
+                  'ID of the [workspace](https://docs.seam.co/core-concepts/workspaces) associated with the event.',
                 format: 'uuid',
                 type: 'string',
               },
@@ -24980,7 +24980,7 @@ const openapi: OpenAPISpec = {
           },
           {
             description:
-              "A [thermostat's](https://docs.seam.co/latest/capability-guides/thermostats) reported temperature changed by at least 1 °C.",
+              "A [thermostat's](https://docs.seam.co/capability-guides/thermostats) reported temperature changed by at least 1 °C.",
             properties: {
               connected_account_custom_metadata: {
                 additionalProperties: {
@@ -24992,7 +24992,7 @@ const openapi: OpenAPISpec = {
               },
               connected_account_id: {
                 description:
-                  'ID of the [connected account](https://docs.seam.co/latest/core-concepts/connected-accounts) associated with the event.',
+                  'ID of the [connected account](https://docs.seam.co/core-concepts/connected-accounts) associated with the event.',
                 format: 'uuid',
                 type: 'string',
               },
@@ -25047,7 +25047,7 @@ const openapi: OpenAPISpec = {
               },
               workspace_id: {
                 description:
-                  'ID of the [workspace](https://docs.seam.co/latest/core-concepts/workspaces) associated with the event.',
+                  'ID of the [workspace](https://docs.seam.co/core-concepts/workspaces) associated with the event.',
                 format: 'uuid',
                 type: 'string',
               },
@@ -25068,7 +25068,7 @@ const openapi: OpenAPISpec = {
           },
           {
             description:
-              'The name of a [device](https://docs.seam.co/latest/core-concepts/devices) was changed.',
+              'The name of a [device](https://docs.seam.co/core-concepts/devices) was changed.',
             properties: {
               connected_account_custom_metadata: {
                 additionalProperties: {
@@ -25080,7 +25080,7 @@ const openapi: OpenAPISpec = {
               },
               connected_account_id: {
                 description:
-                  'ID of the [connected account](https://docs.seam.co/latest/core-concepts/connected-accounts) associated with the event.',
+                  'ID of the [connected account](https://docs.seam.co/core-concepts/connected-accounts) associated with the event.',
                 format: 'uuid',
                 type: 'string',
               },
@@ -25124,7 +25124,7 @@ const openapi: OpenAPISpec = {
               },
               workspace_id: {
                 description:
-                  'ID of the [workspace](https://docs.seam.co/latest/core-concepts/workspaces) associated with the event.',
+                  'ID of the [workspace](https://docs.seam.co/core-concepts/workspaces) associated with the event.',
                 format: 'uuid',
                 type: 'string',
               },
@@ -25144,7 +25144,7 @@ const openapi: OpenAPISpec = {
           },
           {
             description:
-              'A [camera](https://docs.seam.co/latest/core-concepts/devices) was activated, for example, by motion detection.',
+              'A [camera](https://docs.seam.co/core-concepts/devices) was activated, for example, by motion detection.',
             properties: {
               activation_reason: {
                 description: 'The reason the camera was activated.',
@@ -25161,7 +25161,7 @@ const openapi: OpenAPISpec = {
               },
               connected_account_id: {
                 description:
-                  'ID of the [connected account](https://docs.seam.co/latest/core-concepts/connected-accounts) associated with the event.',
+                  'ID of the [connected account](https://docs.seam.co/core-concepts/connected-accounts) associated with the event.',
                 format: 'uuid',
                 type: 'string',
               },
@@ -25218,7 +25218,7 @@ const openapi: OpenAPISpec = {
               },
               workspace_id: {
                 description:
-                  'ID of the [workspace](https://docs.seam.co/latest/core-concepts/workspaces) associated with the event.',
+                  'ID of the [workspace](https://docs.seam.co/core-concepts/workspaces) associated with the event.',
                 format: 'uuid',
                 type: 'string',
               },
@@ -25238,7 +25238,7 @@ const openapi: OpenAPISpec = {
           },
           {
             description:
-              'A doorbell button was pressed on a [device](https://docs.seam.co/latest/core-concepts/devices).',
+              'A doorbell button was pressed on a [device](https://docs.seam.co/core-concepts/devices).',
             properties: {
               connected_account_custom_metadata: {
                 additionalProperties: {
@@ -25250,7 +25250,7 @@ const openapi: OpenAPISpec = {
               },
               connected_account_id: {
                 description:
-                  'ID of the [connected account](https://docs.seam.co/latest/core-concepts/connected-accounts) associated with the event.',
+                  'ID of the [connected account](https://docs.seam.co/core-concepts/connected-accounts) associated with the event.',
                 format: 'uuid',
                 type: 'string',
               },
@@ -25302,7 +25302,7 @@ const openapi: OpenAPISpec = {
               },
               workspace_id: {
                 description:
-                  'ID of the [workspace](https://docs.seam.co/latest/core-concepts/workspaces) associated with the event.',
+                  'ID of the [workspace](https://docs.seam.co/core-concepts/workspaces) associated with the event.',
                 format: 'uuid',
                 type: 'string',
               },
@@ -25321,7 +25321,7 @@ const openapi: OpenAPISpec = {
           },
           {
             description:
-              'An [enrollment automation](https://docs.seam.co/latest/capability-guides/mobile-access/issuing-mobile-credentials-from-an-access-control-system#prepare-the-phones-for-a-user-identity-to-start-receiving-mobile-credentials-using-an-enrollment-aut) was deleted.',
+              'An [enrollment automation](https://docs.seam.co/capability-guides/mobile-access/issuing-mobile-credentials-from-an-access-control-system#prepare-the-phones-for-a-user-identity-to-start-receiving-mobile-credentials-using-an-enrollment-aut) was deleted.',
             properties: {
               created_at: {
                 description: 'Date and time at which the event was created.',
@@ -25349,7 +25349,7 @@ const openapi: OpenAPISpec = {
               },
               workspace_id: {
                 description:
-                  'ID of the [workspace](https://docs.seam.co/latest/core-concepts/workspaces) associated with the event.',
+                  'ID of the [workspace](https://docs.seam.co/core-concepts/workspaces) associated with the event.',
                 format: 'uuid',
                 type: 'string',
               },
@@ -25399,7 +25399,7 @@ const openapi: OpenAPISpec = {
               },
               workspace_id: {
                 description:
-                  'ID of the [workspace](https://docs.seam.co/latest/core-concepts/workspaces) associated with the event.',
+                  'ID of the [workspace](https://docs.seam.co/core-concepts/workspaces) associated with the event.',
                 format: 'uuid',
                 type: 'string',
               },
@@ -25461,7 +25461,7 @@ const openapi: OpenAPISpec = {
               },
               workspace_id: {
                 description:
-                  'ID of the [workspace](https://docs.seam.co/latest/core-concepts/workspaces) associated with the event.',
+                  'ID of the [workspace](https://docs.seam.co/core-concepts/workspaces) associated with the event.',
                 format: 'uuid',
                 type: 'string',
               },
@@ -25525,7 +25525,7 @@ const openapi: OpenAPISpec = {
               },
               workspace_id: {
                 description:
-                  'ID of the [workspace](https://docs.seam.co/latest/core-concepts/workspaces) associated with the event.',
+                  'ID of the [workspace](https://docs.seam.co/core-concepts/workspaces) associated with the event.',
                 format: 'uuid',
                 type: 'string',
               },
@@ -25589,7 +25589,7 @@ const openapi: OpenAPISpec = {
               },
               workspace_id: {
                 description:
-                  'ID of the [workspace](https://docs.seam.co/latest/core-concepts/workspaces) associated with the event.',
+                  'ID of the [workspace](https://docs.seam.co/core-concepts/workspaces) associated with the event.',
                 format: 'uuid',
                 type: 'string',
               },
@@ -25616,7 +25616,7 @@ const openapi: OpenAPISpec = {
         properties: {
           client_session_id: {
             description:
-              'ID of the [client session](https://docs.seam.co/latest/core-concepts/authentication/client-session-tokens) associated with the Instant Key.',
+              'ID of the [client session](https://docs.seam.co/core-concepts/authentication/client-session-tokens) associated with the Instant Key.',
             format: 'uuid',
             type: 'string',
           },
@@ -25674,7 +25674,7 @@ const openapi: OpenAPISpec = {
           },
           workspace_id: {
             description:
-              'ID of the [workspace](https://docs.seam.co/latest/core-concepts/workspaces) that contains the Instant Key.',
+              'ID of the [workspace](https://docs.seam.co/core-concepts/workspaces) that contains the Instant Key.',
             format: 'uuid',
             type: 'string',
           },
@@ -25716,7 +25716,7 @@ const openapi: OpenAPISpec = {
           },
           workspace_id: {
             description:
-              'ID of the [workspace](https://docs.seam.co/latest/core-concepts/workspaces) associated with the magic link.',
+              'ID of the [workspace](https://docs.seam.co/core-concepts/workspaces) associated with the magic link.',
             format: 'uuid',
             type: 'string',
           },
@@ -25734,7 +25734,7 @@ const openapi: OpenAPISpec = {
       },
       noise_threshold: {
         description:
-          'Represents a [noise threshold](https://docs.seam.co/latest/capability-guides/noise-sensors/configure-noise-threshold-settings) for a [noise sensor](https://docs.seam.co/latest/capability-guides/noise-sensors). Thresholds represent the limits of noise tolerated at a property, which can be customized for each hour of the day. Each device has its own default thresholds, but you can use the Seam API to modify them.',
+          'Represents a [noise threshold](https://docs.seam.co/capability-guides/noise-sensors/configure-noise-threshold-settings) for a [noise sensor](https://docs.seam.co/capability-guides/noise-sensors). Thresholds represent the limits of noise tolerated at a property, which can be customized for each hour of the day. Each device has its own default thresholds, but you can use the Seam API to modify them.',
         properties: {
           device_id: {
             description:
@@ -25760,7 +25760,7 @@ const openapi: OpenAPISpec = {
           },
           noise_threshold_nrs: {
             description:
-              'Noise level in Noiseaware Noise Risk Score (NRS) for the noise threshold. This parameter is only relevant for [Noiseaware sensors](https://docs.seam.co/latest/device-and-system-integration-guides/noiseaware-sensors).',
+              'Noise level in Noiseaware Noise Risk Score (NRS) for the noise threshold. This parameter is only relevant for [Noiseaware sensors](https://docs.seam.co/device-and-system-integration-guides/noiseaware-sensors).',
             format: 'float',
             type: 'number',
           },
@@ -25818,7 +25818,7 @@ const openapi: OpenAPISpec = {
               oneOf: [{ type: 'string' }, { type: 'boolean' }],
             },
             description:
-              'Optional [custom metadata](https://docs.seam.co/latest/core-concepts/devices/adding-custom-metadata-to-a-device) for the phone.\n  ',
+              'Optional [custom metadata](https://docs.seam.co/core-concepts/devices/adding-custom-metadata-to-a-device) for the phone.\n  ',
             type: 'object',
           },
           device_id: {
@@ -25918,7 +25918,7 @@ const openapi: OpenAPISpec = {
           },
           workspace_id: {
             description:
-              'ID of the [workspace](https://docs.seam.co/latest/core-concepts/workspaces) that contains the phone.\n  ',
+              'ID of the [workspace](https://docs.seam.co/core-concepts/workspaces) that contains the phone.\n  ',
             format: 'uuid',
             type: 'string',
           },
@@ -25982,11 +25982,11 @@ const openapi: OpenAPISpec = {
                     'Access system credentials associated with the phone provider session.',
                   items: {
                     description:
-                      'Means by which an [access control system user](https://docs.seam.co/latest/capability-guides/access-systems/user-management) gains access at an [entrance](https://docs.seam.co/latest/capability-guides/access-systems/retrieving-entrance-details). The `acs_credential` object represents a [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials) that provides an ACS user access within an [access control system](https://docs.seam.co/latest/capability-guides/access-systems).\n\nAn access control system generally uses digital means of access to authorize a user trying to get through a specific entrance. Examples of credentials include plastic key cards, mobile keys, biometric identifiers, and PIN codes. The electronic nature of these credentials, as well as the fact that access is centralized, enables both the rapid provisioning and rescinding of access and the ability to compile access audit logs.\n\nFor each `acs_credential`, you define the access method. You can also specify additional properties, such as a PIN code, depending on the credential type.',
+                      'Means by which an [access control system user](https://docs.seam.co/capability-guides/access-systems/user-management) gains access at an [entrance](https://docs.seam.co/capability-guides/access-systems/retrieving-entrance-details). The `acs_credential` object represents a [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials) that provides an ACS user access within an [access control system](https://docs.seam.co/capability-guides/access-systems).\n\nAn access control system generally uses digital means of access to authorize a user trying to get through a specific entrance. Examples of credentials include plastic key cards, mobile keys, biometric identifiers, and PIN codes. The electronic nature of these credentials, as well as the fact that access is centralized, enables both the rapid provisioning and rescinding of access and the ability to compile access audit logs.\n\nFor each `acs_credential`, you define the access method. You can also specify additional properties, such as a PIN code, depending on the credential type.',
                     properties: {
                       access_method: {
                         description:
-                          'Access method for the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials). Supported values: `code`, `card`, `mobile_key`, `cloud_key`.',
+                          'Access method for the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials). Supported values: `code`, `card`, `mobile_key`, `cloud_key`.',
                         enum: ['code', 'card', 'mobile_key', 'cloud_key'],
                         type: 'string',
                       },
@@ -25998,23 +25998,23 @@ const openapi: OpenAPISpec = {
                       acs_entrances: {
                         items: {
                           description:
-                            'Represents an [entrance](https://docs.seam.co/latest/capability-guides/access-systems/retrieving-entrance-details) within an [access control system](https://docs.seam.co/latest/capability-guides/access-systems).\n\nIn an access control system, an entrance is a secured door, gate, zone, or other method of entry. You can list details for all the `acs_entrance` resources in your workspace or get these details for a specific `acs_entrance`. You can also list all entrances associated with a specific credential, and you can list all credentials associated with a specific entrance.',
+                            'Represents an [entrance](https://docs.seam.co/capability-guides/access-systems/retrieving-entrance-details) within an [access control system](https://docs.seam.co/capability-guides/access-systems).\n\nIn an access control system, an entrance is a secured door, gate, zone, or other method of entry. You can list details for all the `acs_entrance` resources in your workspace or get these details for a specific `acs_entrance`. You can also list all entrances associated with a specific credential, and you can list all credentials associated with a specific entrance.',
                           properties: {
                             acs_entrance_id: {
                               description:
-                                'ID of the [entrance](https://docs.seam.co/latest/capability-guides/access-systems/retrieving-entrance-details).',
+                                'ID of the [entrance](https://docs.seam.co/capability-guides/access-systems/retrieving-entrance-details).',
                               format: 'uuid',
                               type: 'string',
                             },
                             acs_system_id: {
                               description:
-                                'ID of the [access control system](https://docs.seam.co/latest/capability-guides/access-systems) that contains the [entrance](https://docs.seam.co/latest/capability-guides/access-systems/retrieving-entrance-details).',
+                                'ID of the [access control system](https://docs.seam.co/capability-guides/access-systems) that contains the [entrance](https://docs.seam.co/capability-guides/access-systems/retrieving-entrance-details).',
                               format: 'uuid',
                               type: 'string',
                             },
                             assa_abloy_vostio_metadata: {
                               description:
-                                'ASSA ABLOY Vostio-specific metadata associated with the [entrance](https://docs.seam.co/latest/capability-guides/access-systems/retrieving-entrance-details).',
+                                'ASSA ABLOY Vostio-specific metadata associated with the [entrance](https://docs.seam.co/capability-guides/access-systems/retrieving-entrance-details).',
                               properties: {
                                 door_name: {
                                   description:
@@ -26054,7 +26054,7 @@ const openapi: OpenAPISpec = {
                             },
                             avigilon_alta_metadata: {
                               description:
-                                'Avigilon Alta-specific metadata associated with the [entrance](https://docs.seam.co/latest/capability-guides/access-systems/retrieving-entrance-details).',
+                                'Avigilon Alta-specific metadata associated with the [entrance](https://docs.seam.co/capability-guides/access-systems/retrieving-entrance-details).',
                               properties: {
                                 entry_name: {
                                   description:
@@ -26108,7 +26108,7 @@ const openapi: OpenAPISpec = {
                             },
                             brivo_metadata: {
                               description:
-                                'Brivo-specific metadata associated with the [entrance](https://docs.seam.co/latest/capability-guides/access-systems/retrieving-entrance-details).',
+                                'Brivo-specific metadata associated with the [entrance](https://docs.seam.co/capability-guides/access-systems/retrieving-entrance-details).',
                               properties: {
                                 access_point_id: {
                                   description:
@@ -26161,24 +26161,24 @@ const openapi: OpenAPISpec = {
                             },
                             connected_account_id: {
                               description:
-                                'ID of the [connected account](https://docs.seam.co/latest/capability-guides/access-systems/retrieving-entrance-details) associated with the [entrance](https://docs.seam.co/latest/capability-guides/access-systems/retrieving-entrance-details).',
+                                'ID of the [connected account](https://docs.seam.co/capability-guides/access-systems/retrieving-entrance-details) associated with the [entrance](https://docs.seam.co/capability-guides/access-systems/retrieving-entrance-details).',
                               format: 'uuid',
                               type: 'string',
                             },
                             created_at: {
                               description:
-                                'Date and time at which the [entrance](https://docs.seam.co/latest/capability-guides/access-systems/retrieving-entrance-details) was created.',
+                                'Date and time at which the [entrance](https://docs.seam.co/capability-guides/access-systems/retrieving-entrance-details) was created.',
                               format: 'date-time',
                               type: 'string',
                             },
                             display_name: {
                               description:
-                                'Display name for the [entrance](https://docs.seam.co/latest/capability-guides/access-systems/retrieving-entrance-details).',
+                                'Display name for the [entrance](https://docs.seam.co/capability-guides/access-systems/retrieving-entrance-details).',
                               type: 'string',
                             },
                             dormakaba_ambiance_metadata: {
                               description:
-                                'dormakaba Ambiance-specific metadata associated with the [entrance](https://docs.seam.co/latest/capability-guides/access-systems/retrieving-entrance-details).',
+                                'dormakaba Ambiance-specific metadata associated with the [entrance](https://docs.seam.co/capability-guides/access-systems/retrieving-entrance-details).',
                               properties: {
                                 access_point_name: {
                                   description:
@@ -26191,7 +26191,7 @@ const openapi: OpenAPISpec = {
                             },
                             dormakaba_community_metadata: {
                               description:
-                                'dormakaba Community-specific metadata associated with the [entrance](https://docs.seam.co/latest/capability-guides/access-systems/retrieving-entrance-details).',
+                                'dormakaba Community-specific metadata associated with the [entrance](https://docs.seam.co/capability-guides/access-systems/retrieving-entrance-details).',
                               properties: {
                                 access_point_profile: {
                                   description:
@@ -26204,7 +26204,7 @@ const openapi: OpenAPISpec = {
                             },
                             errors: {
                               description:
-                                'Errors associated with the [entrance](https://docs.seam.co/latest/capability-guides/access-systems/retrieving-entrance-details).',
+                                'Errors associated with the [entrance](https://docs.seam.co/capability-guides/access-systems/retrieving-entrance-details).',
                               items: {
                                 properties: {
                                   error_code: {
@@ -26225,7 +26225,7 @@ const openapi: OpenAPISpec = {
                             },
                             hotek_metadata: {
                               description:
-                                'Hotek-specific metadata associated with the [entrance](https://docs.seam.co/latest/capability-guides/access-systems/retrieving-entrance-details).',
+                                'Hotek-specific metadata associated with the [entrance](https://docs.seam.co/capability-guides/access-systems/retrieving-entrance-details).',
                               properties: {
                                 common_area_name: {
                                   description: 'Display name of the entrance.',
@@ -26244,12 +26244,12 @@ const openapi: OpenAPISpec = {
                             },
                             is_locked: {
                               description:
-                                'Indicates whether the [entrance](https://docs.seam.co/latest/capability-guides/access-systems/retrieving-entrance-details) is currently locked.',
+                                'Indicates whether the [entrance](https://docs.seam.co/capability-guides/access-systems/retrieving-entrance-details) is currently locked.',
                               type: 'boolean',
                             },
                             latch_metadata: {
                               description:
-                                'Latch-specific metadata associated with the [entrance](https://docs.seam.co/latest/capability-guides/access-systems/retrieving-entrance-details).',
+                                'Latch-specific metadata associated with the [entrance](https://docs.seam.co/capability-guides/access-systems/retrieving-entrance-details).',
                               properties: {
                                 accessibility_type: {
                                   description:
@@ -26282,7 +26282,7 @@ const openapi: OpenAPISpec = {
                             },
                             salto_ks_metadata: {
                               description:
-                                'Salto KS-specific metadata associated with the [entrance](https://docs.seam.co/latest/capability-guides/access-systems/retrieving-entrance-details).',
+                                'Salto KS-specific metadata associated with the [entrance](https://docs.seam.co/capability-guides/access-systems/retrieving-entrance-details).',
                               properties: {
                                 battery_level: {
                                   description:
@@ -26335,7 +26335,7 @@ const openapi: OpenAPISpec = {
                             },
                             salto_space_metadata: {
                               description:
-                                'Salto Space-specific metadata associated with the [entrance](https://docs.seam.co/latest/capability-guides/access-systems/retrieving-entrance-details).',
+                                'Salto Space-specific metadata associated with the [entrance](https://docs.seam.co/capability-guides/access-systems/retrieving-entrance-details).',
                               properties: {
                                 audit_on_keys: {
                                   description:
@@ -26378,7 +26378,7 @@ const openapi: OpenAPISpec = {
                             },
                             visionline_metadata: {
                               description:
-                                'Visionline-specific metadata associated with the [entrance](https://docs.seam.co/latest/capability-guides/access-systems/retrieving-entrance-details).',
+                                'Visionline-specific metadata associated with the [entrance](https://docs.seam.co/capability-guides/access-systems/retrieving-entrance-details).',
                               properties: {
                                 door_category: {
                                   description:
@@ -26428,10 +26428,10 @@ const openapi: OpenAPISpec = {
                             },
                             warnings: {
                               description:
-                                'Warnings associated with the [entrance](https://docs.seam.co/latest/capability-guides/access-systems/retrieving-entrance-details).',
+                                'Warnings associated with the [entrance](https://docs.seam.co/capability-guides/access-systems/retrieving-entrance-details).',
                               items: {
                                 description:
-                                  'Warning associated with the [entrance](https://docs.seam.co/latest/capability-guides/access-systems/retrieving-entrance-details).',
+                                  'Warning associated with the [entrance](https://docs.seam.co/capability-guides/access-systems/retrieving-entrance-details).',
                                 discriminator: { propertyName: 'warning_code' },
                                 oneOf: [
                                   {
@@ -26574,19 +26574,19 @@ const openapi: OpenAPISpec = {
                       },
                       acs_system_id: {
                         description:
-                          'ID of the [access control system](https://docs.seam.co/latest/capability-guides/access-systems) that contains the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials).',
+                          'ID of the [access control system](https://docs.seam.co/capability-guides/access-systems) that contains the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials).',
                         format: 'uuid',
                         type: 'string',
                       },
                       acs_user_id: {
                         description:
-                          'ID of the [ACS user](https://docs.seam.co/latest/capability-guides/access-systems/user-management) to whom the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials) belongs.',
+                          'ID of the [ACS user](https://docs.seam.co/capability-guides/access-systems/user-management) to whom the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials) belongs.',
                         format: 'uuid',
                         type: 'string',
                       },
                       assa_abloy_vostio_metadata: {
                         description:
-                          'Vostio-specific metadata for the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials).',
+                          'Vostio-specific metadata for the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials).',
                         properties: {
                           auto_join: {
                             description:
@@ -26624,42 +26624,42 @@ const openapi: OpenAPISpec = {
                       },
                       card_number: {
                         description:
-                          'Number of the card associated with the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials).',
+                          'Number of the card associated with the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials).',
                         nullable: true,
                         type: 'string',
                       },
                       code: {
                         description:
-                          'Access (PIN) code for the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials).',
+                          'Access (PIN) code for the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials).',
                         nullable: true,
                         type: 'string',
                       },
                       connected_account_id: {
                         description:
-                          'ID of the [connected account](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials#connected-accounts) to which the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials) belongs.',
+                          'ID of the [connected account](https://docs.seam.co/capability-guides/access-systems/managing-credentials#connected-accounts) to which the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials) belongs.',
                         format: 'uuid',
                         type: 'string',
                       },
                       created_at: {
                         description:
-                          'Date and time at which the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials) was created.',
+                          'Date and time at which the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials) was created.',
                         format: 'date-time',
                         type: 'string',
                       },
                       display_name: {
                         description:
-                          'Display name that corresponds to the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials) type.',
+                          'Display name that corresponds to the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials) type.',
                         minLength: 1,
                         type: 'string',
                       },
                       ends_at: {
                         description:
-                          'Date and time at which the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials) validity ends, in [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) format. Must be a time in the future and after `starts_at`.',
+                          'Date and time at which the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials) validity ends, in [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) format. Must be a time in the future and after `starts_at`.',
                         type: 'string',
                       },
                       errors: {
                         description:
-                          'Errors associated with the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials).',
+                          'Errors associated with the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials).',
                         items: {
                           properties: {
                             error_code: { type: 'string' },
@@ -26672,7 +26672,7 @@ const openapi: OpenAPISpec = {
                       },
                       external_type: {
                         description:
-                          'Brand-specific terminology for the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials) type. Supported values: `pti_card`, `brivo_credential`, `hid_credential`, `visionline_card`.',
+                          'Brand-specific terminology for the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials) type. Supported values: `pti_card`, `brivo_credential`, `hid_credential`, `visionline_card`.',
                         enum: [
                           'pti_card',
                           'brivo_credential',
@@ -26691,65 +26691,65 @@ const openapi: OpenAPISpec = {
                       },
                       external_type_display_name: {
                         description:
-                          'Display name that corresponds to the brand-specific terminology for the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials) type.',
+                          'Display name that corresponds to the brand-specific terminology for the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials) type.',
                         type: 'string',
                       },
                       is_issued: {
                         description:
-                          'Indicates whether the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials) has been encoded onto a card.',
+                          'Indicates whether the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials) has been encoded onto a card.',
                         type: 'boolean',
                       },
                       is_latest_desired_state_synced_with_provider: {
                         description:
-                          'Indicates whether the latest state of the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials) has been synced from Seam to the provider.',
+                          'Indicates whether the latest state of the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials) has been synced from Seam to the provider.',
                         nullable: true,
                         type: 'boolean',
                       },
                       is_managed: { enum: [true], type: 'boolean' },
                       is_multi_phone_sync_credential: {
                         description:
-                          'Indicates whether the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials) is a [multi-phone sync credential](https://docs.seam.co/latest/capability-guides/mobile-access/issuing-mobile-credentials-from-an-access-control-system#what-are-multi-phone-sync-credentials).',
+                          'Indicates whether the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials) is a [multi-phone sync credential](https://docs.seam.co/capability-guides/mobile-access/issuing-mobile-credentials-from-an-access-control-system#what-are-multi-phone-sync-credentials).',
                         type: 'boolean',
                       },
                       is_one_time_use: {
                         description:
-                          'Indicates whether the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials) can only be used once. If `true`, the code becomes invalid after the first use.',
+                          'Indicates whether the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials) can only be used once. If `true`, the code becomes invalid after the first use.',
                         type: 'boolean',
                       },
                       issued_at: {
                         description:
-                          'Date and time at which the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials) was encoded onto a card.',
+                          'Date and time at which the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials) was encoded onto a card.',
                         format: 'date-time',
                         nullable: true,
                         type: 'string',
                       },
                       latest_desired_state_synced_with_provider_at: {
                         description:
-                          'Date and time at which the state of the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials) was most recently synced from Seam to the provider.',
+                          'Date and time at which the state of the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials) was most recently synced from Seam to the provider.',
                         format: 'date-time',
                         nullable: true,
                         type: 'string',
                       },
                       parent_acs_credential_id: {
                         description:
-                          'ID of the parent [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials).',
+                          'ID of the parent [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials).',
                         format: 'uuid',
                         type: 'string',
                       },
                       starts_at: {
                         description:
-                          'Date and time at which the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials) validity starts, in [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) format.',
+                          'Date and time at which the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials) validity starts, in [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) format.',
                         type: 'string',
                       },
                       user_identity_id: {
                         description:
-                          'ID of the [user identity](https://docs.seam.co/latest/api/user_identities) to whom the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials) belongs.',
+                          'ID of the [user identity](https://docs.seam.co/api/user_identities) to whom the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials) belongs.',
                         format: 'uuid',
                         type: 'string',
                       },
                       visionline_metadata: {
                         description:
-                          'Visionline-specific metadata for the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials).',
+                          'Visionline-specific metadata for the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials).',
                         properties: {
                           auto_join: {
                             description:
@@ -26801,15 +26801,15 @@ const openapi: OpenAPISpec = {
                       },
                       warnings: {
                         description:
-                          'Warnings associated with the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials).',
+                          'Warnings associated with the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials).',
                         items: {
                           description:
-                            'Warning associated with the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials).',
+                            'Warning associated with the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials).',
                           discriminator: { propertyName: 'warning_code' },
                           oneOf: [
                             {
                               description:
-                                'Indicates that the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials) is waiting to be issued.',
+                                'Indicates that the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials) is waiting to be issued.',
                               properties: {
                                 created_at: {
                                   description:
@@ -26838,7 +26838,7 @@ const openapi: OpenAPISpec = {
                             },
                             {
                               description:
-                                "Indicates that the schedule of one of the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials)'s children was modified externally.",
+                                "Indicates that the schedule of one of the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials)'s children was modified externally.",
                               properties: {
                                 created_at: {
                                   description:
@@ -26867,7 +26867,7 @@ const openapi: OpenAPISpec = {
                             },
                             {
                               description:
-                                'Indicates that the schedule of the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials) was modified to avoid creating a credential with a start date in the past.',
+                                'Indicates that the schedule of the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials) was modified to avoid creating a credential with a start date in the past.',
                               properties: {
                                 created_at: {
                                   description:
@@ -26896,7 +26896,7 @@ const openapi: OpenAPISpec = {
                             },
                             {
                               description:
-                                'Indicates that the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials) is being deleted.',
+                                'Indicates that the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials) is being deleted.',
                               properties: {
                                 created_at: {
                                   description:
@@ -26925,7 +26925,7 @@ const openapi: OpenAPISpec = {
                             },
                             {
                               description:
-                                'An unknown issue occurred while syncing the state of the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials) with the provider. This issue may affect the proper functioning of the credential.',
+                                'An unknown issue occurred while syncing the state of the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials) with the provider. This issue may affect the proper functioning of the credential.',
                               properties: {
                                 created_at: {
                                   description:
@@ -26954,7 +26954,7 @@ const openapi: OpenAPISpec = {
                             },
                             {
                               description:
-                                'Access permissions for the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials) have changed. [Reissue](https://docs.seam.co/latest/capability-guides/access-systems/working-with-card-encoders-and-scanners/creating-and-encoding-card-based-credentials) (re-encode) the credential. This issue may affect the proper functioning of the credential.',
+                                'Access permissions for the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials) have changed. [Reissue](https://docs.seam.co/capability-guides/access-systems/working-with-card-encoders-and-scanners/creating-and-encoding-card-based-credentials) (re-encode) the credential. This issue may affect the proper functioning of the credential.',
                               properties: {
                                 created_at: {
                                   description:
@@ -26987,7 +26987,7 @@ const openapi: OpenAPISpec = {
                       },
                       workspace_id: {
                         description:
-                          'ID of the [workspace](https://docs.seam.co/latest/core-concepts/workspaces) that contains the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials).',
+                          'ID of the [workspace](https://docs.seam.co/core-concepts/workspaces) that contains the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials).',
                         format: 'uuid',
                         type: 'string',
                       },
@@ -27205,7 +27205,7 @@ const openapi: OpenAPISpec = {
               },
               workspace_id: {
                 description:
-                  'ID of the [workspace](https://docs.seam.co/latest/core-concepts/workspaces) that contains the user identity.',
+                  'ID of the [workspace](https://docs.seam.co/core-concepts/workspaces) that contains the user identity.',
                 format: 'uuid',
                 type: 'string',
               },
@@ -27311,7 +27311,7 @@ const openapi: OpenAPISpec = {
           },
           workspace_id: {
             description:
-              'ID of the [workspace](https://docs.seam.co/latest/core-concepts/workspaces) associated with the space.',
+              'ID of the [workspace](https://docs.seam.co/core-concepts/workspaces) associated with the space.',
             format: 'uuid',
             type: 'string',
           },
@@ -27444,7 +27444,7 @@ const openapi: OpenAPISpec = {
               properties: {
                 climate_preset_key: {
                   description:
-                    'Key of the [climate preset](https://docs.seam.co/latest/capability-guides/thermostats/creating-and-managing-climate-presets) to activate at the `starts_at_time`.',
+                    'Key of the [climate preset](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-climate-presets) to activate at the `starts_at_time`.',
                   type: 'string',
                 },
                 starts_at_time: {
@@ -27466,7 +27466,7 @@ const openapi: OpenAPISpec = {
           },
           workspace_id: {
             description:
-              'ID of the [workspace](https://docs.seam.co/latest/core-concepts/workspaces) that contains the thermostat daily program.',
+              'ID of the [workspace](https://docs.seam.co/core-concepts/workspaces) that contains the thermostat daily program.',
             format: 'uuid',
             type: 'string',
           },
@@ -27484,34 +27484,34 @@ const openapi: OpenAPISpec = {
       },
       thermostat_schedule: {
         description:
-          'Represents a [thermostat schedule](https://docs.seam.co/latest/capability-guides/thermostats/creating-and-managing-thermostat-schedules) that activates a configured [climate preset](https://docs.seam.co/latest/capability-guides/thermostats/creating-and-managing-climate-presets) on a [thermostat](https://docs.seam.co/latest/capability-guides/thermostats) at a specified starting time and deactivates the climate preset at a specified ending time.',
+          'Represents a [thermostat schedule](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-thermostat-schedules) that activates a configured [climate preset](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-climate-presets) on a [thermostat](https://docs.seam.co/capability-guides/thermostats) at a specified starting time and deactivates the climate preset at a specified ending time.',
         properties: {
           climate_preset_key: {
             description:
-              'Key of the [climate preset](https://docs.seam.co/latest/capability-guides/thermostats/creating-and-managing-climate-presets) to use for the [thermostat schedule](https://docs.seam.co/latest/capability-guides/thermostats/creating-and-managing-thermostat-schedules).',
+              'Key of the [climate preset](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-climate-presets) to use for the [thermostat schedule](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-thermostat-schedules).',
             type: 'string',
           },
           created_at: {
             description:
-              'Date and time at which the [thermostat schedule](https://docs.seam.co/latest/capability-guides/thermostats/creating-and-managing-thermostat-schedules) was created.',
+              'Date and time at which the [thermostat schedule](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-thermostat-schedules) was created.',
             format: 'date-time',
             type: 'string',
           },
           device_id: {
             description:
-              'ID of the desired [thermostat](https://docs.seam.co/latest/capability-guides/thermostats) device.',
+              'ID of the desired [thermostat](https://docs.seam.co/capability-guides/thermostats) device.',
             format: 'uuid',
             type: 'string',
           },
           ends_at: {
             description:
-              'Date and time at which the [thermostat schedule](https://docs.seam.co/latest/capability-guides/thermostats/creating-and-managing-thermostat-schedules) ends, in [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) format.',
+              'Date and time at which the [thermostat schedule](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-thermostat-schedules) ends, in [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) format.',
             format: 'date-time',
             type: 'string',
           },
           errors: {
             description:
-              'Errors associated with the [thermostat schedule](https://docs.seam.co/latest/capability-guides/thermostats/creating-and-managing-thermostat-schedules).',
+              'Errors associated with the [thermostat schedule](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-thermostat-schedules).',
             items: {
               properties: {
                 error_code: {
@@ -27532,12 +27532,12 @@ const openapi: OpenAPISpec = {
           },
           is_override_allowed: {
             description:
-              "Indicates whether a person at the thermostat can change the thermostat's settings after the [thermostat schedule](https://docs.seam.co/latest/capability-guides/thermostats/creating-and-managing-thermostat-schedules) starts.",
+              "Indicates whether a person at the thermostat can change the thermostat's settings after the [thermostat schedule](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-thermostat-schedules) starts.",
             type: 'boolean',
           },
           max_override_period_minutes: {
             description:
-              "Number of minutes for which a person at the thermostat can change the thermostat's settings after the activation of the scheduled [climate preset](https://docs.seam.co/latest/capability-guides/thermostats/creating-and-managing-climate-presets). See also [Specifying Manual Override Permissions](https://docs.seam.co/latest/capability-guides/thermostats/creating-and-managing-thermostat-schedules#specifying-manual-override-permissions).",
+              "Number of minutes for which a person at the thermostat can change the thermostat's settings after the activation of the scheduled [climate preset](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-climate-presets). See also [Specifying Manual Override Permissions](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-thermostat-schedules#specifying-manual-override-permissions).",
             exclusiveMinimum: true,
             minimum: 0,
             nullable: true,
@@ -27545,25 +27545,25 @@ const openapi: OpenAPISpec = {
           },
           name: {
             description:
-              'User-friendly name to identify the [thermostat schedule](https://docs.seam.co/latest/capability-guides/thermostats/creating-and-managing-thermostat-schedules).',
+              'User-friendly name to identify the [thermostat schedule](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-thermostat-schedules).',
             nullable: true,
             type: 'string',
           },
           starts_at: {
             description:
-              'Date and time at which the [thermostat schedule](https://docs.seam.co/latest/capability-guides/thermostats/creating-and-managing-thermostat-schedules) starts, in [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) format.',
+              'Date and time at which the [thermostat schedule](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-thermostat-schedules) starts, in [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) format.',
             format: 'date-time',
             type: 'string',
           },
           thermostat_schedule_id: {
             description:
-              'ID of the [thermostat schedule](https://docs.seam.co/latest/capability-guides/thermostats/creating-and-managing-thermostat-schedules).',
+              'ID of the [thermostat schedule](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-thermostat-schedules).',
             format: 'uuid',
             type: 'string',
           },
           workspace_id: {
             description:
-              'ID of the [workspace](https://docs.seam.co/latest/core-concepts/workspaces) that contains the thermostat schedule.',
+              'ID of the [workspace](https://docs.seam.co/core-concepts/workspaces) that contains the thermostat schedule.',
             format: 'uuid',
             type: 'string',
           },
@@ -27584,7 +27584,7 @@ const openapi: OpenAPISpec = {
       },
       unmanaged_access_code: {
         description:
-          'Represents an [unmanaged smart lock access code](https://docs.seam.co/latest/capability-guides/smart-locks/access-codes/migrating-existing-access-codes).\n\nAn access code is a code used for a keypad or pinpad device. Unlike physical keys, which can easily be lost or duplicated, PIN codes can be customized, tracked, and altered on the fly.\n\nWhen you create an access code on a device in Seam, it is created as a managed access code. Access codes that exist on a device that were not created through Seam are considered unmanaged codes. We strictly limit the operations that can be performed on unmanaged codes.\n\nPrior to using Seam to manage your devices, you may have used another lock management system to manage the access codes on your devices. Where possible, we help you keep any existing access codes on devices and transition those codes to ones managed by your Seam workspace.\n\nNot all providers support unmanaged access codes. The following providers do not support unmanaged access codes:\n\n- [Kwikset](https://docs.seam.co/latest/device-and-system-integration-guides/kwikset-locks)',
+          'Represents an [unmanaged smart lock access code](https://docs.seam.co/capability-guides/smart-locks/access-codes/migrating-existing-access-codes).\n\nAn access code is a code used for a keypad or pinpad device. Unlike physical keys, which can easily be lost or duplicated, PIN codes can be customized, tracked, and altered on the fly.\n\nWhen you create an access code on a device in Seam, it is created as a managed access code. Access codes that exist on a device that were not created through Seam are considered unmanaged codes. We strictly limit the operations that can be performed on unmanaged codes.\n\nPrior to using Seam to manage your devices, you may have used another lock management system to manage the access codes on your devices. Where possible, we help you keep any existing access codes on devices and transition those codes to ones managed by your Seam workspace.\n\nNot all providers support unmanaged access codes. The following providers do not support unmanaged access codes:\n\n- [Kwikset](https://docs.seam.co/device-and-system-integration-guides/kwikset-locks)',
         properties: {
           access_code_id: {
             description: 'Unique identifier for the access code.',
@@ -27680,7 +27680,7 @@ const openapi: OpenAPISpec = {
           },
           errors: {
             description:
-              'Errors associated with the [access code](https://docs.seam.co/latest/capability-guides/smart-locks/access-codes).',
+              'Errors associated with the [access code](https://docs.seam.co/capability-guides/smart-locks/access-codes).',
             items: {
               discriminator: { propertyName: 'error_code' },
               oneOf: [
@@ -28475,7 +28475,7 @@ const openapi: OpenAPISpec = {
                     },
                     is_connected_account_error: {
                       description:
-                        'Indicates that the error is a [connected account](https://docs.seam.co/latest/api/connected_accounts) error.',
+                        'Indicates that the error is a [connected account](https://docs.seam.co/api/connected_accounts) error.',
                       enum: [true],
                       type: 'boolean',
                     },
@@ -28518,7 +28518,7 @@ const openapi: OpenAPISpec = {
                     },
                     is_connected_account_error: {
                       description:
-                        'Indicates that the error is a [connected account](https://docs.seam.co/latest/api/connected_accounts) error.',
+                        'Indicates that the error is a [connected account](https://docs.seam.co/api/connected_accounts) error.',
                       enum: [true],
                       type: 'boolean',
                     },
@@ -28688,7 +28688,7 @@ const openapi: OpenAPISpec = {
                 },
                 {
                   description:
-                    'Indicates that the [backup access code pool](https://docs.seam.co/latest/capability-guides/smart-locks/access-codes/backup-access-codes) is empty.',
+                    'Indicates that the [backup access code pool](https://docs.seam.co/capability-guides/smart-locks/access-codes/backup-access-codes) is empty.',
                   properties: {
                     created_at: {
                       description:
@@ -28984,7 +28984,7 @@ const openapi: OpenAPISpec = {
                 },
                 {
                   description:
-                    'Indicates that the Seam API cannot communicate with [Seam Bridge](https://docs.seam.co/latest/capability-guides/seam-bridge), for example, if the Seam Bridge executable has stopped or if the computer running the Seam Bridge executable is offline. See also [Troubleshooting Your Access Control System](https://docs.seam.co/latest/capability-guides/access-systems/troubleshooting-your-access-control-system#acs_system.errors.seam_bridge_disconnected).',
+                    'Indicates that the Seam API cannot communicate with [Seam Bridge](https://docs.seam.co/capability-guides/seam-bridge), for example, if the Seam Bridge executable has stopped or if the computer running the Seam Bridge executable is offline. See also [Troubleshooting Your Access Control System](https://docs.seam.co/capability-guides/access-systems/troubleshooting-your-access-control-system#acs_system.errors.seam_bridge_disconnected).',
                   properties: {
                     created_at: {
                       description:
@@ -29000,7 +29000,7 @@ const openapi: OpenAPISpec = {
                     },
                     is_bridge_error: {
                       description:
-                        'Indicates whether the error is related to [Seam Bridge](https://docs.seam.co/latest/capability-guides/seam-bridge).',
+                        'Indicates whether the error is related to [Seam Bridge](https://docs.seam.co/capability-guides/seam-bridge).',
                       type: 'boolean',
                     },
                     is_connected_account_error: {
@@ -29062,10 +29062,10 @@ const openapi: OpenAPISpec = {
           },
           warnings: {
             description:
-              'Warnings associated with the [access code](https://docs.seam.co/latest/capability-guides/smart-locks/access-codes).',
+              'Warnings associated with the [access code](https://docs.seam.co/capability-guides/smart-locks/access-codes).',
             items: {
               description:
-                'Warnings associated with the [access code](https://docs.seam.co/latest/capability-guides/smart-locks/access-codes).',
+                'Warnings associated with the [access code](https://docs.seam.co/capability-guides/smart-locks/access-codes).',
               discriminator: { propertyName: 'warning_code' },
               oneOf: [
                 {
@@ -29617,7 +29617,7 @@ const openapi: OpenAPISpec = {
           },
           connected_account_id: {
             description:
-              'ID of the [connected account](https://docs.seam.co/latest/core-concepts/connected-accounts) that contains the access group.',
+              'ID of the [connected account](https://docs.seam.co/core-concepts/connected-accounts) that contains the access group.',
             format: 'uuid',
             type: 'string',
           },
@@ -29635,7 +29635,7 @@ const openapi: OpenAPISpec = {
               oneOf: [
                 {
                   description:
-                    'Indicates that the [access group](https://docs.seam.co/latest/capability-guides/access-systems/user-management/assigning-users-to-access-groups) was not created on the [access system](https://docs.seam.co/latest/capability-guides/access-systems). This is likely due to an internal unexpected error. Contact Seam [support](mailto:support@seam.co).',
+                    'Indicates that the [access group](https://docs.seam.co/capability-guides/access-systems/user-management/assigning-users-to-access-groups) was not created on the [access system](https://docs.seam.co/capability-guides/access-systems). This is likely due to an internal unexpected error. Contact Seam [support](mailto:support@seam.co).',
                   properties: {
                     created_at: {
                       description:
@@ -30101,7 +30101,7 @@ const openapi: OpenAPISpec = {
           },
           workspace_id: {
             description:
-              'ID of the [workspace](https://docs.seam.co/latest/core-concepts/workspaces) that contains the access group.',
+              'ID of the [workspace](https://docs.seam.co/core-concepts/workspaces) that contains the access group.',
             format: 'uuid',
             type: 'string',
           },
@@ -30129,36 +30129,36 @@ const openapi: OpenAPISpec = {
       },
       unmanaged_acs_credential: {
         description:
-          'Means by which an [ACS user](https://docs.seam.co/latest/capability-guides/access-systems/user-management) gains access at an [entrance](https://docs.seam.co/latest/capability-guides/access-systems/retrieving-entrance-details). The `unmanaged_acs_credential` object, which is not managed by Seam, represents a [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials) that provides an ACS user access within an [access control system](https://docs.seam.co/latest/capability-guides/access-systems). For each `acs_credential` object, you define the access method. You can also specify additional properties, such as a PIN code.',
+          'Means by which an [ACS user](https://docs.seam.co/capability-guides/access-systems/user-management) gains access at an [entrance](https://docs.seam.co/capability-guides/access-systems/retrieving-entrance-details). The `unmanaged_acs_credential` object, which is not managed by Seam, represents a [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials) that provides an ACS user access within an [access control system](https://docs.seam.co/capability-guides/access-systems). For each `acs_credential` object, you define the access method. You can also specify additional properties, such as a PIN code.',
         properties: {
           access_method: {
             description:
-              'Access method for the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials). Supported values: `code`, `card`, `mobile_key`, `cloud_key`.',
+              'Access method for the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials). Supported values: `code`, `card`, `mobile_key`, `cloud_key`.',
             enum: ['code', 'card', 'mobile_key', 'cloud_key'],
             type: 'string',
           },
           acs_credential_id: {
             description:
-              'ID of the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials).',
+              'ID of the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials).',
             format: 'uuid',
             type: 'string',
           },
           acs_credential_pool_id: { format: 'uuid', type: 'string' },
           acs_system_id: {
             description:
-              'ID of the [access control system](https://docs.seam.co/latest/capability-guides/access-systems) that contains the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials).',
+              'ID of the [access control system](https://docs.seam.co/capability-guides/access-systems) that contains the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials).',
             format: 'uuid',
             type: 'string',
           },
           acs_user_id: {
             description:
-              'ID of the [ACS user](https://docs.seam.co/latest/capability-guides/access-systems/user-management) to whom the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials) belongs.',
+              'ID of the [ACS user](https://docs.seam.co/capability-guides/access-systems/user-management) to whom the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials) belongs.',
             format: 'uuid',
             type: 'string',
           },
           assa_abloy_vostio_metadata: {
             description:
-              'Vostio-specific metadata for the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials).',
+              'Vostio-specific metadata for the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials).',
             properties: {
               auto_join: {
                 description:
@@ -30195,42 +30195,42 @@ const openapi: OpenAPISpec = {
           },
           card_number: {
             description:
-              'Number of the card associated with the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials).',
+              'Number of the card associated with the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials).',
             nullable: true,
             type: 'string',
           },
           code: {
             description:
-              'Access (PIN) code for the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials).',
+              'Access (PIN) code for the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials).',
             nullable: true,
             type: 'string',
           },
           connected_account_id: {
             description:
-              'ID of the [connected account](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials#connected-accounts) to which the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials) belongs.',
+              'ID of the [connected account](https://docs.seam.co/capability-guides/access-systems/managing-credentials#connected-accounts) to which the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials) belongs.',
             format: 'uuid',
             type: 'string',
           },
           created_at: {
             description:
-              'Date and time at which the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials) was created.',
+              'Date and time at which the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials) was created.',
             format: 'date-time',
             type: 'string',
           },
           display_name: {
             description:
-              'Display name that corresponds to the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials) type.',
+              'Display name that corresponds to the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials) type.',
             minLength: 1,
             type: 'string',
           },
           ends_at: {
             description:
-              'Date and time at which the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials) validity ends, in [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) format. Must be a time in the future and after `starts_at`.',
+              'Date and time at which the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials) validity ends, in [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) format. Must be a time in the future and after `starts_at`.',
             type: 'string',
           },
           errors: {
             description:
-              'Errors associated with the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials).',
+              'Errors associated with the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials).',
             items: {
               properties: {
                 error_code: { type: 'string' },
@@ -30243,7 +30243,7 @@ const openapi: OpenAPISpec = {
           },
           external_type: {
             description:
-              'Brand-specific terminology for the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials) type. Supported values: `pti_card`, `brivo_credential`, `hid_credential`, `visionline_card`.',
+              'Brand-specific terminology for the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials) type. Supported values: `pti_card`, `brivo_credential`, `hid_credential`, `visionline_card`.',
             enum: [
               'pti_card',
               'brivo_credential',
@@ -30262,65 +30262,65 @@ const openapi: OpenAPISpec = {
           },
           external_type_display_name: {
             description:
-              'Display name that corresponds to the brand-specific terminology for the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials) type.',
+              'Display name that corresponds to the brand-specific terminology for the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials) type.',
             type: 'string',
           },
           is_issued: {
             description:
-              'Indicates whether the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials) has been encoded onto a card.',
+              'Indicates whether the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials) has been encoded onto a card.',
             type: 'boolean',
           },
           is_latest_desired_state_synced_with_provider: {
             description:
-              'Indicates whether the latest state of the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials) has been synced from Seam to the provider.',
+              'Indicates whether the latest state of the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials) has been synced from Seam to the provider.',
             nullable: true,
             type: 'boolean',
           },
           is_managed: { enum: [false], type: 'boolean' },
           is_multi_phone_sync_credential: {
             description:
-              'Indicates whether the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials) is a [multi-phone sync credential](https://docs.seam.co/latest/capability-guides/mobile-access/issuing-mobile-credentials-from-an-access-control-system#what-are-multi-phone-sync-credentials).',
+              'Indicates whether the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials) is a [multi-phone sync credential](https://docs.seam.co/capability-guides/mobile-access/issuing-mobile-credentials-from-an-access-control-system#what-are-multi-phone-sync-credentials).',
             type: 'boolean',
           },
           is_one_time_use: {
             description:
-              'Indicates whether the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials) can only be used once. If `true`, the code becomes invalid after the first use.',
+              'Indicates whether the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials) can only be used once. If `true`, the code becomes invalid after the first use.',
             type: 'boolean',
           },
           issued_at: {
             description:
-              'Date and time at which the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials) was encoded onto a card.',
+              'Date and time at which the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials) was encoded onto a card.',
             format: 'date-time',
             nullable: true,
             type: 'string',
           },
           latest_desired_state_synced_with_provider_at: {
             description:
-              'Date and time at which the state of the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials) was most recently synced from Seam to the provider.',
+              'Date and time at which the state of the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials) was most recently synced from Seam to the provider.',
             format: 'date-time',
             nullable: true,
             type: 'string',
           },
           parent_acs_credential_id: {
             description:
-              'ID of the parent [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials).',
+              'ID of the parent [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials).',
             format: 'uuid',
             type: 'string',
           },
           starts_at: {
             description:
-              'Date and time at which the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials) validity starts, in [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) format.',
+              'Date and time at which the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials) validity starts, in [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) format.',
             type: 'string',
           },
           user_identity_id: {
             description:
-              'ID of the [user identity](https://docs.seam.co/latest/api/user_identities) to whom the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials) belongs.',
+              'ID of the [user identity](https://docs.seam.co/api/user_identities) to whom the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials) belongs.',
             format: 'uuid',
             type: 'string',
           },
           visionline_metadata: {
             description:
-              'Visionline-specific metadata for the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials).',
+              'Visionline-specific metadata for the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials).',
             properties: {
               auto_join: {
                 description:
@@ -30370,15 +30370,15 @@ const openapi: OpenAPISpec = {
           },
           warnings: {
             description:
-              'Warnings associated with the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials).',
+              'Warnings associated with the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials).',
             items: {
               description:
-                'Warning associated with the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials).',
+                'Warning associated with the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials).',
               discriminator: { propertyName: 'warning_code' },
               oneOf: [
                 {
                   description:
-                    'Indicates that the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials) is waiting to be issued.',
+                    'Indicates that the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials) is waiting to be issued.',
                   properties: {
                     created_at: {
                       description:
@@ -30403,7 +30403,7 @@ const openapi: OpenAPISpec = {
                 },
                 {
                   description:
-                    "Indicates that the schedule of one of the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials)'s children was modified externally.",
+                    "Indicates that the schedule of one of the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials)'s children was modified externally.",
                   properties: {
                     created_at: {
                       description:
@@ -30428,7 +30428,7 @@ const openapi: OpenAPISpec = {
                 },
                 {
                   description:
-                    'Indicates that the schedule of the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials) was modified to avoid creating a credential with a start date in the past.',
+                    'Indicates that the schedule of the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials) was modified to avoid creating a credential with a start date in the past.',
                   properties: {
                     created_at: {
                       description:
@@ -30453,7 +30453,7 @@ const openapi: OpenAPISpec = {
                 },
                 {
                   description:
-                    'Indicates that the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials) is being deleted.',
+                    'Indicates that the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials) is being deleted.',
                   properties: {
                     created_at: {
                       description:
@@ -30478,7 +30478,7 @@ const openapi: OpenAPISpec = {
                 },
                 {
                   description:
-                    'An unknown issue occurred while syncing the state of the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials) with the provider. This issue may affect the proper functioning of the credential.',
+                    'An unknown issue occurred while syncing the state of the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials) with the provider. This issue may affect the proper functioning of the credential.',
                   properties: {
                     created_at: {
                       description:
@@ -30503,7 +30503,7 @@ const openapi: OpenAPISpec = {
                 },
                 {
                   description:
-                    'Access permissions for the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials) have changed. [Reissue](https://docs.seam.co/latest/capability-guides/access-systems/working-with-card-encoders-and-scanners/creating-and-encoding-card-based-credentials) (re-encode) the credential. This issue may affect the proper functioning of the credential.',
+                    'Access permissions for the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials) have changed. [Reissue](https://docs.seam.co/capability-guides/access-systems/working-with-card-encoders-and-scanners/creating-and-encoding-card-based-credentials) (re-encode) the credential. This issue may affect the proper functioning of the credential.',
                   properties: {
                     created_at: {
                       description:
@@ -30532,7 +30532,7 @@ const openapi: OpenAPISpec = {
           },
           workspace_id: {
             description:
-              'ID of the [workspace](https://docs.seam.co/latest/core-concepts/workspaces) that contains the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials).',
+              'ID of the [workspace](https://docs.seam.co/core-concepts/workspaces) that contains the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials).',
             format: 'uuid',
             type: 'string',
           },
@@ -30555,11 +30555,11 @@ const openapi: OpenAPISpec = {
       },
       unmanaged_acs_user: {
         description:
-          'Represents an unmanaged [user](https://docs.seam.co/latest/capability-guides/access-systems/user-management) in an [access system](https://docs.seam.co/latest/capability-guides/access-systems).',
+          'Represents an unmanaged [user](https://docs.seam.co/capability-guides/access-systems/user-management) in an [access system](https://docs.seam.co/capability-guides/access-systems).',
         properties: {
           access_schedule: {
             description:
-              "`starts_at` and `ends_at` timestamps for the [access system user's](https://docs.seam.co/latest/capability-guides/access-systems/user-management) access.",
+              "`starts_at` and `ends_at` timestamps for the [access system user's](https://docs.seam.co/capability-guides/access-systems/user-management) access.",
             properties: {
               ends_at: {
                 description:
@@ -30580,31 +30580,31 @@ const openapi: OpenAPISpec = {
           },
           acs_system_id: {
             description:
-              'ID of the [access system](https://docs.seam.co/latest/capability-guides/access-systems) that contains the [access system user](https://docs.seam.co/latest/capability-guides/access-systems/user-management).',
+              'ID of the [access system](https://docs.seam.co/capability-guides/access-systems) that contains the [access system user](https://docs.seam.co/capability-guides/access-systems/user-management).',
             format: 'uuid',
             type: 'string',
           },
           acs_user_id: {
             description:
-              'ID of the [access system user](https://docs.seam.co/latest/capability-guides/access-systems/user-management).',
+              'ID of the [access system user](https://docs.seam.co/capability-guides/access-systems/user-management).',
             format: 'uuid',
             type: 'string',
           },
           connected_account_id: {
             description:
-              '\n      The ID of the [connected account](https://docs.seam.co/latest/core-concepts/connected-accounts) that is associated with the [access system user](https://docs.seam.co/latest/capability-guides/access-systems/user-management).\n    ',
+              '\n      The ID of the [connected account](https://docs.seam.co/core-concepts/connected-accounts) that is associated with the [access system user](https://docs.seam.co/capability-guides/access-systems/user-management).\n    ',
             format: 'uuid',
             type: 'string',
           },
           created_at: {
             description:
-              'Date and time at which the [access system user](https://docs.seam.co/latest/capability-guides/access-systems/user-management) was created.',
+              'Date and time at which the [access system user](https://docs.seam.co/capability-guides/access-systems/user-management) was created.',
             format: 'date-time',
             type: 'string',
           },
           display_name: {
             description:
-              'Display name for the [access system user](https://docs.seam.co/latest/capability-guides/access-systems/user-management).',
+              'Display name for the [access system user](https://docs.seam.co/capability-guides/access-systems/user-management).',
             type: 'string',
           },
           email: {
@@ -30615,21 +30615,21 @@ const openapi: OpenAPISpec = {
           },
           email_address: {
             description:
-              'Email address of the [access system user](https://docs.seam.co/latest/capability-guides/access-systems/user-management).',
+              'Email address of the [access system user](https://docs.seam.co/capability-guides/access-systems/user-management).',
             format: 'email',
             type: 'string',
           },
           errors: {
             description:
-              'Errors associated with the [access system user](https://docs.seam.co/latest/capability-guides/access-systems/user-management).',
+              'Errors associated with the [access system user](https://docs.seam.co/capability-guides/access-systems/user-management).',
             items: {
               description:
-                'Errors associated with the [access system user](https://docs.seam.co/latest/capability-guides/access-systems/user-management).',
+                'Errors associated with the [access system user](https://docs.seam.co/capability-guides/access-systems/user-management).',
               discriminator: { propertyName: 'error_code' },
               oneOf: [
                 {
                   description:
-                    'Indicates that the [access system user](https://docs.seam.co/latest/capability-guides/access-systems/user-management) was deleted from the [access system](https://docs.seam.co/latest/capability-guides/access-systems) outside of Seam.',
+                    'Indicates that the [access system user](https://docs.seam.co/capability-guides/access-systems/user-management) was deleted from the [access system](https://docs.seam.co/capability-guides/access-systems) outside of Seam.',
                   properties: {
                     created_at: {
                       description:
@@ -30652,7 +30652,7 @@ const openapi: OpenAPISpec = {
                 },
                 {
                   description:
-                    'Indicates that the [access system user](https://docs.seam.co/latest/capability-guides/access-systems/user-management) could not be subscribed on Salto KS because the subscription limit has been exceeded.',
+                    'Indicates that the [access system user](https://docs.seam.co/capability-guides/access-systems/user-management) could not be subscribed on Salto KS because the subscription limit has been exceeded.',
                   properties: {
                     created_at: {
                       description:
@@ -30675,7 +30675,7 @@ const openapi: OpenAPISpec = {
                 },
                 {
                   description:
-                    'Indicates that the [access system user](https://docs.seam.co/latest/capability-guides/access-systems/user-management) was not created on the [access system](https://docs.seam.co/latest/capability-guides/access-systems). This is likely due to an internal unexpected error. Contact Seam [support](mailto:support@seam.co).',
+                    'Indicates that the [access system user](https://docs.seam.co/capability-guides/access-systems/user-management) was not created on the [access system](https://docs.seam.co/capability-guides/access-systems). This is likely due to an internal unexpected error. Contact Seam [support](mailto:support@seam.co).',
                   properties: {
                     created_at: {
                       description:
@@ -30698,7 +30698,7 @@ const openapi: OpenAPISpec = {
                 },
                 {
                   description:
-                    'Indicates that the [access system user](https://docs.seam.co/latest/capability-guides/access-systems/user-management) was not updated on the [access system](https://docs.seam.co/latest/capability-guides/access-systems). This is likely due to an internal unexpected error. Contact Seam [support](mailto:support@seam.co).',
+                    'Indicates that the [access system user](https://docs.seam.co/capability-guides/access-systems/user-management) was not updated on the [access system](https://docs.seam.co/capability-guides/access-systems). This is likely due to an internal unexpected error. Contact Seam [support](mailto:support@seam.co).',
                   properties: {
                     created_at: {
                       description:
@@ -30721,7 +30721,7 @@ const openapi: OpenAPISpec = {
                 },
                 {
                   description:
-                    'Indicates that the [access system user](https://docs.seam.co/latest/capability-guides/access-systems/user-management) was not deleted on the [access system](https://docs.seam.co/latest/capability-guides/access-systems). This is likely due to an internal unexpected error. Contact Seam [support](mailto:support@seam.co).',
+                    'Indicates that the [access system user](https://docs.seam.co/capability-guides/access-systems/user-management) was not deleted on the [access system](https://docs.seam.co/capability-guides/access-systems). This is likely due to an internal unexpected error. Contact Seam [support](mailto:support@seam.co).',
                   properties: {
                     created_at: {
                       description:
@@ -30744,7 +30744,7 @@ const openapi: OpenAPISpec = {
                 },
                 {
                   description:
-                    'Indicates that the [access system user](https://docs.seam.co/latest/capability-guides/access-systems/user-management) was created from the Seam API but also exists on Mission Control. This is unsupported. Contact Seam [support](mailto:support@seam.co).',
+                    'Indicates that the [access system user](https://docs.seam.co/capability-guides/access-systems/user-management) was created from the Seam API but also exists on Mission Control. This is unsupported. Contact Seam [support](mailto:support@seam.co).',
                   properties: {
                     created_at: {
                       description:
@@ -30771,7 +30771,7 @@ const openapi: OpenAPISpec = {
           },
           external_type: {
             description:
-              'Brand-specific terminology for the [access system user](https://docs.seam.co/latest/capability-guides/access-systems/user-management) type.',
+              'Brand-specific terminology for the [access system user](https://docs.seam.co/capability-guides/access-systems/user-management) type.',
             enum: [
               'pti_user',
               'brivo_user',
@@ -30786,12 +30786,12 @@ const openapi: OpenAPISpec = {
           },
           external_type_display_name: {
             description:
-              'Display name that corresponds to the brand-specific terminology for the [access system user](https://docs.seam.co/latest/capability-guides/access-systems/user-management) type.',
+              'Display name that corresponds to the brand-specific terminology for the [access system user](https://docs.seam.co/capability-guides/access-systems/user-management) type.',
             type: 'string',
           },
           full_name: {
             description:
-              'Full name of the [access system user](https://docs.seam.co/latest/capability-guides/access-systems/user-management).',
+              'Full name of the [access system user](https://docs.seam.co/capability-guides/access-systems/user-management).',
             minLength: 1,
             type: 'string',
           },
@@ -30799,7 +30799,7 @@ const openapi: OpenAPISpec = {
           is_managed: { enum: [false], type: 'boolean' },
           is_suspended: {
             description:
-              'Indicates whether the [access system user](https://docs.seam.co/latest/capability-guides/access-systems/user-management) is currently [suspended](https://docs.seam.co/latest/capability-guides/access-systems/user-management/suspending-and-unsuspending-users).',
+              'Indicates whether the [access system user](https://docs.seam.co/capability-guides/access-systems/user-management) is currently [suspended](https://docs.seam.co/capability-guides/access-systems/user-management/suspending-and-unsuspending-users).',
             type: 'boolean',
           },
           last_successful_sync_at: {
@@ -30812,7 +30812,7 @@ const openapi: OpenAPISpec = {
           },
           pending_mutations: {
             description:
-              'Pending mutations associated with the [access system user](https://docs.seam.co/latest/capability-guides/access-systems/user-management). Seam is in the process of pushing these mutations to the integrated access system.',
+              'Pending mutations associated with the [access system user](https://docs.seam.co/capability-guides/access-systems/user-management). Seam is in the process of pushing these mutations to the integrated access system.',
             items: {
               discriminator: { propertyName: 'mutation_code' },
               oneOf: [
@@ -31241,12 +31241,12 @@ const openapi: OpenAPISpec = {
           },
           phone_number: {
             description:
-              'Phone number of the [access system user](https://docs.seam.co/latest/capability-guides/access-systems/user-management) in E.164 format (for example, `+15555550100`).',
+              'Phone number of the [access system user](https://docs.seam.co/capability-guides/access-systems/user-management) in E.164 format (for example, `+15555550100`).',
             type: 'string',
           },
           salto_space_metadata: {
             description:
-              'Salto Space-specific metadata associated with the [access system user](https://docs.seam.co/latest/capability-guides/access-systems/user-management).',
+              'Salto Space-specific metadata associated with the [access system user](https://docs.seam.co/capability-guides/access-systems/user-management).',
             properties: {
               audit_openings: {
                 description:
@@ -31262,38 +31262,38 @@ const openapi: OpenAPISpec = {
           },
           user_identity_email_address: {
             description:
-              'Email address of the user identity associated with the [access system user](https://docs.seam.co/latest/capability-guides/access-systems/user-management).',
+              'Email address of the user identity associated with the [access system user](https://docs.seam.co/capability-guides/access-systems/user-management).',
             nullable: true,
             type: 'string',
           },
           user_identity_full_name: {
             description:
-              'Full name of the user identity associated with the [access system user](https://docs.seam.co/latest/capability-guides/access-systems/user-management).',
+              'Full name of the user identity associated with the [access system user](https://docs.seam.co/capability-guides/access-systems/user-management).',
             nullable: true,
             type: 'string',
           },
           user_identity_id: {
             description:
-              'ID of the user identity associated with the [access system user](https://docs.seam.co/latest/capability-guides/access-systems/user-management).',
+              'ID of the user identity associated with the [access system user](https://docs.seam.co/capability-guides/access-systems/user-management).',
             type: 'string',
           },
           user_identity_phone_number: {
             description:
-              'Phone number of the user identity associated with the [access system user](https://docs.seam.co/latest/capability-guides/access-systems/user-management) in E.164 format (for example, `+15555550100`).',
+              'Phone number of the user identity associated with the [access system user](https://docs.seam.co/capability-guides/access-systems/user-management) in E.164 format (for example, `+15555550100`).',
             nullable: true,
             type: 'string',
           },
           warnings: {
             description:
-              'Warnings associated with the [access system user](https://docs.seam.co/latest/capability-guides/access-systems/user-management).',
+              'Warnings associated with the [access system user](https://docs.seam.co/capability-guides/access-systems/user-management).',
             items: {
               description:
-                'Warnings associated with the [access system user](https://docs.seam.co/latest/capability-guides/access-systems/user-management).',
+                'Warnings associated with the [access system user](https://docs.seam.co/capability-guides/access-systems/user-management).',
               discriminator: { propertyName: 'warning_code' },
               oneOf: [
                 {
                   description:
-                    'Indicates that the [access system user](https://docs.seam.co/latest/capability-guides/access-systems/user-management) is being deleted from the [access system](https://docs.seam.co/latest/capability-guides/access-systems). This is a temporary state, and the access system user will be deleted shortly.',
+                    'Indicates that the [access system user](https://docs.seam.co/capability-guides/access-systems/user-management) is being deleted from the [access system](https://docs.seam.co/capability-guides/access-systems). This is a temporary state, and the access system user will be deleted shortly.',
                   properties: {
                     created_at: {
                       description:
@@ -31313,7 +31313,7 @@ const openapi: OpenAPISpec = {
                 },
                 {
                   description:
-                    'Indicates that the [access system user](https://docs.seam.co/latest/capability-guides/access-systems/user-management) is not subscribed on Salto KS, so they cannot unlock doors or perform any actions. This occurs when the their access schedule hasn’t started yet, if their access schedule has ended, if the site has reached its limit for active users (subscription slots), or if they have been manually unsubscribed.',
+                    'Indicates that the [access system user](https://docs.seam.co/capability-guides/access-systems/user-management) is not subscribed on Salto KS, so they cannot unlock doors or perform any actions. This occurs when the their access schedule hasn’t started yet, if their access schedule has ended, if the site has reached its limit for active users (subscription slots), or if they have been manually unsubscribed.',
                   properties: {
                     created_at: {
                       description:
@@ -31336,7 +31336,7 @@ const openapi: OpenAPISpec = {
                 },
                 {
                   description:
-                    'An unknown issue occurred while syncing the state of this [access system user](https://docs.seam.co/latest/capability-guides/access-systems/user-management) with the provider. This issue may affect the proper functioning of this user.',
+                    'An unknown issue occurred while syncing the state of this [access system user](https://docs.seam.co/capability-guides/access-systems/user-management) with the provider. This issue may affect the proper functioning of this user.',
                   properties: {
                     created_at: {
                       description:
@@ -31359,7 +31359,7 @@ const openapi: OpenAPISpec = {
                 },
                 {
                   description:
-                    'Indicates that the [access system user](https://docs.seam.co/latest/capability-guides/access-systems/user-management) was created on Latch Mission Control. Please use the Latch Mission Control to manage this user.',
+                    'Indicates that the [access system user](https://docs.seam.co/capability-guides/access-systems/user-management) was created on Latch Mission Control. Please use the Latch Mission Control to manage this user.',
                   properties: {
                     created_at: {
                       description:
@@ -31386,7 +31386,7 @@ const openapi: OpenAPISpec = {
           },
           workspace_id: {
             description:
-              'ID of the [workspace](https://docs.seam.co/latest/core-concepts/workspaces) that contains the [access system user](https://docs.seam.co/latest/capability-guides/access-systems/user-management).',
+              'ID of the [workspace](https://docs.seam.co/core-concepts/workspaces) that contains the [access system user](https://docs.seam.co/capability-guides/access-systems/user-management).',
             format: 'uuid',
             type: 'string',
           },
@@ -31409,7 +31409,7 @@ const openapi: OpenAPISpec = {
       },
       unmanaged_device: {
         description:
-          'Represents an [unmanaged device](https://docs.seam.co/latest/core-concepts/devices/managed-and-unmanaged-devices). An unmanaged device has a limited set of visible properties and a subset of supported events. You cannot control an unmanaged device. Any [access codes](https://docs.seam.co/latest/capability-guides/smart-locks/access-codes/migrating-existing-access-codes) on an unmanaged device are unmanaged. To control an unmanaged device with Seam, [convert it to a managed device](https://docs.seam.co/latest/core-concepts/devices/managed-and-unmanaged-devices#convert-an-unmanaged-device-to-managed).',
+          'Represents an [unmanaged device](https://docs.seam.co/core-concepts/devices/managed-and-unmanaged-devices). An unmanaged device has a limited set of visible properties and a subset of supported events. You cannot control an unmanaged device. Any [access codes](https://docs.seam.co/capability-guides/smart-locks/access-codes/migrating-existing-access-codes) on an unmanaged device are unmanaged. To control an unmanaged device with Seam, [convert it to a managed device](https://docs.seam.co/core-concepts/devices/managed-and-unmanaged-devices#convert-an-unmanaged-device-to-managed).',
         properties: {
           can_configure_auto_lock: { type: 'boolean' },
           can_hvac_cool: { type: 'boolean' },
@@ -31437,10 +31437,10 @@ const openapi: OpenAPISpec = {
           can_unlock_with_code: { type: 'boolean' },
           capabilities_supported: {
             description:
-              '\n        Collection of capabilities that the device supports when connected to Seam. Values are `access_code`, which indicates that the device can manage and utilize digital PIN codes for secure access; `lock`, which indicates that the device controls a door locking mechanism, enabling the remote opening and closing of doors and other entry points; `noise_detection`, which indicates that the device supports monitoring and responding to ambient noise levels; `thermostat`, which indicates that the device can regulate and adjust indoor temperatures; `battery`, which indicates that the device can manage battery life and health; and `phone`, which indicates that the device is a mobile device, such as a smartphone. **Important:** Superseded by [capability flags](https://docs.seam.co/latest/capability-guides/device-and-system-capabilities#capability-flags).\n        ',
+              '\n        Collection of capabilities that the device supports when connected to Seam. Values are `access_code`, which indicates that the device can manage and utilize digital PIN codes for secure access; `lock`, which indicates that the device controls a door locking mechanism, enabling the remote opening and closing of doors and other entry points; `noise_detection`, which indicates that the device supports monitoring and responding to ambient noise levels; `thermostat`, which indicates that the device can regulate and adjust indoor temperatures; `battery`, which indicates that the device can manage battery life and health; and `phone`, which indicates that the device is a mobile device, such as a smartphone. **Important:** Superseded by [capability flags](https://docs.seam.co/capability-guides/device-and-system-capabilities#capability-flags).\n        ',
             items: {
               description:
-                '\n        Collection of capabilities that the device supports when connected to Seam. **Important:** Superseded by [capability flags](https://docs.seam.co/latest/capability-guides/device-and-system-capabilities#capability-flags).\n        ',
+                '\n        Collection of capabilities that the device supports when connected to Seam. **Important:** Superseded by [capability flags](https://docs.seam.co/capability-guides/device-and-system-capabilities#capability-flags).\n        ',
               enum: [
                 'access_code',
                 'lock',
@@ -31470,7 +31470,7 @@ const openapi: OpenAPISpec = {
               oneOf: [{ type: 'string' }, { type: 'boolean' }],
             },
             description:
-              'Set of key:value pairs. Adding custom metadata to a resource, such as a [Connect Webview](https://docs.seam.co/latest/core-concepts/connect-webviews/attaching-custom-data-to-the-connect-webview), [connected account](https://docs.seam.co/latest/core-concepts/connected-accounts/adding-custom-metadata-to-a-connected-account), or [device](https://docs.seam.co/latest/core-concepts/devices/adding-custom-metadata-to-a-device), enables you to store custom information, like customer details or internal IDs from your application.',
+              'Set of key:value pairs. Adding custom metadata to a resource, such as a [Connect Webview](https://docs.seam.co/core-concepts/connect-webviews/attaching-custom-data-to-the-connect-webview), [connected account](https://docs.seam.co/core-concepts/connected-accounts/adding-custom-metadata-to-a-connected-account), or [device](https://docs.seam.co/core-concepts/devices/adding-custom-metadata-to-a-device), enables you to store custom information, like customer details or internal IDs from your application.',
             type: 'object',
           },
           device_id: {
@@ -31572,7 +31572,7 @@ const openapi: OpenAPISpec = {
                     },
                     is_connected_account_error: {
                       description:
-                        'Indicates that the error is a [connected account](https://docs.seam.co/latest/api/connected_accounts) error.',
+                        'Indicates that the error is a [connected account](https://docs.seam.co/api/connected_accounts) error.',
                       enum: [true],
                       type: 'boolean',
                     },
@@ -31615,7 +31615,7 @@ const openapi: OpenAPISpec = {
                     },
                     is_connected_account_error: {
                       description:
-                        'Indicates that the error is a [connected account](https://docs.seam.co/latest/api/connected_accounts) error.',
+                        'Indicates that the error is a [connected account](https://docs.seam.co/api/connected_accounts) error.',
                       enum: [true],
                       type: 'boolean',
                     },
@@ -31785,7 +31785,7 @@ const openapi: OpenAPISpec = {
                 },
                 {
                   description:
-                    'Indicates that the [backup access code pool](https://docs.seam.co/latest/capability-guides/smart-locks/access-codes/backup-access-codes) is empty.',
+                    'Indicates that the [backup access code pool](https://docs.seam.co/capability-guides/smart-locks/access-codes/backup-access-codes) is empty.',
                   properties: {
                     created_at: {
                       description:
@@ -32081,7 +32081,7 @@ const openapi: OpenAPISpec = {
                 },
                 {
                   description:
-                    'Indicates that the Seam API cannot communicate with [Seam Bridge](https://docs.seam.co/latest/capability-guides/seam-bridge), for example, if the Seam Bridge executable has stopped or if the computer running the Seam Bridge executable is offline. See also [Troubleshooting Your Access Control System](https://docs.seam.co/latest/capability-guides/access-systems/troubleshooting-your-access-control-system#acs_system.errors.seam_bridge_disconnected).',
+                    'Indicates that the Seam API cannot communicate with [Seam Bridge](https://docs.seam.co/capability-guides/seam-bridge), for example, if the Seam Bridge executable has stopped or if the computer running the Seam Bridge executable is offline. See also [Troubleshooting Your Access Control System](https://docs.seam.co/capability-guides/access-systems/troubleshooting-your-access-control-system#acs_system.errors.seam_bridge_disconnected).',
                   properties: {
                     created_at: {
                       description:
@@ -32097,7 +32097,7 @@ const openapi: OpenAPISpec = {
                     },
                     is_bridge_error: {
                       description:
-                        'Indicates whether the error is related to [Seam Bridge](https://docs.seam.co/latest/capability-guides/seam-bridge).',
+                        'Indicates whether the error is related to [Seam Bridge](https://docs.seam.co/capability-guides/seam-bridge).',
                       type: 'boolean',
                     },
                     is_connected_account_error: {
@@ -33023,7 +33023,7 @@ const openapi: OpenAPISpec = {
       },
       user_identity: {
         description:
-          'Represents a [user identity](https://docs.seam.co/latest/capability-guides/mobile-access/managing-mobile-app-user-accounts-with-user-identities#what-is-a-user-identity) associated with an application user account.',
+          'Represents a [user identity](https://docs.seam.co/capability-guides/mobile-access/managing-mobile-app-user-accounts-with-user-identities#what-is-a-user-identity) associated with an application user account.',
         properties: {
           acs_user_ids: {
             description:
@@ -33179,7 +33179,7 @@ const openapi: OpenAPISpec = {
           },
           workspace_id: {
             description:
-              'ID of the [workspace](https://docs.seam.co/latest/core-concepts/workspaces) that contains the user identity.',
+              'ID of the [workspace](https://docs.seam.co/core-concepts/workspaces) that contains the user identity.',
             format: 'uuid',
             type: 'string',
           },
@@ -33202,27 +33202,27 @@ const openapi: OpenAPISpec = {
       },
       webhook: {
         description:
-          'Represents a [webhook](https://docs.seam.co/latest/developer-tools/webhooks) that enables you to receive notifications of events. When you create a webhook, specify the endpoint URL at which you want to receive events and the set of event types that you want to receive.',
+          'Represents a [webhook](https://docs.seam.co/developer-tools/webhooks) that enables you to receive notifications of events. When you create a webhook, specify the endpoint URL at which you want to receive events and the set of event types that you want to receive.',
         properties: {
           event_types: {
             description:
-              'Types of events that the [webhook](https://docs.seam.co/latest/developer-tools/webhooks) should receive.',
+              'Types of events that the [webhook](https://docs.seam.co/developer-tools/webhooks) should receive.',
             items: { type: 'string' },
             type: 'array',
           },
           secret: {
             description:
-              'Secret associated with the [webhook](https://docs.seam.co/latest/developer-tools/webhooks).',
+              'Secret associated with the [webhook](https://docs.seam.co/developer-tools/webhooks).',
             type: 'string',
           },
           url: {
             description:
-              'URL for the [webhook](https://docs.seam.co/latest/developer-tools/webhooks).',
+              'URL for the [webhook](https://docs.seam.co/developer-tools/webhooks).',
             type: 'string',
           },
           webhook_id: {
             description:
-              'ID of the [webhook](https://docs.seam.co/latest/developer-tools/webhooks).',
+              'ID of the [webhook](https://docs.seam.co/developer-tools/webhooks).',
             type: 'string',
           },
         },
@@ -33232,11 +33232,11 @@ const openapi: OpenAPISpec = {
       },
       workspace: {
         description:
-          'Represents a Seam [workspace](https://docs.seam.co/latest/core-concepts/workspaces). A workspace is a top-level entity that encompasses all other resources below it, such as devices, connected accounts, and Connect Webviews. Seam provides two types of workspaces. A [sandbox workspace](https://docs.seam.co/latest/core-concepts/workspaces#sandbox-workspaces) is a special type of workspace designed for testing code. Sandbox workspaces offer test device accounts and virtual devices that you can connect and control. This ability to work with virtual devices is quite handy because it removes the need to own physical devices from multiple brands. To connect real devices and systems to Seam, use a [production workspace](https://docs.seam.co/latest/core-concepts/workspaces#production-workspaces).',
+          'Represents a Seam [workspace](https://docs.seam.co/core-concepts/workspaces). A workspace is a top-level entity that encompasses all other resources below it, such as devices, connected accounts, and Connect Webviews. Seam provides two types of workspaces. A [sandbox workspace](https://docs.seam.co/core-concepts/workspaces#sandbox-workspaces) is a special type of workspace designed for testing code. Sandbox workspaces offer test device accounts and virtual devices that you can connect and control. This ability to work with virtual devices is quite handy because it removes the need to own physical devices from multiple brands. To connect real devices and systems to Seam, use a [production workspace](https://docs.seam.co/core-concepts/workspaces#production-workspaces).',
         properties: {
           company_name: {
             description:
-              'Company name associated with the [workspace](https://docs.seam.co/latest/core-concepts/workspaces).',
+              'Company name associated with the [workspace](https://docs.seam.co/core-concepts/workspaces).',
             type: 'string',
           },
           connect_partner_name: {
@@ -33249,28 +33249,28 @@ const openapi: OpenAPISpec = {
             properties: {
               inviter_logo_url: {
                 description:
-                  'URL of the inviter logo for [Connect Webviews](https://docs.seam.co/latest/core-concepts/connect-webviews) in the workspace. See also [Customize the Look and Feel of Your Connect Webviews](https://docs.seam.co/latest/core-concepts/connect-webviews/customizing-connect-webviews#customize-the-look-and-feel-of-your-connect-webviews).',
+                  'URL of the inviter logo for [Connect Webviews](https://docs.seam.co/core-concepts/connect-webviews) in the workspace. See also [Customize the Look and Feel of Your Connect Webviews](https://docs.seam.co/core-concepts/connect-webviews/customizing-connect-webviews#customize-the-look-and-feel-of-your-connect-webviews).',
                 type: 'string',
               },
               logo_shape: {
                 description:
-                  'Logo shape for [Connect Webviews](https://docs.seam.co/latest/core-concepts/connect-webviews) in the workspace. See also [Customize the Look and Feel of Your Connect Webviews](https://docs.seam.co/latest/core-concepts/connect-webviews/customizing-connect-webviews#customize-the-look-and-feel-of-your-connect-webviews).',
+                  'Logo shape for [Connect Webviews](https://docs.seam.co/core-concepts/connect-webviews) in the workspace. See also [Customize the Look and Feel of Your Connect Webviews](https://docs.seam.co/core-concepts/connect-webviews/customizing-connect-webviews#customize-the-look-and-feel-of-your-connect-webviews).',
                 enum: ['circle', 'square'],
                 type: 'string',
               },
               primary_button_color: {
                 description:
-                  'Primary button color for [Connect Webviews](https://docs.seam.co/latest/core-concepts/connect-webviews) in the workspace. See also [Customize the Look and Feel of Your Connect Webviews](https://docs.seam.co/latest/core-concepts/connect-webviews/customizing-connect-webviews#customize-the-look-and-feel-of-your-connect-webviews).',
+                  'Primary button color for [Connect Webviews](https://docs.seam.co/core-concepts/connect-webviews) in the workspace. See also [Customize the Look and Feel of Your Connect Webviews](https://docs.seam.co/core-concepts/connect-webviews/customizing-connect-webviews#customize-the-look-and-feel-of-your-connect-webviews).',
                 type: 'string',
               },
               primary_button_text_color: {
                 description:
-                  'Primary button text color for [Connect Webviews](https://docs.seam.co/latest/core-concepts/connect-webviews) in the workspace. See also [Customize the Look and Feel of Your Connect Webviews](https://docs.seam.co/latest/core-concepts/connect-webviews/customizing-connect-webviews#customize-the-look-and-feel-of-your-connect-webviews).',
+                  'Primary button text color for [Connect Webviews](https://docs.seam.co/core-concepts/connect-webviews) in the workspace. See also [Customize the Look and Feel of Your Connect Webviews](https://docs.seam.co/core-concepts/connect-webviews/customizing-connect-webviews#customize-the-look-and-feel-of-your-connect-webviews).',
                 type: 'string',
               },
               success_message: {
                 description:
-                  'Success message for [Connect Webviews](https://docs.seam.co/latest/core-concepts/connect-webviews) in the workspace. See also [Customize the Look and Feel of Your Connect Webviews](https://docs.seam.co/latest/core-concepts/connect-webviews/customizing-connect-webviews#customize-the-look-and-feel-of-your-connect-webviews).',
+                  'Success message for [Connect Webviews](https://docs.seam.co/core-concepts/connect-webviews) in the workspace. See also [Customize the Look and Feel of Your Connect Webviews](https://docs.seam.co/core-concepts/connect-webviews/customizing-connect-webviews#customize-the-look-and-feel-of-your-connect-webviews).',
                 type: 'string',
               },
             },
@@ -33283,27 +33283,27 @@ const openapi: OpenAPISpec = {
           },
           is_sandbox: {
             description:
-              'Indicates whether the workspace is a [sandbox workspace](https://docs.seam.co/latest/core-concepts/workspaces#sandbox-workspaces).',
+              'Indicates whether the workspace is a [sandbox workspace](https://docs.seam.co/core-concepts/workspaces#sandbox-workspaces).',
             type: 'boolean',
           },
           is_suspended: {
             description:
-              'Indicates whether the [sandbox workspace](https://docs.seam.co/latest/core-concepts/workspaces#sandbox-workspaces) is suspended. Seam suspends sandbox workspaces that have not been accessed in 14 days.',
+              'Indicates whether the [sandbox workspace](https://docs.seam.co/core-concepts/workspaces#sandbox-workspaces) is suspended. Seam suspends sandbox workspaces that have not been accessed in 14 days.',
             type: 'boolean',
           },
           name: {
             description:
-              'Name of the [workspace](https://docs.seam.co/latest/core-concepts/workspaces).',
+              'Name of the [workspace](https://docs.seam.co/core-concepts/workspaces).',
             type: 'string',
           },
           publishable_key: {
             description:
-              'Publishable key for the [workspace](https://docs.seam.co/latest/core-concepts/workspaces). This key is used to identify the workspace in client-side applications.',
+              'Publishable key for the [workspace](https://docs.seam.co/core-concepts/workspaces). This key is used to identify the workspace in client-side applications.',
             type: 'string',
           },
           workspace_id: {
             description:
-              'ID of the [workspace](https://docs.seam.co/latest/core-concepts/workspaces).',
+              'ID of the [workspace](https://docs.seam.co/core-concepts/workspaces).',
             format: 'uuid',
             type: 'string',
           },
@@ -33388,7 +33388,7 @@ const openapi: OpenAPISpec = {
     '/access_codes/create': {
       post: {
         description:
-          'Creates a new [access code](https://docs.seam.co/latest/low-level-apis/access-codes). For granting access, we recommend [Access Grants](https://docs.seam.co/latest/use-cases/granting-access) instead: they work across both standalone smart locks and access control systems and manage the underlying codes for you. Use this low-level endpoint only when you need direct control over a code on a single device, such as setting a custom PIN value.',
+          'Creates a new [access code](https://docs.seam.co/low-level-apis/access-codes). For granting access, we recommend [Access Grants](https://docs.seam.co/use-cases/granting-access) instead: they work across both standalone smart locks and access control systems and manage the underlying codes for you. Use this low-level endpoint only when you need direct control over a code on a single device, such as setting a custom PIN value.',
         operationId: 'accessCodesCreatePost',
         requestBody: {
           content: {
@@ -33397,7 +33397,7 @@ const openapi: OpenAPISpec = {
                 properties: {
                   allow_external_modification: {
                     description:
-                      'Indicates whether [external modification](https://docs.seam.co/latest/capability-guides/smart-locks/access-codes#external-modification) of the code is allowed. Default: `false`.',
+                      'Indicates whether [external modification](https://docs.seam.co/capability-guides/smart-locks/access-codes#external-modification) of the code is allowed. Default: `false`.',
                     type: 'boolean',
                   },
                   attempt_for_offline_device: {
@@ -33413,7 +33413,7 @@ const openapi: OpenAPISpec = {
                   },
                   common_code_key: {
                     description:
-                      'Key to identify access codes that should have the same code. Any two access codes with the same `common_code_key` are guaranteed to have the same `code`. See also [Creating and Updating Multiple Linked Access Codes](https://docs.seam.co/latest/capability-guides/smart-locks/access-codes/creating-and-updating-multiple-linked-access-codes).',
+                      'Key to identify access codes that should have the same code. Any two access codes with the same `common_code_key` are guaranteed to have the same `code`. See also [Creating and Updating Multiple Linked Access Codes](https://docs.seam.co/capability-guides/smart-locks/access-codes/creating-and-updating-multiple-linked-access-codes).',
                     type: 'string',
                   },
                   device_id: {
@@ -33429,23 +33429,23 @@ const openapi: OpenAPISpec = {
                   },
                   is_external_modification_allowed: {
                     description:
-                      'Indicates whether [external modification](https://docs.seam.co/latest/capability-guides/smart-locks/access-codes#external-modification) of the code is allowed. Default: `false`.',
+                      'Indicates whether [external modification](https://docs.seam.co/capability-guides/smart-locks/access-codes#external-modification) of the code is allowed. Default: `false`.',
                     type: 'boolean',
                   },
                   is_offline_access_code: {
                     description:
-                      'Indicates whether the access code is an [offline access code](https://docs.seam.co/latest/capability-guides/smart-locks/access-codes/offline-access-codes).',
+                      'Indicates whether the access code is an [offline access code](https://docs.seam.co/capability-guides/smart-locks/access-codes/offline-access-codes).',
                     type: 'boolean',
                   },
                   is_one_time_use: {
                     description:
-                      'Indicates whether the [offline access code](https://docs.seam.co/latest/capability-guides/smart-locks/access-codes/offline-access-codes) is a single-use access code.',
+                      'Indicates whether the [offline access code](https://docs.seam.co/capability-guides/smart-locks/access-codes/offline-access-codes) is a single-use access code.',
                     type: 'boolean',
                   },
                   max_time_rounding: {
                     default: '1hour',
                     description:
-                      'Maximum rounding adjustment. To create a daily-bound [offline access code](https://docs.seam.co/latest/capability-guides/smart-locks/access-codes/offline-access-codes) for devices that support this feature, set this parameter to `1d`.',
+                      'Maximum rounding adjustment. To create a daily-bound [offline access code](https://docs.seam.co/capability-guides/smart-locks/access-codes/offline-access-codes) for devices that support this feature, set this parameter to `1d`.',
                     enum: ['1hour', '1day', '1h', '1d'],
                     type: 'string',
                   },
@@ -33456,7 +33456,7 @@ const openapi: OpenAPISpec = {
                   },
                   prefer_native_scheduling: {
                     description:
-                      'Indicates whether [native scheduling](https://docs.seam.co/latest/capability-guides/smart-locks/access-codes#native-scheduling) should be used for time-bound codes when supported by the provider. Default: `true`.',
+                      'Indicates whether [native scheduling](https://docs.seam.co/capability-guides/smart-locks/access-codes#native-scheduling) should be used for time-bound codes when supported by the provider. Default: `true`.',
                     type: 'boolean',
                   },
                   preferred_code_length: {
@@ -33477,7 +33477,7 @@ const openapi: OpenAPISpec = {
                   },
                   use_backup_access_code_pool: {
                     description:
-                      'Indicates whether to use a [backup access code pool](https://docs.seam.co/latest/capability-guides/smart-locks/access-codes#backup-access-codes) provided by Seam. If `true`, you can use [`/access_codes/pull_backup_access_code`](https://docs.seam.co/latest/api/access_codes/pull_backup_access_code).',
+                      'Indicates whether to use a [backup access code pool](https://docs.seam.co/capability-guides/smart-locks/access-codes#backup-access-codes) provided by Seam. If `true`, you can use [`/access_codes/pull_backup_access_code`](https://docs.seam.co/api/access_codes/pull_backup_access_code).',
                     type: 'boolean',
                   },
                   use_offline_access_code: {
@@ -33534,7 +33534,7 @@ const openapi: OpenAPISpec = {
     '/access_codes/create_multiple': {
       post: {
         description:
-          'Creates new [access codes](https://docs.seam.co/latest/capability-guides/smart-locks/access-codes) that share a common code across multiple devices.\n\nUsers with more than one door lock in a property may want to create groups of linked access codes, all of which have the same code (PIN). For example, a short-term rental host may want to provide guests the same PIN for both a front door lock and a back door lock.\n\nIf you specify a custom code, Seam assigns this custom code to each of the resulting access codes. However, in this case, Seam does not link these access codes together with a `common_code_key`. That is, `common_code_key` remains null for these access codes.\n\nIf you want to change these access codes that are not linked by a `common_code_key`, you cannot use `/access_codes/update_multiple`. However, you can update each of these access codes individually, using `/access_codes/update`.\n\nSee also [Creating and Updating Multiple Linked Access Codes](https://docs.seam.co/latest/capability-guides/smart-locks/access-codes/creating-and-updating-multiple-linked-access-codes).',
+          'Creates new [access codes](https://docs.seam.co/capability-guides/smart-locks/access-codes) that share a common code across multiple devices.\n\nUsers with more than one door lock in a property may want to create groups of linked access codes, all of which have the same code (PIN). For example, a short-term rental host may want to provide guests the same PIN for both a front door lock and a back door lock.\n\nIf you specify a custom code, Seam assigns this custom code to each of the resulting access codes. However, in this case, Seam does not link these access codes together with a `common_code_key`. That is, `common_code_key` remains null for these access codes.\n\nIf you want to change these access codes that are not linked by a `common_code_key`, you cannot use `/access_codes/update_multiple`. However, you can update each of these access codes individually, using `/access_codes/update`.\n\nSee also [Creating and Updating Multiple Linked Access Codes](https://docs.seam.co/capability-guides/smart-locks/access-codes/creating-and-updating-multiple-linked-access-codes).',
         operationId: 'accessCodesCreateMultiplePost',
         requestBody: {
           content: {
@@ -33543,7 +33543,7 @@ const openapi: OpenAPISpec = {
                 properties: {
                   allow_external_modification: {
                     description:
-                      'Indicates whether [external modification](https://docs.seam.co/latest/capability-guides/smart-locks/access-codes#external-modification) of the code is allowed. Default: `false`.',
+                      'Indicates whether [external modification](https://docs.seam.co/capability-guides/smart-locks/access-codes#external-modification) of the code is allowed. Default: `false`.',
                     type: 'boolean',
                   },
                   attempt_for_offline_device: {
@@ -33577,7 +33577,7 @@ const openapi: OpenAPISpec = {
                   },
                   is_external_modification_allowed: {
                     description:
-                      'Indicates whether [external modification](https://docs.seam.co/latest/capability-guides/smart-locks/access-codes#external-modification) of the code is allowed. Default: `false`.',
+                      'Indicates whether [external modification](https://docs.seam.co/capability-guides/smart-locks/access-codes#external-modification) of the code is allowed. Default: `false`.',
                     type: 'boolean',
                   },
                   name: {
@@ -33587,7 +33587,7 @@ const openapi: OpenAPISpec = {
                   },
                   prefer_native_scheduling: {
                     description:
-                      'Indicates whether [native scheduling](https://docs.seam.co/latest/capability-guides/smart-locks/access-codes#native-scheduling) should be used for time-bound codes when supported by the provider. Default: `true`.',
+                      'Indicates whether [native scheduling](https://docs.seam.co/capability-guides/smart-locks/access-codes#native-scheduling) should be used for time-bound codes when supported by the provider. Default: `true`.',
                     type: 'boolean',
                   },
                   preferred_code_length: {
@@ -33603,7 +33603,7 @@ const openapi: OpenAPISpec = {
                   },
                   use_backup_access_code_pool: {
                     description:
-                      'Indicates whether to use a [backup access code pool](https://docs.seam.co/latest/capability-guides/smart-locks/access-codes#backup-access-codes) provided by Seam. If `true`, you can use [`/access_codes/pull_backup_access_code`](https://docs.seam.co/latest/api/access_codes/pull_backup_access_code).',
+                      'Indicates whether to use a [backup access code pool](https://docs.seam.co/capability-guides/smart-locks/access-codes#backup-access-codes) provided by Seam. If `true`, you can use [`/access_codes/pull_backup_access_code`](https://docs.seam.co/api/access_codes/pull_backup_access_code).',
                     type: 'boolean',
                   },
                 },
@@ -33652,7 +33652,7 @@ const openapi: OpenAPISpec = {
       },
       put: {
         description:
-          'Creates new [access codes](https://docs.seam.co/latest/capability-guides/smart-locks/access-codes) that share a common code across multiple devices.\n\nUsers with more than one door lock in a property may want to create groups of linked access codes, all of which have the same code (PIN). For example, a short-term rental host may want to provide guests the same PIN for both a front door lock and a back door lock.\n\nIf you specify a custom code, Seam assigns this custom code to each of the resulting access codes. However, in this case, Seam does not link these access codes together with a `common_code_key`. That is, `common_code_key` remains null for these access codes.\n\nIf you want to change these access codes that are not linked by a `common_code_key`, you cannot use `/access_codes/update_multiple`. However, you can update each of these access codes individually, using `/access_codes/update`.\n\nSee also [Creating and Updating Multiple Linked Access Codes](https://docs.seam.co/latest/capability-guides/smart-locks/access-codes/creating-and-updating-multiple-linked-access-codes).',
+          'Creates new [access codes](https://docs.seam.co/capability-guides/smart-locks/access-codes) that share a common code across multiple devices.\n\nUsers with more than one door lock in a property may want to create groups of linked access codes, all of which have the same code (PIN). For example, a short-term rental host may want to provide guests the same PIN for both a front door lock and a back door lock.\n\nIf you specify a custom code, Seam assigns this custom code to each of the resulting access codes. However, in this case, Seam does not link these access codes together with a `common_code_key`. That is, `common_code_key` remains null for these access codes.\n\nIf you want to change these access codes that are not linked by a `common_code_key`, you cannot use `/access_codes/update_multiple`. However, you can update each of these access codes individually, using `/access_codes/update`.\n\nSee also [Creating and Updating Multiple Linked Access Codes](https://docs.seam.co/capability-guides/smart-locks/access-codes/creating-and-updating-multiple-linked-access-codes).',
         operationId: 'accessCodesCreateMultiplePut',
         requestBody: {
           content: {
@@ -33661,7 +33661,7 @@ const openapi: OpenAPISpec = {
                 properties: {
                   allow_external_modification: {
                     description:
-                      'Indicates whether [external modification](https://docs.seam.co/latest/capability-guides/smart-locks/access-codes#external-modification) of the code is allowed. Default: `false`.',
+                      'Indicates whether [external modification](https://docs.seam.co/capability-guides/smart-locks/access-codes#external-modification) of the code is allowed. Default: `false`.',
                     type: 'boolean',
                   },
                   attempt_for_offline_device: {
@@ -33695,7 +33695,7 @@ const openapi: OpenAPISpec = {
                   },
                   is_external_modification_allowed: {
                     description:
-                      'Indicates whether [external modification](https://docs.seam.co/latest/capability-guides/smart-locks/access-codes#external-modification) of the code is allowed. Default: `false`.',
+                      'Indicates whether [external modification](https://docs.seam.co/capability-guides/smart-locks/access-codes#external-modification) of the code is allowed. Default: `false`.',
                     type: 'boolean',
                   },
                   name: {
@@ -33705,7 +33705,7 @@ const openapi: OpenAPISpec = {
                   },
                   prefer_native_scheduling: {
                     description:
-                      'Indicates whether [native scheduling](https://docs.seam.co/latest/capability-guides/smart-locks/access-codes#native-scheduling) should be used for time-bound codes when supported by the provider. Default: `true`.',
+                      'Indicates whether [native scheduling](https://docs.seam.co/capability-guides/smart-locks/access-codes#native-scheduling) should be used for time-bound codes when supported by the provider. Default: `true`.',
                     type: 'boolean',
                   },
                   preferred_code_length: {
@@ -33721,7 +33721,7 @@ const openapi: OpenAPISpec = {
                   },
                   use_backup_access_code_pool: {
                     description:
-                      'Indicates whether to use a [backup access code pool](https://docs.seam.co/latest/capability-guides/smart-locks/access-codes#backup-access-codes) provided by Seam. If `true`, you can use [`/access_codes/pull_backup_access_code`](https://docs.seam.co/latest/api/access_codes/pull_backup_access_code).',
+                      'Indicates whether to use a [backup access code pool](https://docs.seam.co/capability-guides/smart-locks/access-codes#backup-access-codes) provided by Seam. If `true`, you can use [`/access_codes/pull_backup_access_code`](https://docs.seam.co/api/access_codes/pull_backup_access_code).',
                     type: 'boolean',
                   },
                 },
@@ -33772,7 +33772,7 @@ const openapi: OpenAPISpec = {
     '/access_codes/delete': {
       delete: {
         description:
-          'Deletes an [access code](https://docs.seam.co/latest/capability-guides/smart-locks/access-codes).',
+          'Deletes an [access code](https://docs.seam.co/capability-guides/smart-locks/access-codes).',
         operationId: 'accessCodesDeleteDelete',
         parameters: [
           {
@@ -33845,7 +33845,7 @@ const openapi: OpenAPISpec = {
       },
       post: {
         description:
-          'Deletes an [access code](https://docs.seam.co/latest/capability-guides/smart-locks/access-codes).',
+          'Deletes an [access code](https://docs.seam.co/capability-guides/smart-locks/access-codes).',
         operationId: 'accessCodesDeletePost',
         requestBody: {
           content: {
@@ -33916,7 +33916,7 @@ const openapi: OpenAPISpec = {
     '/access_codes/generate_code': {
       get: {
         description:
-          'Generates a code for an [access code](https://docs.seam.co/latest/capability-guides/smart-locks/access-codes), given a device ID.',
+          'Generates a code for an [access code](https://docs.seam.co/capability-guides/smart-locks/access-codes), given a device ID.',
         operationId: 'accessCodesGenerateCodeGet',
         parameters: [
           {
@@ -33968,7 +33968,7 @@ const openapi: OpenAPISpec = {
       },
       post: {
         description:
-          'Generates a code for an [access code](https://docs.seam.co/latest/capability-guides/smart-locks/access-codes), given a device ID.',
+          'Generates a code for an [access code](https://docs.seam.co/capability-guides/smart-locks/access-codes), given a device ID.',
         operationId: 'accessCodesGenerateCodePost',
         requestBody: {
           content: {
@@ -34027,7 +34027,7 @@ const openapi: OpenAPISpec = {
     '/access_codes/get': {
       get: {
         description:
-          'Returns a specified [access code](https://docs.seam.co/latest/capability-guides/smart-locks/access-codes).\n\nYou must specify either `access_code_id` or both `device_id` and `code`.',
+          'Returns a specified [access code](https://docs.seam.co/capability-guides/smart-locks/access-codes).\n\nYou must specify either `access_code_id` or both `device_id` and `code`.',
         operationId: 'accessCodesGetGet',
         parameters: [
           {
@@ -34096,7 +34096,7 @@ const openapi: OpenAPISpec = {
       },
       post: {
         description:
-          'Returns a specified [access code](https://docs.seam.co/latest/capability-guides/smart-locks/access-codes).\n\nYou must specify either `access_code_id` or both `device_id` and `code`.',
+          'Returns a specified [access code](https://docs.seam.co/capability-guides/smart-locks/access-codes).\n\nYou must specify either `access_code_id` or both `device_id` and `code`.',
         operationId: 'accessCodesGetPost',
         requestBody: {
           content: {
@@ -34631,7 +34631,7 @@ const openapi: OpenAPISpec = {
     '/access_codes/list': {
       get: {
         description:
-          'Returns a list of all [access codes](https://docs.seam.co/latest/capability-guides/smart-locks/access-codes).\n\nSpecify `device_id`, `access_code_ids`, `access_method_id`, or `access_grant_id`.',
+          'Returns a list of all [access codes](https://docs.seam.co/capability-guides/smart-locks/access-codes).\n\nSpecify `device_id`, `access_code_ids`, `access_method_id`, or `access_grant_id`.',
         operationId: 'accessCodesListGet',
         parameters: [
           {
@@ -34764,7 +34764,7 @@ const openapi: OpenAPISpec = {
       },
       post: {
         description:
-          'Returns a list of all [access codes](https://docs.seam.co/latest/capability-guides/smart-locks/access-codes).\n\nSpecify `device_id`, `access_code_ids`, `access_method_id`, or `access_grant_id`.',
+          'Returns a list of all [access codes](https://docs.seam.co/capability-guides/smart-locks/access-codes).\n\nSpecify `device_id`, `access_code_ids`, `access_method_id`, or `access_grant_id`.',
         operationId: 'accessCodesListPost',
         requestBody: {
           content: {
@@ -34872,7 +34872,7 @@ const openapi: OpenAPISpec = {
     '/access_codes/pull_backup_access_code': {
       post: {
         description:
-          "Retrieves a backup access code for an [access code](https://docs.seam.co/latest/capability-guides/smart-locks/access-codes). See also [Managing Backup Access Codes](https://docs.seam.co/latest/capability-guides/smart-locks/access-codes/backup-access-codes).\n\nA backup access code pool is a collection of pre-programmed access codes stored on a device, ready for use. These codes are programmed in addition to the regular access codes on Seam, serving as a safety net for any issues with the primary codes. If there's ever a complication with a primary access code—be it due to intermittent connectivity, manual removal from a device, or provider outages—a backup code can be retrieved. Its end time can then be adjusted to align with the original code, facilitating seamless and uninterrupted access.\n\nYou can pull a backup access code from the pool at any time. These backup codes are guaranteed to work immediately and automatically programmed to be removed from the device after the access code ends.\n\nYou can only pull backup access codes for time-bound access codes.\n\nBefore pulling a backup access code, make sure that the device's `properties.supports_backup_access_code_pool` is `true`. Then, to activate the backup pool, set `use_backup_access_code_pool` to `true` when creating an access code.",
+          "Retrieves a backup access code for an [access code](https://docs.seam.co/capability-guides/smart-locks/access-codes). See also [Managing Backup Access Codes](https://docs.seam.co/capability-guides/smart-locks/access-codes/backup-access-codes).\n\nA backup access code pool is a collection of pre-programmed access codes stored on a device, ready for use. These codes are programmed in addition to the regular access codes on Seam, serving as a safety net for any issues with the primary codes. If there's ever a complication with a primary access code—be it due to intermittent connectivity, manual removal from a device, or provider outages—a backup code can be retrieved. Its end time can then be adjusted to align with the original code, facilitating seamless and uninterrupted access.\n\nYou can pull a backup access code from the pool at any time. These backup codes are guaranteed to work immediately and automatically programmed to be removed from the device after the access code ends.\n\nYou can only pull backup access codes for time-bound access codes.\n\nBefore pulling a backup access code, make sure that the device's `properties.supports_backup_access_code_pool` is `true`. Then, to activate the backup pool, set `use_backup_access_code_pool` to `true` when creating an access code.",
         operationId: 'accessCodesPullBackupAccessCodePost',
         requestBody: {
           content: {
@@ -35007,7 +35007,7 @@ const openapi: OpenAPISpec = {
     '/access_codes/simulate/create_unmanaged_access_code': {
       post: {
         description:
-          'Simulates the creation of an [unmanaged access code](https://docs.seam.co/latest/capability-guides/smart-locks/access-codes/migrating-existing-access-codes) in a [sandbox workspace](https://docs.seam.co/latest/core-concepts/workspaces#sandbox-workspaces).',
+          'Simulates the creation of an [unmanaged access code](https://docs.seam.co/capability-guides/smart-locks/access-codes/migrating-existing-access-codes) in a [sandbox workspace](https://docs.seam.co/core-concepts/workspaces#sandbox-workspaces).',
         operationId: 'accessCodesSimulateCreateUnmanagedAccessCodePost',
         requestBody: {
           content: {
@@ -35077,7 +35077,7 @@ const openapi: OpenAPISpec = {
     '/access_codes/unmanaged/convert_to_managed': {
       patch: {
         description:
-          'Converts an [unmanaged access code](https://docs.seam.co/latest/capability-guides/smart-locks/access-codes/migrating-existing-access-codes) to an [access code managed through Seam](https://docs.seam.co/latest/capability-guides/smart-locks/access-codes).\n\nAn unmanaged access code has a limited set of operations that you can perform on it. Once you convert an unmanaged access code to a managed access code, the full set of access code operations and lifecycle events becomes available for it.\n\nNote that not all device providers support converting an unmanaged access code to a managed access code.',
+          'Converts an [unmanaged access code](https://docs.seam.co/capability-guides/smart-locks/access-codes/migrating-existing-access-codes) to an [access code managed through Seam](https://docs.seam.co/capability-guides/smart-locks/access-codes).\n\nAn unmanaged access code has a limited set of operations that you can perform on it. Once you convert an unmanaged access code to a managed access code, the full set of access code operations and lifecycle events becomes available for it.\n\nNote that not all device providers support converting an unmanaged access code to a managed access code.',
         operationId: 'accessCodesUnmanagedConvertToManagedPatch',
         requestBody: {
           content: {
@@ -35092,7 +35092,7 @@ const openapi: OpenAPISpec = {
                   },
                   allow_external_modification: {
                     description:
-                      'Indicates whether [external modification](https://docs.seam.co/latest/capability-guides/smart-locks/access-codes#external-modification) of the access code is allowed.',
+                      'Indicates whether [external modification](https://docs.seam.co/capability-guides/smart-locks/access-codes#external-modification) of the access code is allowed.',
                     type: 'boolean',
                   },
                   force: {
@@ -35102,7 +35102,7 @@ const openapi: OpenAPISpec = {
                   },
                   is_external_modification_allowed: {
                     description:
-                      'Indicates whether [external modification](https://docs.seam.co/latest/capability-guides/smart-locks/access-codes#external-modification) of the access code is allowed.',
+                      'Indicates whether [external modification](https://docs.seam.co/capability-guides/smart-locks/access-codes#external-modification) of the access code is allowed.',
                     type: 'boolean',
                   },
                   sync: {
@@ -35149,7 +35149,7 @@ const openapi: OpenAPISpec = {
       },
       post: {
         description:
-          'Converts an [unmanaged access code](https://docs.seam.co/latest/capability-guides/smart-locks/access-codes/migrating-existing-access-codes) to an [access code managed through Seam](https://docs.seam.co/latest/capability-guides/smart-locks/access-codes).\n\nAn unmanaged access code has a limited set of operations that you can perform on it. Once you convert an unmanaged access code to a managed access code, the full set of access code operations and lifecycle events becomes available for it.\n\nNote that not all device providers support converting an unmanaged access code to a managed access code.',
+          'Converts an [unmanaged access code](https://docs.seam.co/capability-guides/smart-locks/access-codes/migrating-existing-access-codes) to an [access code managed through Seam](https://docs.seam.co/capability-guides/smart-locks/access-codes).\n\nAn unmanaged access code has a limited set of operations that you can perform on it. Once you convert an unmanaged access code to a managed access code, the full set of access code operations and lifecycle events becomes available for it.\n\nNote that not all device providers support converting an unmanaged access code to a managed access code.',
         operationId: 'accessCodesUnmanagedConvertToManagedPost',
         requestBody: {
           content: {
@@ -35164,7 +35164,7 @@ const openapi: OpenAPISpec = {
                   },
                   allow_external_modification: {
                     description:
-                      'Indicates whether [external modification](https://docs.seam.co/latest/capability-guides/smart-locks/access-codes#external-modification) of the access code is allowed.',
+                      'Indicates whether [external modification](https://docs.seam.co/capability-guides/smart-locks/access-codes#external-modification) of the access code is allowed.',
                     type: 'boolean',
                   },
                   force: {
@@ -35174,7 +35174,7 @@ const openapi: OpenAPISpec = {
                   },
                   is_external_modification_allowed: {
                     description:
-                      'Indicates whether [external modification](https://docs.seam.co/latest/capability-guides/smart-locks/access-codes#external-modification) of the access code is allowed.',
+                      'Indicates whether [external modification](https://docs.seam.co/capability-guides/smart-locks/access-codes#external-modification) of the access code is allowed.',
                     type: 'boolean',
                   },
                   sync: {
@@ -35223,7 +35223,7 @@ const openapi: OpenAPISpec = {
     '/access_codes/unmanaged/delete': {
       delete: {
         description:
-          'Deletes an [unmanaged access code](https://docs.seam.co/latest/capability-guides/smart-locks/access-codes/migrating-existing-access-codes).',
+          'Deletes an [unmanaged access code](https://docs.seam.co/capability-guides/smart-locks/access-codes/migrating-existing-access-codes).',
         operationId: 'accessCodesUnmanagedDeleteDelete',
         parameters: [
           {
@@ -35285,7 +35285,7 @@ const openapi: OpenAPISpec = {
       },
       post: {
         description:
-          'Deletes an [unmanaged access code](https://docs.seam.co/latest/capability-guides/smart-locks/access-codes/migrating-existing-access-codes).',
+          'Deletes an [unmanaged access code](https://docs.seam.co/capability-guides/smart-locks/access-codes/migrating-existing-access-codes).',
         operationId: 'accessCodesUnmanagedDeletePost',
         requestBody: {
           content: {
@@ -35349,7 +35349,7 @@ const openapi: OpenAPISpec = {
     '/access_codes/unmanaged/get': {
       get: {
         description:
-          'Returns a specified [unmanaged access code](https://docs.seam.co/latest/capability-guides/smart-locks/access-codes/migrating-existing-access-codes).\n\nYou must specify either `access_code_id` or both `device_id` and `code`.',
+          'Returns a specified [unmanaged access code](https://docs.seam.co/capability-guides/smart-locks/access-codes/migrating-existing-access-codes).\n\nYou must specify either `access_code_id` or both `device_id` and `code`.',
         operationId: 'accessCodesUnmanagedGetGet',
         parameters: [
           {
@@ -35419,7 +35419,7 @@ const openapi: OpenAPISpec = {
       },
       post: {
         description:
-          'Returns a specified [unmanaged access code](https://docs.seam.co/latest/capability-guides/smart-locks/access-codes/migrating-existing-access-codes).\n\nYou must specify either `access_code_id` or both `device_id` and `code`.',
+          'Returns a specified [unmanaged access code](https://docs.seam.co/capability-guides/smart-locks/access-codes/migrating-existing-access-codes).\n\nYou must specify either `access_code_id` or both `device_id` and `code`.',
         operationId: 'accessCodesUnmanagedGetPost',
         requestBody: {
           content: {
@@ -35488,7 +35488,7 @@ const openapi: OpenAPISpec = {
     '/access_codes/unmanaged/list': {
       get: {
         description:
-          'Returns a list of all [unmanaged access codes](https://docs.seam.co/latest/capability-guides/smart-locks/access-codes/migrating-existing-access-codes).',
+          'Returns a list of all [unmanaged access codes](https://docs.seam.co/capability-guides/smart-locks/access-codes/migrating-existing-access-codes).',
         operationId: 'accessCodesUnmanagedListGet',
         parameters: [
           {
@@ -35589,7 +35589,7 @@ const openapi: OpenAPISpec = {
       },
       post: {
         description:
-          'Returns a list of all [unmanaged access codes](https://docs.seam.co/latest/capability-guides/smart-locks/access-codes/migrating-existing-access-codes).',
+          'Returns a list of all [unmanaged access codes](https://docs.seam.co/capability-guides/smart-locks/access-codes/migrating-existing-access-codes).',
         operationId: 'accessCodesUnmanagedListPost',
         requestBody: {
           content: {
@@ -35677,7 +35677,7 @@ const openapi: OpenAPISpec = {
     '/access_codes/unmanaged/update': {
       patch: {
         description:
-          'Updates a specified [unmanaged access code](https://docs.seam.co/latest/capability-guides/smart-locks/access-codes/migrating-existing-access-codes).',
+          'Updates a specified [unmanaged access code](https://docs.seam.co/capability-guides/smart-locks/access-codes/migrating-existing-access-codes).',
         operationId: 'accessCodesUnmanagedUpdatePatch',
         requestBody: {
           content: {
@@ -35692,7 +35692,7 @@ const openapi: OpenAPISpec = {
                   },
                   allow_external_modification: {
                     description:
-                      'Indicates whether [external modification](https://docs.seam.co/latest/capability-guides/smart-locks/access-codes#external-modification) of the code is allowed.',
+                      'Indicates whether [external modification](https://docs.seam.co/capability-guides/smart-locks/access-codes#external-modification) of the code is allowed.',
                     type: 'boolean',
                   },
                   force: {
@@ -35702,7 +35702,7 @@ const openapi: OpenAPISpec = {
                   },
                   is_external_modification_allowed: {
                     description:
-                      'Indicates whether [external modification](https://docs.seam.co/latest/capability-guides/smart-locks/access-codes#external-modification) of the code is allowed.',
+                      'Indicates whether [external modification](https://docs.seam.co/capability-guides/smart-locks/access-codes#external-modification) of the code is allowed.',
                     type: 'boolean',
                   },
                   is_managed: { type: 'boolean' },
@@ -35744,7 +35744,7 @@ const openapi: OpenAPISpec = {
       },
       post: {
         description:
-          'Updates a specified [unmanaged access code](https://docs.seam.co/latest/capability-guides/smart-locks/access-codes/migrating-existing-access-codes).',
+          'Updates a specified [unmanaged access code](https://docs.seam.co/capability-guides/smart-locks/access-codes/migrating-existing-access-codes).',
         operationId: 'accessCodesUnmanagedUpdatePost',
         requestBody: {
           content: {
@@ -35759,7 +35759,7 @@ const openapi: OpenAPISpec = {
                   },
                   allow_external_modification: {
                     description:
-                      'Indicates whether [external modification](https://docs.seam.co/latest/capability-guides/smart-locks/access-codes#external-modification) of the code is allowed.',
+                      'Indicates whether [external modification](https://docs.seam.co/capability-guides/smart-locks/access-codes#external-modification) of the code is allowed.',
                     type: 'boolean',
                   },
                   force: {
@@ -35769,7 +35769,7 @@ const openapi: OpenAPISpec = {
                   },
                   is_external_modification_allowed: {
                     description:
-                      'Indicates whether [external modification](https://docs.seam.co/latest/capability-guides/smart-locks/access-codes#external-modification) of the code is allowed.',
+                      'Indicates whether [external modification](https://docs.seam.co/capability-guides/smart-locks/access-codes#external-modification) of the code is allowed.',
                     type: 'boolean',
                   },
                   is_managed: { type: 'boolean' },
@@ -35813,7 +35813,7 @@ const openapi: OpenAPISpec = {
     '/access_codes/update': {
       patch: {
         description:
-          'Updates a specified active or upcoming [access code](https://docs.seam.co/latest/capability-guides/smart-locks/access-codes).\n\nSee also [Modifying Access Codes](https://docs.seam.co/latest/capability-guides/smart-locks/access-codes/modifying-access-codes).',
+          'Updates a specified active or upcoming [access code](https://docs.seam.co/capability-guides/smart-locks/access-codes).\n\nSee also [Modifying Access Codes](https://docs.seam.co/capability-guides/smart-locks/access-codes/modifying-access-codes).',
         operationId: 'accessCodesUpdatePatch',
         requestBody: {
           content: {
@@ -35828,7 +35828,7 @@ const openapi: OpenAPISpec = {
                   },
                   allow_external_modification: {
                     description:
-                      'Indicates whether [external modification](https://docs.seam.co/latest/capability-guides/smart-locks/access-codes#external-modification) of the code is allowed. Default: `false`.',
+                      'Indicates whether [external modification](https://docs.seam.co/capability-guides/smart-locks/access-codes#external-modification) of the code is allowed. Default: `false`.',
                     type: 'boolean',
                   },
                   attempt_for_offline_device: {
@@ -35855,7 +35855,7 @@ const openapi: OpenAPISpec = {
                   },
                   is_external_modification_allowed: {
                     description:
-                      'Indicates whether [external modification](https://docs.seam.co/latest/capability-guides/smart-locks/access-codes#external-modification) of the code is allowed. Default: `false`.',
+                      'Indicates whether [external modification](https://docs.seam.co/capability-guides/smart-locks/access-codes#external-modification) of the code is allowed. Default: `false`.',
                     type: 'boolean',
                   },
                   is_managed: {
@@ -35865,18 +35865,18 @@ const openapi: OpenAPISpec = {
                   },
                   is_offline_access_code: {
                     description:
-                      'Indicates whether the access code is an [offline access code](https://docs.seam.co/latest/capability-guides/smart-locks/access-codes/offline-access-codes).',
+                      'Indicates whether the access code is an [offline access code](https://docs.seam.co/capability-guides/smart-locks/access-codes/offline-access-codes).',
                     type: 'boolean',
                   },
                   is_one_time_use: {
                     description:
-                      'Indicates whether the [offline access code](https://docs.seam.co/latest/capability-guides/smart-locks/access-codes/offline-access-codes) is a single-use access code.',
+                      'Indicates whether the [offline access code](https://docs.seam.co/capability-guides/smart-locks/access-codes/offline-access-codes) is a single-use access code.',
                     type: 'boolean',
                   },
                   max_time_rounding: {
                     default: '1hour',
                     description:
-                      'Maximum rounding adjustment. To create a daily-bound [offline access code](https://docs.seam.co/latest/capability-guides/smart-locks/access-codes/offline-access-codes) for devices that support this feature, set this parameter to `1d`.',
+                      'Maximum rounding adjustment. To create a daily-bound [offline access code](https://docs.seam.co/capability-guides/smart-locks/access-codes/offline-access-codes) for devices that support this feature, set this parameter to `1d`.',
                     enum: ['1hour', '1day', '1h', '1d'],
                     type: 'string',
                   },
@@ -35887,7 +35887,7 @@ const openapi: OpenAPISpec = {
                   },
                   prefer_native_scheduling: {
                     description:
-                      'Indicates whether [native scheduling](https://docs.seam.co/latest/capability-guides/smart-locks/access-codes#native-scheduling) should be used for time-bound codes when supported by the provider. Default: `true`.',
+                      'Indicates whether [native scheduling](https://docs.seam.co/capability-guides/smart-locks/access-codes#native-scheduling) should be used for time-bound codes when supported by the provider. Default: `true`.',
                     type: 'boolean',
                   },
                   preferred_code_length: {
@@ -35908,13 +35908,13 @@ const openapi: OpenAPISpec = {
                   },
                   type: {
                     description:
-                      'Type to which you want to convert the access code. To convert a time-bound access code to an ongoing access code, set `type` to `ongoing`. See also [Changing a time-bound access code to permanent access](https://docs.seam.co/latest/capability-guides/smart-locks/access-codes/modifying-access-codes#special-case-2-changing-a-time-bound-access-code-to-permanent-access).',
+                      'Type to which you want to convert the access code. To convert a time-bound access code to an ongoing access code, set `type` to `ongoing`. See also [Changing a time-bound access code to permanent access](https://docs.seam.co/capability-guides/smart-locks/access-codes/modifying-access-codes#special-case-2-changing-a-time-bound-access-code-to-permanent-access).',
                     enum: ['ongoing', 'time_bound'],
                     type: 'string',
                   },
                   use_backup_access_code_pool: {
                     description:
-                      'Indicates whether to use a [backup access code pool](https://docs.seam.co/latest/capability-guides/smart-locks/access-codes#backup-access-codes) provided by Seam. If `true`, you can use [`/access_codes/pull_backup_access_code`](https://docs.seam.co/latest/api/access_codes/pull_backup_access_code).',
+                      'Indicates whether to use a [backup access code pool](https://docs.seam.co/capability-guides/smart-locks/access-codes#backup-access-codes) provided by Seam. If `true`, you can use [`/access_codes/pull_backup_access_code`](https://docs.seam.co/api/access_codes/pull_backup_access_code).',
                     type: 'boolean',
                   },
                   use_offline_access_code: {
@@ -35967,7 +35967,7 @@ const openapi: OpenAPISpec = {
       },
       post: {
         description:
-          'Updates a specified active or upcoming [access code](https://docs.seam.co/latest/capability-guides/smart-locks/access-codes).\n\nSee also [Modifying Access Codes](https://docs.seam.co/latest/capability-guides/smart-locks/access-codes/modifying-access-codes).',
+          'Updates a specified active or upcoming [access code](https://docs.seam.co/capability-guides/smart-locks/access-codes).\n\nSee also [Modifying Access Codes](https://docs.seam.co/capability-guides/smart-locks/access-codes/modifying-access-codes).',
         operationId: 'accessCodesUpdatePost',
         requestBody: {
           content: {
@@ -35982,7 +35982,7 @@ const openapi: OpenAPISpec = {
                   },
                   allow_external_modification: {
                     description:
-                      'Indicates whether [external modification](https://docs.seam.co/latest/capability-guides/smart-locks/access-codes#external-modification) of the code is allowed. Default: `false`.',
+                      'Indicates whether [external modification](https://docs.seam.co/capability-guides/smart-locks/access-codes#external-modification) of the code is allowed. Default: `false`.',
                     type: 'boolean',
                   },
                   attempt_for_offline_device: {
@@ -36009,7 +36009,7 @@ const openapi: OpenAPISpec = {
                   },
                   is_external_modification_allowed: {
                     description:
-                      'Indicates whether [external modification](https://docs.seam.co/latest/capability-guides/smart-locks/access-codes#external-modification) of the code is allowed. Default: `false`.',
+                      'Indicates whether [external modification](https://docs.seam.co/capability-guides/smart-locks/access-codes#external-modification) of the code is allowed. Default: `false`.',
                     type: 'boolean',
                   },
                   is_managed: {
@@ -36019,18 +36019,18 @@ const openapi: OpenAPISpec = {
                   },
                   is_offline_access_code: {
                     description:
-                      'Indicates whether the access code is an [offline access code](https://docs.seam.co/latest/capability-guides/smart-locks/access-codes/offline-access-codes).',
+                      'Indicates whether the access code is an [offline access code](https://docs.seam.co/capability-guides/smart-locks/access-codes/offline-access-codes).',
                     type: 'boolean',
                   },
                   is_one_time_use: {
                     description:
-                      'Indicates whether the [offline access code](https://docs.seam.co/latest/capability-guides/smart-locks/access-codes/offline-access-codes) is a single-use access code.',
+                      'Indicates whether the [offline access code](https://docs.seam.co/capability-guides/smart-locks/access-codes/offline-access-codes) is a single-use access code.',
                     type: 'boolean',
                   },
                   max_time_rounding: {
                     default: '1hour',
                     description:
-                      'Maximum rounding adjustment. To create a daily-bound [offline access code](https://docs.seam.co/latest/capability-guides/smart-locks/access-codes/offline-access-codes) for devices that support this feature, set this parameter to `1d`.',
+                      'Maximum rounding adjustment. To create a daily-bound [offline access code](https://docs.seam.co/capability-guides/smart-locks/access-codes/offline-access-codes) for devices that support this feature, set this parameter to `1d`.',
                     enum: ['1hour', '1day', '1h', '1d'],
                     type: 'string',
                   },
@@ -36041,7 +36041,7 @@ const openapi: OpenAPISpec = {
                   },
                   prefer_native_scheduling: {
                     description:
-                      'Indicates whether [native scheduling](https://docs.seam.co/latest/capability-guides/smart-locks/access-codes#native-scheduling) should be used for time-bound codes when supported by the provider. Default: `true`.',
+                      'Indicates whether [native scheduling](https://docs.seam.co/capability-guides/smart-locks/access-codes#native-scheduling) should be used for time-bound codes when supported by the provider. Default: `true`.',
                     type: 'boolean',
                   },
                   preferred_code_length: {
@@ -36062,13 +36062,13 @@ const openapi: OpenAPISpec = {
                   },
                   type: {
                     description:
-                      'Type to which you want to convert the access code. To convert a time-bound access code to an ongoing access code, set `type` to `ongoing`. See also [Changing a time-bound access code to permanent access](https://docs.seam.co/latest/capability-guides/smart-locks/access-codes/modifying-access-codes#special-case-2-changing-a-time-bound-access-code-to-permanent-access).',
+                      'Type to which you want to convert the access code. To convert a time-bound access code to an ongoing access code, set `type` to `ongoing`. See also [Changing a time-bound access code to permanent access](https://docs.seam.co/capability-guides/smart-locks/access-codes/modifying-access-codes#special-case-2-changing-a-time-bound-access-code-to-permanent-access).',
                     enum: ['ongoing', 'time_bound'],
                     type: 'string',
                   },
                   use_backup_access_code_pool: {
                     description:
-                      'Indicates whether to use a [backup access code pool](https://docs.seam.co/latest/capability-guides/smart-locks/access-codes#backup-access-codes) provided by Seam. If `true`, you can use [`/access_codes/pull_backup_access_code`](https://docs.seam.co/latest/api/access_codes/pull_backup_access_code).',
+                      'Indicates whether to use a [backup access code pool](https://docs.seam.co/capability-guides/smart-locks/access-codes#backup-access-codes) provided by Seam. If `true`, you can use [`/access_codes/pull_backup_access_code`](https://docs.seam.co/api/access_codes/pull_backup_access_code).',
                     type: 'boolean',
                   },
                   use_offline_access_code: {
@@ -36121,7 +36121,7 @@ const openapi: OpenAPISpec = {
       },
       put: {
         description:
-          'Updates a specified active or upcoming [access code](https://docs.seam.co/latest/capability-guides/smart-locks/access-codes).\n\nSee also [Modifying Access Codes](https://docs.seam.co/latest/capability-guides/smart-locks/access-codes/modifying-access-codes).',
+          'Updates a specified active or upcoming [access code](https://docs.seam.co/capability-guides/smart-locks/access-codes).\n\nSee also [Modifying Access Codes](https://docs.seam.co/capability-guides/smart-locks/access-codes/modifying-access-codes).',
         operationId: 'accessCodesUpdatePut',
         requestBody: {
           content: {
@@ -36136,7 +36136,7 @@ const openapi: OpenAPISpec = {
                   },
                   allow_external_modification: {
                     description:
-                      'Indicates whether [external modification](https://docs.seam.co/latest/capability-guides/smart-locks/access-codes#external-modification) of the code is allowed. Default: `false`.',
+                      'Indicates whether [external modification](https://docs.seam.co/capability-guides/smart-locks/access-codes#external-modification) of the code is allowed. Default: `false`.',
                     type: 'boolean',
                   },
                   attempt_for_offline_device: {
@@ -36163,7 +36163,7 @@ const openapi: OpenAPISpec = {
                   },
                   is_external_modification_allowed: {
                     description:
-                      'Indicates whether [external modification](https://docs.seam.co/latest/capability-guides/smart-locks/access-codes#external-modification) of the code is allowed. Default: `false`.',
+                      'Indicates whether [external modification](https://docs.seam.co/capability-guides/smart-locks/access-codes#external-modification) of the code is allowed. Default: `false`.',
                     type: 'boolean',
                   },
                   is_managed: {
@@ -36173,18 +36173,18 @@ const openapi: OpenAPISpec = {
                   },
                   is_offline_access_code: {
                     description:
-                      'Indicates whether the access code is an [offline access code](https://docs.seam.co/latest/capability-guides/smart-locks/access-codes/offline-access-codes).',
+                      'Indicates whether the access code is an [offline access code](https://docs.seam.co/capability-guides/smart-locks/access-codes/offline-access-codes).',
                     type: 'boolean',
                   },
                   is_one_time_use: {
                     description:
-                      'Indicates whether the [offline access code](https://docs.seam.co/latest/capability-guides/smart-locks/access-codes/offline-access-codes) is a single-use access code.',
+                      'Indicates whether the [offline access code](https://docs.seam.co/capability-guides/smart-locks/access-codes/offline-access-codes) is a single-use access code.',
                     type: 'boolean',
                   },
                   max_time_rounding: {
                     default: '1hour',
                     description:
-                      'Maximum rounding adjustment. To create a daily-bound [offline access code](https://docs.seam.co/latest/capability-guides/smart-locks/access-codes/offline-access-codes) for devices that support this feature, set this parameter to `1d`.',
+                      'Maximum rounding adjustment. To create a daily-bound [offline access code](https://docs.seam.co/capability-guides/smart-locks/access-codes/offline-access-codes) for devices that support this feature, set this parameter to `1d`.',
                     enum: ['1hour', '1day', '1h', '1d'],
                     type: 'string',
                   },
@@ -36195,7 +36195,7 @@ const openapi: OpenAPISpec = {
                   },
                   prefer_native_scheduling: {
                     description:
-                      'Indicates whether [native scheduling](https://docs.seam.co/latest/capability-guides/smart-locks/access-codes#native-scheduling) should be used for time-bound codes when supported by the provider. Default: `true`.',
+                      'Indicates whether [native scheduling](https://docs.seam.co/capability-guides/smart-locks/access-codes#native-scheduling) should be used for time-bound codes when supported by the provider. Default: `true`.',
                     type: 'boolean',
                   },
                   preferred_code_length: {
@@ -36216,13 +36216,13 @@ const openapi: OpenAPISpec = {
                   },
                   type: {
                     description:
-                      'Type to which you want to convert the access code. To convert a time-bound access code to an ongoing access code, set `type` to `ongoing`. See also [Changing a time-bound access code to permanent access](https://docs.seam.co/latest/capability-guides/smart-locks/access-codes/modifying-access-codes#special-case-2-changing-a-time-bound-access-code-to-permanent-access).',
+                      'Type to which you want to convert the access code. To convert a time-bound access code to an ongoing access code, set `type` to `ongoing`. See also [Changing a time-bound access code to permanent access](https://docs.seam.co/capability-guides/smart-locks/access-codes/modifying-access-codes#special-case-2-changing-a-time-bound-access-code-to-permanent-access).',
                     enum: ['ongoing', 'time_bound'],
                     type: 'string',
                   },
                   use_backup_access_code_pool: {
                     description:
-                      'Indicates whether to use a [backup access code pool](https://docs.seam.co/latest/capability-guides/smart-locks/access-codes#backup-access-codes) provided by Seam. If `true`, you can use [`/access_codes/pull_backup_access_code`](https://docs.seam.co/latest/api/access_codes/pull_backup_access_code).',
+                      'Indicates whether to use a [backup access code pool](https://docs.seam.co/capability-guides/smart-locks/access-codes#backup-access-codes) provided by Seam. If `true`, you can use [`/access_codes/pull_backup_access_code`](https://docs.seam.co/api/access_codes/pull_backup_access_code).',
                     type: 'boolean',
                   },
                   use_offline_access_code: {
@@ -36277,7 +36277,7 @@ const openapi: OpenAPISpec = {
     '/access_codes/update_multiple': {
       patch: {
         description:
-          'Updates [access codes](https://docs.seam.co/latest/capability-guides/smart-locks/access-codes) that share a common code across multiple devices.\n\nSpecify the `common_code_key` to identify the set of access codes that you want to update.\n\nSee also [Update Linked Access Codes](https://docs.seam.co/latest/capability-guides/smart-locks/access-codes/creating-and-updating-multiple-linked-access-codes#update-linked-access-codes).',
+          'Updates [access codes](https://docs.seam.co/capability-guides/smart-locks/access-codes) that share a common code across multiple devices.\n\nSpecify the `common_code_key` to identify the set of access codes that you want to update.\n\nSee also [Update Linked Access Codes](https://docs.seam.co/capability-guides/smart-locks/access-codes/creating-and-updating-multiple-linked-access-codes#update-linked-access-codes).',
         operationId: 'accessCodesUpdateMultiplePatch',
         requestBody: {
           content: {
@@ -36343,7 +36343,7 @@ const openapi: OpenAPISpec = {
       },
       post: {
         description:
-          'Updates [access codes](https://docs.seam.co/latest/capability-guides/smart-locks/access-codes) that share a common code across multiple devices.\n\nSpecify the `common_code_key` to identify the set of access codes that you want to update.\n\nSee also [Update Linked Access Codes](https://docs.seam.co/latest/capability-guides/smart-locks/access-codes/creating-and-updating-multiple-linked-access-codes#update-linked-access-codes).',
+          'Updates [access codes](https://docs.seam.co/capability-guides/smart-locks/access-codes) that share a common code across multiple devices.\n\nSpecify the `common_code_key` to identify the set of access codes that you want to update.\n\nSee also [Update Linked Access Codes](https://docs.seam.co/capability-guides/smart-locks/access-codes/creating-and-updating-multiple-linked-access-codes#update-linked-access-codes).',
         operationId: 'accessCodesUpdateMultiplePost',
         requestBody: {
           content: {
@@ -36411,7 +36411,7 @@ const openapi: OpenAPISpec = {
     '/access_grants/create': {
       post: {
         description:
-          'Creates a new [Access Grant](https://docs.seam.co/latest/use-cases/granting-access/access-grants). Access Grants are the default and recommended way to grant a user access to any physical space, irrespective of the locking hardware. They work with both standalone smart locks (using `device_ids`) and access control systems (using `acs_entrance_ids` or `space_ids`), and can issue PIN codes, key cards, and mobile keys through a single request.',
+          'Creates a new [Access Grant](https://docs.seam.co/use-cases/granting-access/access-grants). Access Grants are the default and recommended way to grant a user access to any physical space, irrespective of the locking hardware. They work with both standalone smart locks (using `device_ids`) and access control systems (using `acs_entrance_ids` or `space_ids`), and can issue PIN codes, key cards, and mobile keys through a single request.',
         operationId: 'accessGrantsCreatePost',
         requestBody: {
           content: {
@@ -36483,7 +36483,7 @@ const openapi: OpenAPISpec = {
                       acs_entrance_ids: {
                         default: [],
                         description:
-                          'Set of IDs of the [entrances](https://docs.seam.co/latest/api/acs/systems/list) to which access is being granted.',
+                          'Set of IDs of the [entrances](https://docs.seam.co/api/acs/systems/list) to which access is being granted.',
                         items: { format: 'uuid', type: 'string' },
                         type: 'array',
                       },
@@ -36496,7 +36496,7 @@ const openapi: OpenAPISpec = {
                       device_ids: {
                         default: [],
                         description:
-                          'Set of IDs of the [devices](https://docs.seam.co/latest/api/devices/list) to which access is being granted.',
+                          'Set of IDs of the [devices](https://docs.seam.co/api/devices/list) to which access is being granted.',
                         items: { format: 'uuid', type: 'string' },
                         type: 'array',
                       },
@@ -37576,7 +37576,7 @@ const openapi: OpenAPISpec = {
                         },
                         errors: {
                           description:
-                            'Errors associated with the [access grant](https://docs.seam.co/latest/capability-guides/access-grants).',
+                            'Errors associated with the [access grant](https://docs.seam.co/capability-guides/access-grants).',
                           items: {
                             discriminator: { propertyName: 'error_code' },
                             oneOf: [
@@ -37874,15 +37874,15 @@ const openapi: OpenAPISpec = {
                         },
                         warnings: {
                           description:
-                            'Warnings associated with the [access grant](https://docs.seam.co/latest/capability-guides/access-grants).',
+                            'Warnings associated with the [access grant](https://docs.seam.co/capability-guides/access-grants).',
                           items: {
                             description:
-                              'Warning associated with the [access grant](https://docs.seam.co/latest/capability-guides/access-grants).',
+                              'Warning associated with the [access grant](https://docs.seam.co/capability-guides/access-grants).',
                             discriminator: { propertyName: 'warning_code' },
                             oneOf: [
                               {
                                 description:
-                                  'Indicates that the [access grant](https://docs.seam.co/latest/capability-guides/access-grants) is being deleted.',
+                                  'Indicates that the [access grant](https://docs.seam.co/capability-guides/access-grants) is being deleted.',
                                 properties: {
                                   created_at: {
                                     description:
@@ -38000,7 +38000,7 @@ const openapi: OpenAPISpec = {
                               },
                               {
                                 description:
-                                  'Indicates that the access times for this [access grant](https://docs.seam.co/latest/capability-guides/access-grants) are being updated.',
+                                  'Indicates that the access times for this [access grant](https://docs.seam.co/capability-guides/access-grants) are being updated.',
                                 properties: {
                                   access_method_ids: {
                                     description:
@@ -38285,7 +38285,7 @@ const openapi: OpenAPISpec = {
                         },
                         errors: {
                           description:
-                            'Errors associated with the [access grant](https://docs.seam.co/latest/capability-guides/access-grants).',
+                            'Errors associated with the [access grant](https://docs.seam.co/capability-guides/access-grants).',
                           items: {
                             discriminator: { propertyName: 'error_code' },
                             oneOf: [
@@ -38583,15 +38583,15 @@ const openapi: OpenAPISpec = {
                         },
                         warnings: {
                           description:
-                            'Warnings associated with the [access grant](https://docs.seam.co/latest/capability-guides/access-grants).',
+                            'Warnings associated with the [access grant](https://docs.seam.co/capability-guides/access-grants).',
                           items: {
                             description:
-                              'Warning associated with the [access grant](https://docs.seam.co/latest/capability-guides/access-grants).',
+                              'Warning associated with the [access grant](https://docs.seam.co/capability-guides/access-grants).',
                             discriminator: { propertyName: 'warning_code' },
                             oneOf: [
                               {
                                 description:
-                                  'Indicates that the [access grant](https://docs.seam.co/latest/capability-guides/access-grants) is being deleted.',
+                                  'Indicates that the [access grant](https://docs.seam.co/capability-guides/access-grants) is being deleted.',
                                 properties: {
                                   created_at: {
                                     description:
@@ -38709,7 +38709,7 @@ const openapi: OpenAPISpec = {
                               },
                               {
                                 description:
-                                  'Indicates that the access times for this [access grant](https://docs.seam.co/latest/capability-guides/access-grants) are being updated.',
+                                  'Indicates that the access times for this [access grant](https://docs.seam.co/capability-guides/access-grants) are being updated.',
                                 properties: {
                                   access_method_ids: {
                                     description:
@@ -39040,7 +39040,7 @@ const openapi: OpenAPISpec = {
                           },
                           errors: {
                             description:
-                              'Errors associated with the [access grant](https://docs.seam.co/latest/capability-guides/access-grants).',
+                              'Errors associated with the [access grant](https://docs.seam.co/capability-guides/access-grants).',
                             items: {
                               discriminator: { propertyName: 'error_code' },
                               oneOf: [
@@ -39341,15 +39341,15 @@ const openapi: OpenAPISpec = {
                           },
                           warnings: {
                             description:
-                              'Warnings associated with the [access grant](https://docs.seam.co/latest/capability-guides/access-grants).',
+                              'Warnings associated with the [access grant](https://docs.seam.co/capability-guides/access-grants).',
                             items: {
                               description:
-                                'Warning associated with the [access grant](https://docs.seam.co/latest/capability-guides/access-grants).',
+                                'Warning associated with the [access grant](https://docs.seam.co/capability-guides/access-grants).',
                               discriminator: { propertyName: 'warning_code' },
                               oneOf: [
                                 {
                                   description:
-                                    'Indicates that the [access grant](https://docs.seam.co/latest/capability-guides/access-grants) is being deleted.',
+                                    'Indicates that the [access grant](https://docs.seam.co/capability-guides/access-grants) is being deleted.',
                                   properties: {
                                     created_at: {
                                       description:
@@ -39467,7 +39467,7 @@ const openapi: OpenAPISpec = {
                                 },
                                 {
                                   description:
-                                    'Indicates that the access times for this [access grant](https://docs.seam.co/latest/capability-guides/access-grants) are being updated.',
+                                    'Indicates that the access times for this [access grant](https://docs.seam.co/capability-guides/access-grants) are being updated.',
                                   properties: {
                                     access_method_ids: {
                                       description:
@@ -39787,7 +39787,7 @@ const openapi: OpenAPISpec = {
                           },
                           errors: {
                             description:
-                              'Errors associated with the [access grant](https://docs.seam.co/latest/capability-guides/access-grants).',
+                              'Errors associated with the [access grant](https://docs.seam.co/capability-guides/access-grants).',
                             items: {
                               discriminator: { propertyName: 'error_code' },
                               oneOf: [
@@ -40088,15 +40088,15 @@ const openapi: OpenAPISpec = {
                           },
                           warnings: {
                             description:
-                              'Warnings associated with the [access grant](https://docs.seam.co/latest/capability-guides/access-grants).',
+                              'Warnings associated with the [access grant](https://docs.seam.co/capability-guides/access-grants).',
                             items: {
                               description:
-                                'Warning associated with the [access grant](https://docs.seam.co/latest/capability-guides/access-grants).',
+                                'Warning associated with the [access grant](https://docs.seam.co/capability-guides/access-grants).',
                               discriminator: { propertyName: 'warning_code' },
                               oneOf: [
                                 {
                                   description:
-                                    'Indicates that the [access grant](https://docs.seam.co/latest/capability-guides/access-grants) is being deleted.',
+                                    'Indicates that the [access grant](https://docs.seam.co/capability-guides/access-grants) is being deleted.',
                                   properties: {
                                     created_at: {
                                       description:
@@ -40214,7 +40214,7 @@ const openapi: OpenAPISpec = {
                                 },
                                 {
                                   description:
-                                    'Indicates that the access times for this [access grant](https://docs.seam.co/latest/capability-guides/access-grants) are being updated.',
+                                    'Indicates that the access times for this [access grant](https://docs.seam.co/capability-guides/access-grants) are being updated.',
                                   properties: {
                                     access_method_ids: {
                                       description:
@@ -40880,7 +40880,7 @@ const openapi: OpenAPISpec = {
     '/access_methods/encode': {
       post: {
         description:
-          'Encodes an existing access method onto a plastic card placed on the specified [encoder](https://docs.seam.co/latest/capability-guides/access-systems/working-with-card-encoders-and-scanners).',
+          'Encodes an existing access method onto a plastic card placed on the specified [encoder](https://docs.seam.co/capability-guides/access-systems/working-with-card-encoders-and-scanners).',
         operationId: 'accessMethodsEncodePost',
         requestBody: {
           content: {
@@ -41524,7 +41524,7 @@ const openapi: OpenAPISpec = {
     '/access_methods/unlock_door': {
       post: {
         description:
-          'Remotely unlocks a specified [entrance](https://docs.seam.co/latest/capability-guides/access-systems/retrieving-entrance-details) using the cloud key credential associated with an access method. Returns an action attempt that tracks the progress of the unlock operation.',
+          'Remotely unlocks a specified [entrance](https://docs.seam.co/capability-guides/access-systems/retrieving-entrance-details) using the cloud key credential associated with an access method. Returns an action attempt that tracks the progress of the unlock operation.',
         operationId: 'accessMethodsUnlockDoorPost',
         requestBody: {
           content: {
@@ -41673,7 +41673,7 @@ const openapi: OpenAPISpec = {
                         },
                         pending_mutations: {
                           description:
-                            'Pending mutations for the [access method](https://docs.seam.co/latest/capability-guides/access-grants/delivering-access-methods). Indicates operations that are in progress.',
+                            'Pending mutations for the [access method](https://docs.seam.co/capability-guides/access-grants/delivering-access-methods). Indicates operations that are in progress.',
                           items: {
                             discriminator: { propertyName: 'mutation_code' },
                             oneOf: [
@@ -41885,15 +41885,15 @@ const openapi: OpenAPISpec = {
                         },
                         warnings: {
                           description:
-                            'Warnings associated with the [access method](https://docs.seam.co/latest/capability-guides/access-grants/delivering-access-methods).',
+                            'Warnings associated with the [access method](https://docs.seam.co/capability-guides/access-grants/delivering-access-methods).',
                           items: {
                             description:
-                              'Warning associated with the [access method](https://docs.seam.co/latest/capability-guides/access-grants/delivering-access-methods).',
+                              'Warning associated with the [access method](https://docs.seam.co/capability-guides/access-grants/delivering-access-methods).',
                             discriminator: { propertyName: 'warning_code' },
                             oneOf: [
                               {
                                 description:
-                                  'Indicates that the [access method](https://docs.seam.co/latest/capability-guides/access-grants/delivering-access-methods) is being deleted.',
+                                  'Indicates that the [access method](https://docs.seam.co/capability-guides/access-grants/delivering-access-methods) is being deleted.',
                                 properties: {
                                   created_at: {
                                     description:
@@ -41922,7 +41922,7 @@ const openapi: OpenAPISpec = {
                               },
                               {
                                 description:
-                                  'Indicates that the access times for this [access method](https://docs.seam.co/latest/capability-guides/access-grants/delivering-access-methods) are being updated.',
+                                  'Indicates that the access times for this [access method](https://docs.seam.co/capability-guides/access-grants/delivering-access-methods) are being updated.',
                                 properties: {
                                   created_at: {
                                     description:
@@ -42127,7 +42127,7 @@ const openapi: OpenAPISpec = {
                         },
                         pending_mutations: {
                           description:
-                            'Pending mutations for the [access method](https://docs.seam.co/latest/capability-guides/access-grants/delivering-access-methods). Indicates operations that are in progress.',
+                            'Pending mutations for the [access method](https://docs.seam.co/capability-guides/access-grants/delivering-access-methods). Indicates operations that are in progress.',
                           items: {
                             discriminator: { propertyName: 'mutation_code' },
                             oneOf: [
@@ -42339,15 +42339,15 @@ const openapi: OpenAPISpec = {
                         },
                         warnings: {
                           description:
-                            'Warnings associated with the [access method](https://docs.seam.co/latest/capability-guides/access-grants/delivering-access-methods).',
+                            'Warnings associated with the [access method](https://docs.seam.co/capability-guides/access-grants/delivering-access-methods).',
                           items: {
                             description:
-                              'Warning associated with the [access method](https://docs.seam.co/latest/capability-guides/access-grants/delivering-access-methods).',
+                              'Warning associated with the [access method](https://docs.seam.co/capability-guides/access-grants/delivering-access-methods).',
                             discriminator: { propertyName: 'warning_code' },
                             oneOf: [
                               {
                                 description:
-                                  'Indicates that the [access method](https://docs.seam.co/latest/capability-guides/access-grants/delivering-access-methods) is being deleted.',
+                                  'Indicates that the [access method](https://docs.seam.co/capability-guides/access-grants/delivering-access-methods) is being deleted.',
                                 properties: {
                                   created_at: {
                                     description:
@@ -42376,7 +42376,7 @@ const openapi: OpenAPISpec = {
                               },
                               {
                                 description:
-                                  'Indicates that the access times for this [access method](https://docs.seam.co/latest/capability-guides/access-grants/delivering-access-methods) are being updated.',
+                                  'Indicates that the access times for this [access method](https://docs.seam.co/capability-guides/access-grants/delivering-access-methods) are being updated.',
                                 properties: {
                                   created_at: {
                                     description:
@@ -42613,7 +42613,7 @@ const openapi: OpenAPISpec = {
                           },
                           pending_mutations: {
                             description:
-                              'Pending mutations for the [access method](https://docs.seam.co/latest/capability-guides/access-grants/delivering-access-methods). Indicates operations that are in progress.',
+                              'Pending mutations for the [access method](https://docs.seam.co/capability-guides/access-grants/delivering-access-methods). Indicates operations that are in progress.',
                             items: {
                               discriminator: { propertyName: 'mutation_code' },
                               oneOf: [
@@ -42826,15 +42826,15 @@ const openapi: OpenAPISpec = {
                           },
                           warnings: {
                             description:
-                              'Warnings associated with the [access method](https://docs.seam.co/latest/capability-guides/access-grants/delivering-access-methods).',
+                              'Warnings associated with the [access method](https://docs.seam.co/capability-guides/access-grants/delivering-access-methods).',
                             items: {
                               description:
-                                'Warning associated with the [access method](https://docs.seam.co/latest/capability-guides/access-grants/delivering-access-methods).',
+                                'Warning associated with the [access method](https://docs.seam.co/capability-guides/access-grants/delivering-access-methods).',
                               discriminator: { propertyName: 'warning_code' },
                               oneOf: [
                                 {
                                   description:
-                                    'Indicates that the [access method](https://docs.seam.co/latest/capability-guides/access-grants/delivering-access-methods) is being deleted.',
+                                    'Indicates that the [access method](https://docs.seam.co/capability-guides/access-grants/delivering-access-methods) is being deleted.',
                                   properties: {
                                     created_at: {
                                       description:
@@ -42863,7 +42863,7 @@ const openapi: OpenAPISpec = {
                                 },
                                 {
                                   description:
-                                    'Indicates that the access times for this [access method](https://docs.seam.co/latest/capability-guides/access-grants/delivering-access-methods) are being updated.',
+                                    'Indicates that the access times for this [access method](https://docs.seam.co/capability-guides/access-grants/delivering-access-methods) are being updated.',
                                   properties: {
                                     created_at: {
                                       description:
@@ -43091,7 +43091,7 @@ const openapi: OpenAPISpec = {
                           },
                           pending_mutations: {
                             description:
-                              'Pending mutations for the [access method](https://docs.seam.co/latest/capability-guides/access-grants/delivering-access-methods). Indicates operations that are in progress.',
+                              'Pending mutations for the [access method](https://docs.seam.co/capability-guides/access-grants/delivering-access-methods). Indicates operations that are in progress.',
                             items: {
                               discriminator: { propertyName: 'mutation_code' },
                               oneOf: [
@@ -43304,15 +43304,15 @@ const openapi: OpenAPISpec = {
                           },
                           warnings: {
                             description:
-                              'Warnings associated with the [access method](https://docs.seam.co/latest/capability-guides/access-grants/delivering-access-methods).',
+                              'Warnings associated with the [access method](https://docs.seam.co/capability-guides/access-grants/delivering-access-methods).',
                             items: {
                               description:
-                                'Warning associated with the [access method](https://docs.seam.co/latest/capability-guides/access-grants/delivering-access-methods).',
+                                'Warning associated with the [access method](https://docs.seam.co/capability-guides/access-grants/delivering-access-methods).',
                               discriminator: { propertyName: 'warning_code' },
                               oneOf: [
                                 {
                                   description:
-                                    'Indicates that the [access method](https://docs.seam.co/latest/capability-guides/access-grants/delivering-access-methods) is being deleted.',
+                                    'Indicates that the [access method](https://docs.seam.co/capability-guides/access-grants/delivering-access-methods) is being deleted.',
                                   properties: {
                                     created_at: {
                                       description:
@@ -43341,7 +43341,7 @@ const openapi: OpenAPISpec = {
                                 },
                                 {
                                   description:
-                                    'Indicates that the access times for this [access method](https://docs.seam.co/latest/capability-guides/access-grants/delivering-access-methods) are being updated.',
+                                    'Indicates that the access times for this [access method](https://docs.seam.co/capability-guides/access-grants/delivering-access-methods) are being updated.',
                                   properties: {
                                     created_at: {
                                       description:
@@ -43461,7 +43461,7 @@ const openapi: OpenAPISpec = {
     '/acs/access_groups/add_user': {
       post: {
         description:
-          'Adds a specified [access system user](https://docs.seam.co/latest/capability-guides/access-systems/user-management) to a specified [access group](https://docs.seam.co/latest/capability-guides/access-systems/user-management/assigning-users-to-access-groups).',
+          'Adds a specified [access system user](https://docs.seam.co/capability-guides/access-systems/user-management) to a specified [access group](https://docs.seam.co/capability-guides/access-systems/user-management/assigning-users-to-access-groups).',
         operationId: 'acsAccessGroupsAddUserPost',
         requestBody: {
           content: {
@@ -43523,7 +43523,7 @@ const openapi: OpenAPISpec = {
       },
       put: {
         description:
-          'Adds a specified [access system user](https://docs.seam.co/latest/capability-guides/access-systems/user-management) to a specified [access group](https://docs.seam.co/latest/capability-guides/access-systems/user-management/assigning-users-to-access-groups).',
+          'Adds a specified [access system user](https://docs.seam.co/capability-guides/access-systems/user-management) to a specified [access group](https://docs.seam.co/capability-guides/access-systems/user-management/assigning-users-to-access-groups).',
         operationId: 'acsAccessGroupsAddUserPut',
         requestBody: {
           content: {
@@ -43587,7 +43587,7 @@ const openapi: OpenAPISpec = {
     '/acs/access_groups/delete': {
       delete: {
         description:
-          'Deletes a specified [access group](https://docs.seam.co/latest/capability-guides/access-systems/user-management/assigning-users-to-access-groups).',
+          'Deletes a specified [access group](https://docs.seam.co/capability-guides/access-systems/user-management/assigning-users-to-access-groups).',
         operationId: 'acsAccessGroupsDeleteDelete',
         parameters: [
           {
@@ -43632,7 +43632,7 @@ const openapi: OpenAPISpec = {
       },
       post: {
         description:
-          'Deletes a specified [access group](https://docs.seam.co/latest/capability-guides/access-systems/user-management/assigning-users-to-access-groups).',
+          'Deletes a specified [access group](https://docs.seam.co/capability-guides/access-systems/user-management/assigning-users-to-access-groups).',
         operationId: 'acsAccessGroupsDeletePost',
         requestBody: {
           content: {
@@ -43685,7 +43685,7 @@ const openapi: OpenAPISpec = {
     '/acs/access_groups/get': {
       get: {
         description:
-          'Returns a specified [access group](https://docs.seam.co/latest/capability-guides/access-systems/user-management/assigning-users-to-access-groups).',
+          'Returns a specified [access group](https://docs.seam.co/capability-guides/access-systems/user-management/assigning-users-to-access-groups).',
         operationId: 'acsAccessGroupsGetGet',
         parameters: [
           {
@@ -43735,7 +43735,7 @@ const openapi: OpenAPISpec = {
       },
       post: {
         description:
-          'Returns a specified [access group](https://docs.seam.co/latest/capability-guides/access-systems/user-management/assigning-users-to-access-groups).',
+          'Returns a specified [access group](https://docs.seam.co/capability-guides/access-systems/user-management/assigning-users-to-access-groups).',
         operationId: 'acsAccessGroupsGetPost',
         requestBody: {
           content: {
@@ -43792,7 +43792,7 @@ const openapi: OpenAPISpec = {
     '/acs/access_groups/list': {
       get: {
         description:
-          'Returns a list of all [access groups](https://docs.seam.co/latest/capability-guides/access-systems/user-management/assigning-users-to-access-groups).',
+          'Returns a list of all [access groups](https://docs.seam.co/capability-guides/access-systems/user-management/assigning-users-to-access-groups).',
         operationId: 'acsAccessGroupsListGet',
         parameters: [
           {
@@ -43873,7 +43873,7 @@ const openapi: OpenAPISpec = {
       },
       post: {
         description:
-          'Returns a list of all [access groups](https://docs.seam.co/latest/capability-guides/access-systems/user-management/assigning-users-to-access-groups).',
+          'Returns a list of all [access groups](https://docs.seam.co/capability-guides/access-systems/user-management/assigning-users-to-access-groups).',
         operationId: 'acsAccessGroupsListPost',
         requestBody: {
           content: {
@@ -43949,7 +43949,7 @@ const openapi: OpenAPISpec = {
     '/acs/access_groups/list_accessible_entrances': {
       get: {
         description:
-          'Returns a list of all accessible entrances for a specified [access group](https://docs.seam.co/latest/capability-guides/access-systems/user-management/assigning-users-to-access-groups).',
+          'Returns a list of all accessible entrances for a specified [access group](https://docs.seam.co/capability-guides/access-systems/user-management/assigning-users-to-access-groups).',
         operationId: 'acsAccessGroupsListAccessibleEntrancesGet',
         parameters: [
           {
@@ -44001,7 +44001,7 @@ const openapi: OpenAPISpec = {
       },
       post: {
         description:
-          'Returns a list of all accessible entrances for a specified [access group](https://docs.seam.co/latest/capability-guides/access-systems/user-management/assigning-users-to-access-groups).',
+          'Returns a list of all accessible entrances for a specified [access group](https://docs.seam.co/capability-guides/access-systems/user-management/assigning-users-to-access-groups).',
         operationId: 'acsAccessGroupsListAccessibleEntrancesPost',
         requestBody: {
           content: {
@@ -44060,7 +44060,7 @@ const openapi: OpenAPISpec = {
     '/acs/access_groups/list_users': {
       get: {
         description:
-          'Returns a list of all [access system users](https://docs.seam.co/latest/capability-guides/access-systems/user-management) in an [access group](https://docs.seam.co/latest/capability-guides/access-systems/user-management/assigning-users-to-access-groups).',
+          'Returns a list of all [access system users](https://docs.seam.co/capability-guides/access-systems/user-management) in an [access group](https://docs.seam.co/capability-guides/access-systems/user-management/assigning-users-to-access-groups).',
         operationId: 'acsAccessGroupsListUsersGet',
         parameters: [
           {
@@ -44112,7 +44112,7 @@ const openapi: OpenAPISpec = {
       },
       post: {
         description:
-          'Returns a list of all [access system users](https://docs.seam.co/latest/capability-guides/access-systems/user-management) in an [access group](https://docs.seam.co/latest/capability-guides/access-systems/user-management/assigning-users-to-access-groups).',
+          'Returns a list of all [access system users](https://docs.seam.co/capability-guides/access-systems/user-management) in an [access group](https://docs.seam.co/capability-guides/access-systems/user-management/assigning-users-to-access-groups).',
         operationId: 'acsAccessGroupsListUsersPost',
         requestBody: {
           content: {
@@ -44171,7 +44171,7 @@ const openapi: OpenAPISpec = {
     '/acs/access_groups/remove_user': {
       delete: {
         description:
-          'Removes a specified [access system user](https://docs.seam.co/latest/capability-guides/access-systems/user-management) from a specified [access group](https://docs.seam.co/latest/capability-guides/access-systems/user-management/assigning-users-to-access-groups).',
+          'Removes a specified [access system user](https://docs.seam.co/capability-guides/access-systems/user-management) from a specified [access group](https://docs.seam.co/capability-guides/access-systems/user-management/assigning-users-to-access-groups).',
         operationId: 'acsAccessGroupsRemoveUserDelete',
         parameters: [
           {
@@ -44238,7 +44238,7 @@ const openapi: OpenAPISpec = {
       },
       post: {
         description:
-          'Removes a specified [access system user](https://docs.seam.co/latest/capability-guides/access-systems/user-management) from a specified [access group](https://docs.seam.co/latest/capability-guides/access-systems/user-management/assigning-users-to-access-groups).',
+          'Removes a specified [access system user](https://docs.seam.co/capability-guides/access-systems/user-management) from a specified [access group](https://docs.seam.co/capability-guides/access-systems/user-management/assigning-users-to-access-groups).',
         operationId: 'acsAccessGroupsRemoveUserPost',
         requestBody: {
           content: {
@@ -44302,7 +44302,7 @@ const openapi: OpenAPISpec = {
     '/acs/access_groups/unmanaged/get': {
       get: {
         description:
-          'Returns a specified unmanaged [access group](https://docs.seam.co/latest/capability-guides/access-systems/user-management/assigning-users-to-access-groups).',
+          'Returns a specified unmanaged [access group](https://docs.seam.co/capability-guides/access-systems/user-management/assigning-users-to-access-groups).',
         operationId: 'acsAccessGroupsUnmanagedGetGet',
         parameters: [
           {
@@ -44355,7 +44355,7 @@ const openapi: OpenAPISpec = {
       },
       post: {
         description:
-          'Returns a specified unmanaged [access group](https://docs.seam.co/latest/capability-guides/access-systems/user-management/assigning-users-to-access-groups).',
+          'Returns a specified unmanaged [access group](https://docs.seam.co/capability-guides/access-systems/user-management/assigning-users-to-access-groups).',
         operationId: 'acsAccessGroupsUnmanagedGetPost',
         requestBody: {
           content: {
@@ -44415,7 +44415,7 @@ const openapi: OpenAPISpec = {
     '/acs/access_groups/unmanaged/list': {
       get: {
         description:
-          'Returns a list of all unmanaged [access groups](https://docs.seam.co/latest/capability-guides/access-systems/user-management/assigning-users-to-access-groups).',
+          'Returns a list of all unmanaged [access groups](https://docs.seam.co/capability-guides/access-systems/user-management/assigning-users-to-access-groups).',
         operationId: 'acsAccessGroupsUnmanagedListGet',
         parameters: [
           {
@@ -44490,7 +44490,7 @@ const openapi: OpenAPISpec = {
       },
       post: {
         description:
-          'Returns a list of all unmanaged [access groups](https://docs.seam.co/latest/capability-guides/access-systems/user-management/assigning-users-to-access-groups).',
+          'Returns a list of all unmanaged [access groups](https://docs.seam.co/capability-guides/access-systems/user-management/assigning-users-to-access-groups).',
         operationId: 'acsAccessGroupsUnmanagedListPost',
         requestBody: {
           content: {
@@ -44769,7 +44769,7 @@ const openapi: OpenAPISpec = {
     '/acs/credentials/assign': {
       patch: {
         description:
-          'Assigns a specified [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials) to a specified [access system user](https://docs.seam.co/latest/capability-guides/access-systems/user-management).',
+          'Assigns a specified [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials) to a specified [access system user](https://docs.seam.co/capability-guides/access-systems/user-management).',
         operationId: 'acsCredentialsAssignPatch',
         requestBody: {
           content: {
@@ -44836,7 +44836,7 @@ const openapi: OpenAPISpec = {
       },
       post: {
         description:
-          'Assigns a specified [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials) to a specified [access system user](https://docs.seam.co/latest/capability-guides/access-systems/user-management).',
+          'Assigns a specified [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials) to a specified [access system user](https://docs.seam.co/capability-guides/access-systems/user-management).',
         operationId: 'acsCredentialsAssignPost',
         requestBody: {
           content: {
@@ -44905,7 +44905,7 @@ const openapi: OpenAPISpec = {
     '/acs/credentials/create': {
       post: {
         description:
-          'Creates a new [credential](https://docs.seam.co/latest/low-level-apis/managing-credentials) for a specified [ACS user](https://docs.seam.co/latest/capability-guides/access-systems/user-management). For granting access, we recommend [Access Grants](https://docs.seam.co/latest/use-cases/granting-access) instead: they create and manage the underlying credentials for you, across access systems and standalone smart locks alike. Use this low-level endpoint only when you need direct control over an individual ACS credential.',
+          'Creates a new [credential](https://docs.seam.co/low-level-apis/managing-credentials) for a specified [ACS user](https://docs.seam.co/capability-guides/access-systems/user-management). For granting access, we recommend [Access Grants](https://docs.seam.co/use-cases/granting-access) instead: they create and manage the underlying credentials for you, across access systems and standalone smart locks alike. Use this low-level endpoint only when you need direct control over an individual ACS credential.',
         operationId: 'acsCredentialsCreatePost',
         requestBody: {
           content: {
@@ -44933,7 +44933,7 @@ const openapi: OpenAPISpec = {
                   allowed_acs_entrance_ids: {
                     default: [],
                     description:
-                      'Set of IDs of the [entrances](https://docs.seam.co/latest/capability-guides/access-systems/retrieving-entrance-details) for which the new credential grants access.',
+                      'Set of IDs of the [entrances](https://docs.seam.co/capability-guides/access-systems/retrieving-entrance-details) for which the new credential grants access.',
                     items: { format: 'uuid', type: 'string' },
                     type: 'array',
                   },
@@ -44953,7 +44953,7 @@ const openapi: OpenAPISpec = {
                   },
                   code: {
                     description:
-                      'Access (PIN) code for the new credential. There may be manufacturer-specific code restrictions. For details, see the applicable [device or system integration guide](https://docs.seam.co/latest/device-and-system-integration-guides).',
+                      'Access (PIN) code for the new credential. There may be manufacturer-specific code restrictions. For details, see the applicable [device or system integration guide](https://docs.seam.co/device-and-system-integration-guides).',
                     pattern: '^\\d+$',
                     type: 'string',
                   },
@@ -44980,7 +44980,7 @@ const openapi: OpenAPISpec = {
                   is_multi_phone_sync_credential: {
                     default: false,
                     description:
-                      'Indicates whether the new credential is a [multi-phone sync credential](https://docs.seam.co/latest/capability-guides/mobile-access/issuing-mobile-credentials-from-an-access-control-system#what-are-multi-phone-sync-credentials).',
+                      'Indicates whether the new credential is a [multi-phone sync credential](https://docs.seam.co/capability-guides/mobile-access/issuing-mobile-credentials-from-an-access-control-system#what-are-multi-phone-sync-credentials).',
                     type: 'boolean',
                   },
                   salto_space_metadata: {
@@ -44989,12 +44989,12 @@ const openapi: OpenAPISpec = {
                     properties: {
                       assign_new_key: {
                         description:
-                          'Indicates whether to assign a first, new card to a user. See also [Programming Salto Space Card-based Credentials](https://docs.seam.co/latest/device-and-system-integration-guides/salto-proaccess-space-access-system/programming-salto-space-card-based-credentials).',
+                          'Indicates whether to assign a first, new card to a user. See also [Programming Salto Space Card-based Credentials](https://docs.seam.co/device-and-system-integration-guides/salto-proaccess-space-access-system/programming-salto-space-card-based-credentials).',
                         type: 'boolean',
                       },
                       update_current_key: {
                         description:
-                          "Indicates whether to update the user's existing card. See also [Programming Salto Space Card-based Credentials](https://docs.seam.co/latest/device-and-system-integration-guides/salto-proaccess-space-access-system/programming-salto-space-card-based-credentials).",
+                          "Indicates whether to update the user's existing card. See also [Programming Salto Space Card-based Credentials](https://docs.seam.co/device-and-system-integration-guides/salto-proaccess-space-access-system/programming-salto-space-card-based-credentials).",
                         type: 'boolean',
                         'x-undocumented': 'Not used. Will be deprecated.',
                       },
@@ -45095,7 +45095,7 @@ const openapi: OpenAPISpec = {
     '/acs/credentials/create_offline_code': {
       post: {
         description:
-          'Creates a new offline [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials) for a specified [access system user](https://docs.seam.co/latest/capability-guides/access-systems/user-management).',
+          'Creates a new offline [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials) for a specified [access system user](https://docs.seam.co/capability-guides/access-systems/user-management).',
         operationId: 'acsCredentialsCreateOfflineCodePost',
         requestBody: {
           content: {
@@ -45110,7 +45110,7 @@ const openapi: OpenAPISpec = {
                   },
                   allowed_acs_entrance_id: {
                     description:
-                      'IDs of the [`acs_entrance`s](https://docs.seam.co/latest/capability-guides/access-systems/retrieving-entrance-details) for which the new credential grants access.',
+                      'IDs of the [`acs_entrance`s](https://docs.seam.co/capability-guides/access-systems/retrieving-entrance-details) for which the new credential grants access.',
                     format: 'uuid',
                     type: 'string',
                   },
@@ -45178,7 +45178,7 @@ const openapi: OpenAPISpec = {
     '/acs/credentials/delete': {
       delete: {
         description:
-          'Deletes a specified [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials).',
+          'Deletes a specified [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials).',
         operationId: 'acsCredentialsDeleteDelete',
         parameters: [
           {
@@ -45222,7 +45222,7 @@ const openapi: OpenAPISpec = {
       },
       post: {
         description:
-          'Deletes a specified [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials).',
+          'Deletes a specified [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials).',
         operationId: 'acsCredentialsDeletePost',
         requestBody: {
           content: {
@@ -45274,7 +45274,7 @@ const openapi: OpenAPISpec = {
     '/acs/credentials/get': {
       get: {
         description:
-          'Returns a specified [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials).',
+          'Returns a specified [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials).',
         operationId: 'acsCredentialsGetGet',
         parameters: [
           {
@@ -45324,7 +45324,7 @@ const openapi: OpenAPISpec = {
       },
       post: {
         description:
-          'Returns a specified [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials).',
+          'Returns a specified [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials).',
         operationId: 'acsCredentialsGetPost',
         requestBody: {
           content: {
@@ -45381,7 +45381,7 @@ const openapi: OpenAPISpec = {
     '/acs/credentials/list': {
       get: {
         description:
-          'Returns a list of all [credentials](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials).',
+          'Returns a list of all [credentials](https://docs.seam.co/capability-guides/access-systems/managing-credentials).',
         operationId: 'acsCredentialsListGet',
         responses: {
           200: {
@@ -45422,7 +45422,7 @@ const openapi: OpenAPISpec = {
       },
       post: {
         description:
-          'Returns a list of all [credentials](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials).',
+          'Returns a list of all [credentials](https://docs.seam.co/capability-guides/access-systems/managing-credentials).',
         operationId: 'acsCredentialsListPost',
         requestBody: {
           content: {
@@ -45568,7 +45568,7 @@ const openapi: OpenAPISpec = {
     '/acs/credentials/list_accessible_entrances': {
       get: {
         description:
-          'Returns a list of all [entrances](https://docs.seam.co/latest/api/acs/entrances) to which a [credential](https://docs.seam.co/latest/api/acs/credentials) grants access.',
+          'Returns a list of all [entrances](https://docs.seam.co/api/acs/entrances) to which a [credential](https://docs.seam.co/api/acs/credentials) grants access.',
         operationId: 'acsCredentialsListAccessibleEntrancesGet',
         parameters: [
           {
@@ -45620,7 +45620,7 @@ const openapi: OpenAPISpec = {
       },
       post: {
         description:
-          'Returns a list of all [entrances](https://docs.seam.co/latest/api/acs/entrances) to which a [credential](https://docs.seam.co/latest/api/acs/credentials) grants access.',
+          'Returns a list of all [entrances](https://docs.seam.co/api/acs/entrances) to which a [credential](https://docs.seam.co/api/acs/credentials) grants access.',
         operationId: 'acsCredentialsListAccessibleEntrancesPost',
         requestBody: {
           content: {
@@ -45679,7 +45679,7 @@ const openapi: OpenAPISpec = {
     '/acs/credentials/unassign': {
       patch: {
         description:
-          'Unassigns a specified [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials) from a specified [access system user](https://docs.seam.co/latest/capability-guides/access-systems/user-management).',
+          'Unassigns a specified [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials) from a specified [access system user](https://docs.seam.co/capability-guides/access-systems/user-management).',
         operationId: 'acsCredentialsUnassignPatch',
         requestBody: {
           content: {
@@ -45746,7 +45746,7 @@ const openapi: OpenAPISpec = {
       },
       post: {
         description:
-          'Unassigns a specified [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials) from a specified [access system user](https://docs.seam.co/latest/capability-guides/access-systems/user-management).',
+          'Unassigns a specified [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials) from a specified [access system user](https://docs.seam.co/capability-guides/access-systems/user-management).',
         operationId: 'acsCredentialsUnassignPost',
         requestBody: {
           content: {
@@ -45815,7 +45815,7 @@ const openapi: OpenAPISpec = {
     '/acs/credentials/unmanaged/get': {
       get: {
         description:
-          'Returns a specified unmanaged [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials).',
+          'Returns a specified unmanaged [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials).',
         operationId: 'acsCredentialsUnmanagedGetGet',
         parameters: [
           {
@@ -45867,7 +45867,7 @@ const openapi: OpenAPISpec = {
       },
       post: {
         description:
-          'Returns a specified unmanaged [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials).',
+          'Returns a specified unmanaged [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials).',
         operationId: 'acsCredentialsUnmanagedGetPost',
         requestBody: {
           content: {
@@ -45926,7 +45926,7 @@ const openapi: OpenAPISpec = {
     '/acs/credentials/unmanaged/list': {
       get: {
         description:
-          'Returns a list of all unmanaged [credentials](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials).',
+          'Returns a list of all unmanaged [credentials](https://docs.seam.co/capability-guides/access-systems/managing-credentials).',
         operationId: 'acsCredentialsUnmanagedListGet',
         responses: {
           200: {
@@ -45968,7 +45968,7 @@ const openapi: OpenAPISpec = {
       },
       post: {
         description:
-          'Returns a list of all unmanaged [credentials](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials).',
+          'Returns a list of all unmanaged [credentials](https://docs.seam.co/capability-guides/access-systems/managing-credentials).',
         operationId: 'acsCredentialsUnmanagedListPost',
         requestBody: {
           content: {
@@ -46099,7 +46099,7 @@ const openapi: OpenAPISpec = {
     '/acs/credentials/update': {
       patch: {
         description:
-          'Updates the code and ends at date and time for a specified [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials).',
+          'Updates the code and ends at date and time for a specified [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials).',
         operationId: 'acsCredentialsUpdatePatch',
         requestBody: {
           content: {
@@ -46165,7 +46165,7 @@ const openapi: OpenAPISpec = {
       },
       post: {
         description:
-          'Updates the code and ends at date and time for a specified [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials).',
+          'Updates the code and ends at date and time for a specified [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials).',
         operationId: 'acsCredentialsUpdatePost',
         requestBody: {
           content: {
@@ -46233,7 +46233,7 @@ const openapi: OpenAPISpec = {
     '/acs/encoders/encode_credential': {
       post: {
         description:
-          'Encodes an existing [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials) onto a plastic card placed on the specified [encoder](https://docs.seam.co/latest/capability-guides/access-systems/working-with-card-encoders-and-scanners). Either provide an `acs_credential_id` or an `access_method_id`',
+          'Encodes an existing [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials) onto a plastic card placed on the specified [encoder](https://docs.seam.co/capability-guides/access-systems/working-with-card-encoders-and-scanners). Either provide an `acs_credential_id` or an `access_method_id`',
         operationId: 'acsEncodersEncodeCredentialPost',
         requestBody: {
           content: {
@@ -46305,7 +46305,7 @@ const openapi: OpenAPISpec = {
     '/acs/encoders/get': {
       get: {
         description:
-          'Returns a specified [encoder](https://docs.seam.co/latest/capability-guides/access-systems/working-with-card-encoders-and-scanners).',
+          'Returns a specified [encoder](https://docs.seam.co/capability-guides/access-systems/working-with-card-encoders-and-scanners).',
         operationId: 'acsEncodersGetGet',
         parameters: [
           {
@@ -46353,7 +46353,7 @@ const openapi: OpenAPISpec = {
       },
       post: {
         description:
-          'Returns a specified [encoder](https://docs.seam.co/latest/capability-guides/access-systems/working-with-card-encoders-and-scanners).',
+          'Returns a specified [encoder](https://docs.seam.co/capability-guides/access-systems/working-with-card-encoders-and-scanners).',
         operationId: 'acsEncodersGetPost',
         requestBody: {
           content: {
@@ -46408,7 +46408,7 @@ const openapi: OpenAPISpec = {
     '/acs/encoders/list': {
       get: {
         description:
-          'Returns a list of all [encoders](https://docs.seam.co/latest/capability-guides/access-systems/working-with-card-encoders-and-scanners).',
+          'Returns a list of all [encoders](https://docs.seam.co/capability-guides/access-systems/working-with-card-encoders-and-scanners).',
         operationId: 'acsEncodersListGet',
         responses: {
           200: {
@@ -46449,7 +46449,7 @@ const openapi: OpenAPISpec = {
       },
       post: {
         description:
-          'Returns a list of all [encoders](https://docs.seam.co/latest/capability-guides/access-systems/working-with-card-encoders-and-scanners).',
+          'Returns a list of all [encoders](https://docs.seam.co/capability-guides/access-systems/working-with-card-encoders-and-scanners).',
         operationId: 'acsEncodersListPost',
         requestBody: {
           content: {
@@ -46559,7 +46559,7 @@ const openapi: OpenAPISpec = {
     '/acs/encoders/scan_credential': {
       post: {
         description:
-          'Scans an encoded [acs_credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials) from a plastic card placed on the specified [encoder](https://docs.seam.co/latest/capability-guides/access-systems/working-with-card-encoders-and-scanners).',
+          'Scans an encoded [acs_credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials) from a plastic card placed on the specified [encoder](https://docs.seam.co/capability-guides/access-systems/working-with-card-encoders-and-scanners).',
         operationId: 'acsEncodersScanCredentialPost',
         requestBody: {
           content: {
@@ -46630,7 +46630,7 @@ const openapi: OpenAPISpec = {
     '/acs/encoders/scan_to_assign_credential': {
       post: {
         description:
-          'Scans a physical card placed on the specified [encoder](https://docs.seam.co/latest/capability-guides/access-systems/working-with-card-encoders-and-scanners) and assigns the scanned credential to an ACS user. Provide either an `acs_user_id` or a `user_identity_id`.',
+          'Scans a physical card placed on the specified [encoder](https://docs.seam.co/capability-guides/access-systems/working-with-card-encoders-and-scanners) and assigns the scanned credential to an ACS user. Provide either an `acs_user_id` or a `user_identity_id`.',
         operationId: 'acsEncodersScanToAssignCredentialPost',
         requestBody: {
           content: {
@@ -46715,7 +46715,7 @@ const openapi: OpenAPISpec = {
     '/acs/encoders/simulate/next_credential_encode_will_fail': {
       post: {
         description:
-          'Simulates that the next attempt to encode a [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials) using the specified [encoder](https://docs.seam.co/latest/capability-guides/access-systems/working-with-card-encoders-and-scanners) will fail. You can only perform this action within a [sandbox workspace](https://docs.seam.co/latest/core-concepts/workspaces#sandbox-workspaces).',
+          'Simulates that the next attempt to encode a [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials) using the specified [encoder](https://docs.seam.co/capability-guides/access-systems/working-with-card-encoders-and-scanners) will fail. You can only perform this action within a [sandbox workspace](https://docs.seam.co/core-concepts/workspaces#sandbox-workspaces).',
         operationId: 'acsEncodersSimulateNextCredentialEncodeWillFailPost',
         requestBody: {
           content: {
@@ -46805,7 +46805,7 @@ const openapi: OpenAPISpec = {
     '/acs/encoders/simulate/next_credential_encode_will_succeed': {
       post: {
         description:
-          'Simulates that the next attempt to encode a [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials) using the specified [encoder](https://docs.seam.co/latest/capability-guides/access-systems/working-with-card-encoders-and-scanners) will succeed. You can only perform this action within a [sandbox workspace](https://docs.seam.co/latest/core-concepts/workspaces#sandbox-workspaces).',
+          'Simulates that the next attempt to encode a [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials) using the specified [encoder](https://docs.seam.co/capability-guides/access-systems/working-with-card-encoders-and-scanners) will succeed. You can only perform this action within a [sandbox workspace](https://docs.seam.co/core-concepts/workspaces#sandbox-workspaces).',
         operationId: 'acsEncodersSimulateNextCredentialEncodeWillSucceedPost',
         requestBody: {
           content: {
@@ -46865,7 +46865,7 @@ const openapi: OpenAPISpec = {
     '/acs/encoders/simulate/next_credential_scan_will_fail': {
       post: {
         description:
-          'Simulates that the next attempt to scan a [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials) using the specified [encoder](https://docs.seam.co/latest/capability-guides/access-systems/working-with-card-encoders-and-scanners) will fail. You can only perform this action within a [sandbox workspace](https://docs.seam.co/latest/core-concepts/workspaces#sandbox-workspaces).',
+          'Simulates that the next attempt to scan a [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials) using the specified [encoder](https://docs.seam.co/capability-guides/access-systems/working-with-card-encoders-and-scanners) will fail. You can only perform this action within a [sandbox workspace](https://docs.seam.co/core-concepts/workspaces#sandbox-workspaces).',
         operationId: 'acsEncodersSimulateNextCredentialScanWillFailPost',
         requestBody: {
           content: {
@@ -46948,7 +46948,7 @@ const openapi: OpenAPISpec = {
     '/acs/encoders/simulate/next_credential_scan_will_succeed': {
       post: {
         description:
-          'Simulates that the next attempt to scan a [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials) using the specified [encoder](https://docs.seam.co/latest/capability-guides/access-systems/working-with-card-encoders-and-scanners) will succeed. You can only perform this action within a [sandbox workspace](https://docs.seam.co/latest/core-concepts/workspaces#sandbox-workspaces).',
+          'Simulates that the next attempt to scan a [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials) using the specified [encoder](https://docs.seam.co/capability-guides/access-systems/working-with-card-encoders-and-scanners) will succeed. You can only perform this action within a [sandbox workspace](https://docs.seam.co/core-concepts/workspaces#sandbox-workspaces).',
         operationId: 'acsEncodersSimulateNextCredentialScanWillSucceedPost',
         requestBody: {
           content: {
@@ -47056,7 +47056,7 @@ const openapi: OpenAPISpec = {
     '/acs/entrances/get': {
       get: {
         description:
-          'Returns a specified [access system entrance](https://docs.seam.co/latest/capability-guides/access-systems/retrieving-entrance-details).',
+          'Returns a specified [access system entrance](https://docs.seam.co/capability-guides/access-systems/retrieving-entrance-details).',
         operationId: 'acsEntrancesGetGet',
         parameters: [
           {
@@ -47106,7 +47106,7 @@ const openapi: OpenAPISpec = {
       },
       post: {
         description:
-          'Returns a specified [access system entrance](https://docs.seam.co/latest/capability-guides/access-systems/retrieving-entrance-details).',
+          'Returns a specified [access system entrance](https://docs.seam.co/capability-guides/access-systems/retrieving-entrance-details).',
         operationId: 'acsEntrancesGetPost',
         requestBody: {
           content: {
@@ -47163,7 +47163,7 @@ const openapi: OpenAPISpec = {
     '/acs/entrances/grant_access': {
       post: {
         description:
-          'Grants a specified [access system user](https://docs.seam.co/latest/capability-guides/access-systems/user-management) access to a specified [access system entrance](https://docs.seam.co/latest/capability-guides/access-systems/retrieving-entrance-details).',
+          'Grants a specified [access system user](https://docs.seam.co/capability-guides/access-systems/user-management) access to a specified [access system entrance](https://docs.seam.co/capability-guides/access-systems/retrieving-entrance-details).',
         operationId: 'acsEntrancesGrantAccessPost',
         requestBody: {
           content: {
@@ -47227,7 +47227,7 @@ const openapi: OpenAPISpec = {
     '/acs/entrances/list': {
       get: {
         description:
-          'Returns a list of all [access system entrances](https://docs.seam.co/latest/capability-guides/access-systems/retrieving-entrance-details).',
+          'Returns a list of all [access system entrances](https://docs.seam.co/capability-guides/access-systems/retrieving-entrance-details).',
         operationId: 'acsEntrancesListGet',
         parameters: [
           {
@@ -47371,7 +47371,7 @@ const openapi: OpenAPISpec = {
       },
       post: {
         description:
-          'Returns a list of all [access system entrances](https://docs.seam.co/latest/capability-guides/access-systems/retrieving-entrance-details).',
+          'Returns a list of all [access system entrances](https://docs.seam.co/capability-guides/access-systems/retrieving-entrance-details).',
         operationId: 'acsEntrancesListPost',
         requestBody: {
           content: {
@@ -47488,7 +47488,7 @@ const openapi: OpenAPISpec = {
     '/acs/entrances/list_credentials_with_access': {
       get: {
         description:
-          'Returns a list of all [credentials](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials) with access to a specified [entrance](https://docs.seam.co/latest/capability-guides/access-systems/retrieving-entrance-details).',
+          'Returns a list of all [credentials](https://docs.seam.co/capability-guides/access-systems/managing-credentials) with access to a specified [entrance](https://docs.seam.co/capability-guides/access-systems/retrieving-entrance-details).',
         operationId: 'acsEntrancesListCredentialsWithAccessGet',
         parameters: [
           {
@@ -47552,7 +47552,7 @@ const openapi: OpenAPISpec = {
       },
       post: {
         description:
-          'Returns a list of all [credentials](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials) with access to a specified [entrance](https://docs.seam.co/latest/capability-guides/access-systems/retrieving-entrance-details).',
+          'Returns a list of all [credentials](https://docs.seam.co/capability-guides/access-systems/managing-credentials) with access to a specified [entrance](https://docs.seam.co/capability-guides/access-systems/retrieving-entrance-details).',
         operationId: 'acsEntrancesListCredentialsWithAccessPost',
         requestBody: {
           content: {
@@ -47621,7 +47621,7 @@ const openapi: OpenAPISpec = {
     '/acs/entrances/unlock': {
       post: {
         description:
-          'Remotely unlocks a specified [entrance](https://docs.seam.co/latest/capability-guides/access-systems/retrieving-entrance-details) using a cloud_key credential. Returns an action attempt that tracks the progress of the unlock operation.',
+          'Remotely unlocks a specified [entrance](https://docs.seam.co/capability-guides/access-systems/retrieving-entrance-details) using a cloud_key credential. Returns an action attempt that tracks the progress of the unlock operation.',
         operationId: 'acsEntrancesUnlockPost',
         requestBody: {
           content: {
@@ -47685,7 +47685,7 @@ const openapi: OpenAPISpec = {
     '/acs/systems/get': {
       get: {
         description:
-          'Returns a specified [access system](https://docs.seam.co/latest/capability-guides/access-systems).',
+          'Returns a specified [access system](https://docs.seam.co/capability-guides/access-systems).',
         operationId: 'acsSystemsGetGet',
         parameters: [
           {
@@ -47733,7 +47733,7 @@ const openapi: OpenAPISpec = {
       },
       post: {
         description:
-          'Returns a specified [access system](https://docs.seam.co/latest/capability-guides/access-systems).',
+          'Returns a specified [access system](https://docs.seam.co/capability-guides/access-systems).',
         operationId: 'acsSystemsGetPost',
         requestBody: {
           content: {
@@ -47789,7 +47789,7 @@ const openapi: OpenAPISpec = {
     '/acs/systems/list': {
       get: {
         description:
-          'Returns a list of all [access systems](https://docs.seam.co/latest/capability-guides/access-systems).\n\nTo filter the list of returned access systems by a specific connected account ID, include the `connected_account_id` in the request body. If you omit the `connected_account_id` parameter, the response includes all access systems connected to your workspace.',
+          'Returns a list of all [access systems](https://docs.seam.co/capability-guides/access-systems).\n\nTo filter the list of returned access systems by a specific connected account ID, include the `connected_account_id` in the request body. If you omit the `connected_account_id` parameter, the response includes all access systems connected to your workspace.',
         operationId: 'acsSystemsListGet',
         parameters: [
           {
@@ -47861,7 +47861,7 @@ const openapi: OpenAPISpec = {
       },
       post: {
         description:
-          'Returns a list of all [access systems](https://docs.seam.co/latest/capability-guides/access-systems).\n\nTo filter the list of returned access systems by a specific connected account ID, include the `connected_account_id` in the request body. If you omit the `connected_account_id` parameter, the response includes all access systems connected to your workspace.',
+          'Returns a list of all [access systems](https://docs.seam.co/capability-guides/access-systems).\n\nTo filter the list of returned access systems by a specific connected account ID, include the `connected_account_id` in the request body. If you omit the `connected_account_id` parameter, the response includes all access systems connected to your workspace.',
         operationId: 'acsSystemsListPost',
         requestBody: {
           content: {
@@ -47932,7 +47932,7 @@ const openapi: OpenAPISpec = {
     '/acs/systems/list_compatible_credential_manager_acs_systems': {
       get: {
         description:
-          'Returns a list of all credential manager systems that are compatible with a specified [access system](https://docs.seam.co/latest/capability-guides/access-systems).\n\nSpecify the access system for which you want to retrieve all compatible credential manager systems by including the corresponding `acs_system_id` in the request body.',
+          'Returns a list of all credential manager systems that are compatible with a specified [access system](https://docs.seam.co/capability-guides/access-systems).\n\nSpecify the access system for which you want to retrieve all compatible credential manager systems by including the corresponding `acs_system_id` in the request body.',
         operationId: 'acsSystemsListCompatibleCredentialManagerAcsSystemsGet',
         parameters: [
           {
@@ -47985,7 +47985,7 @@ const openapi: OpenAPISpec = {
       },
       post: {
         description:
-          'Returns a list of all credential manager systems that are compatible with a specified [access system](https://docs.seam.co/latest/capability-guides/access-systems).\n\nSpecify the access system for which you want to retrieve all compatible credential manager systems by including the corresponding `acs_system_id` in the request body.',
+          'Returns a list of all credential manager systems that are compatible with a specified [access system](https://docs.seam.co/capability-guides/access-systems).\n\nSpecify the access system for which you want to retrieve all compatible credential manager systems by including the corresponding `acs_system_id` in the request body.',
         operationId: 'acsSystemsListCompatibleCredentialManagerAcsSystemsPost',
         requestBody: {
           content: {
@@ -48160,7 +48160,7 @@ const openapi: OpenAPISpec = {
     '/acs/users/add_to_access_group': {
       post: {
         description:
-          'Adds a specified [access system user](https://docs.seam.co/latest/capability-guides/access-systems/user-management) to a specified [access group](https://docs.seam.co/latest/capability-guides/access-systems/user-management/assigning-users-to-access-groups).',
+          'Adds a specified [access system user](https://docs.seam.co/capability-guides/access-systems/user-management) to a specified [access group](https://docs.seam.co/capability-guides/access-systems/user-management/assigning-users-to-access-groups).',
         operationId: 'acsUsersAddToAccessGroupPost',
         requestBody: {
           content: {
@@ -48216,7 +48216,7 @@ const openapi: OpenAPISpec = {
       },
       put: {
         description:
-          'Adds a specified [access system user](https://docs.seam.co/latest/capability-guides/access-systems/user-management) to a specified [access group](https://docs.seam.co/latest/capability-guides/access-systems/user-management/assigning-users-to-access-groups).',
+          'Adds a specified [access system user](https://docs.seam.co/capability-guides/access-systems/user-management) to a specified [access group](https://docs.seam.co/capability-guides/access-systems/user-management/assigning-users-to-access-groups).',
         operationId: 'acsUsersAddToAccessGroupPut',
         requestBody: {
           content: {
@@ -48274,7 +48274,7 @@ const openapi: OpenAPISpec = {
     '/acs/users/create': {
       post: {
         description:
-          'Creates a new [access system user](https://docs.seam.co/latest/capability-guides/access-systems/user-management).',
+          'Creates a new [access system user](https://docs.seam.co/capability-guides/access-systems/user-management).',
         operationId: 'acsUsersCreatePost',
         requestBody: {
           content: {
@@ -48322,7 +48322,7 @@ const openapi: OpenAPISpec = {
                   },
                   email_address: {
                     description:
-                      'Email address of the [access system user](https://docs.seam.co/latest/capability-guides/access-systems/user-management).',
+                      'Email address of the [access system user](https://docs.seam.co/capability-guides/access-systems/user-management).',
                     format: 'email',
                     type: 'string',
                   },
@@ -48332,7 +48332,7 @@ const openapi: OpenAPISpec = {
                   },
                   phone_number: {
                     description:
-                      'Phone number of the [access system user](https://docs.seam.co/latest/capability-guides/access-systems/user-management) in E.164 format (for example, `+15555550100`).',
+                      'Phone number of the [access system user](https://docs.seam.co/capability-guides/access-systems/user-management) in E.164 format (for example, `+15555550100`).',
                     type: 'string',
                   },
                   user_identity_id: {
@@ -48384,7 +48384,7 @@ const openapi: OpenAPISpec = {
     '/acs/users/delete': {
       delete: {
         description:
-          "Deletes a specified [access system user](https://docs.seam.co/latest/capability-guides/access-systems/user-management) and invalidates the access system user's [credentials](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials).",
+          "Deletes a specified [access system user](https://docs.seam.co/capability-guides/access-systems/user-management) and invalidates the access system user's [credentials](https://docs.seam.co/capability-guides/access-systems/managing-credentials).",
         operationId: 'acsUsersDeleteDelete',
         parameters: [
           {
@@ -48448,7 +48448,7 @@ const openapi: OpenAPISpec = {
       },
       post: {
         description:
-          "Deletes a specified [access system user](https://docs.seam.co/latest/capability-guides/access-systems/user-management) and invalidates the access system user's [credentials](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials).",
+          "Deletes a specified [access system user](https://docs.seam.co/capability-guides/access-systems/user-management) and invalidates the access system user's [credentials](https://docs.seam.co/capability-guides/access-systems/managing-credentials).",
         operationId: 'acsUsersDeletePost',
         requestBody: {
           content: {
@@ -48511,7 +48511,7 @@ const openapi: OpenAPISpec = {
     '/acs/users/get': {
       get: {
         description:
-          'Returns a specified [access system user](https://docs.seam.co/latest/capability-guides/access-systems/user-management).',
+          'Returns a specified [access system user](https://docs.seam.co/capability-guides/access-systems/user-management).',
         operationId: 'acsUsersGetGet',
         parameters: [
           {
@@ -48579,7 +48579,7 @@ const openapi: OpenAPISpec = {
       },
       post: {
         description:
-          'Returns a specified [access system user](https://docs.seam.co/latest/capability-guides/access-systems/user-management).',
+          'Returns a specified [access system user](https://docs.seam.co/capability-guides/access-systems/user-management).',
         operationId: 'acsUsersGetPost',
         requestBody: {
           content: {
@@ -48646,7 +48646,7 @@ const openapi: OpenAPISpec = {
     '/acs/users/list': {
       get: {
         description:
-          'Returns a list of all [access system users](https://docs.seam.co/latest/capability-guides/access-systems/user-management).',
+          'Returns a list of all [access system users](https://docs.seam.co/capability-guides/access-systems/user-management).',
         operationId: 'acsUsersListGet',
         parameters: [
           {
@@ -48768,7 +48768,7 @@ const openapi: OpenAPISpec = {
       },
       post: {
         description:
-          'Returns a list of all [access system users](https://docs.seam.co/latest/capability-guides/access-systems/user-management).',
+          'Returns a list of all [access system users](https://docs.seam.co/capability-guides/access-systems/user-management).',
         operationId: 'acsUsersListPost',
         requestBody: {
           content: {
@@ -48870,7 +48870,7 @@ const openapi: OpenAPISpec = {
     '/acs/users/list_accessible_entrances': {
       get: {
         description:
-          'Lists the [entrances](https://docs.seam.co/latest/api/acs/entrances) to which a specified [access system user](https://docs.seam.co/latest/capability-guides/access-systems/user-management) has access.',
+          'Lists the [entrances](https://docs.seam.co/api/acs/entrances) to which a specified [access system user](https://docs.seam.co/capability-guides/access-systems/user-management) has access.',
         operationId: 'acsUsersListAccessibleEntrancesGet',
         parameters: [
           {
@@ -48942,7 +48942,7 @@ const openapi: OpenAPISpec = {
       },
       post: {
         description:
-          'Lists the [entrances](https://docs.seam.co/latest/api/acs/entrances) to which a specified [access system user](https://docs.seam.co/latest/capability-guides/access-systems/user-management) has access.',
+          'Lists the [entrances](https://docs.seam.co/api/acs/entrances) to which a specified [access system user](https://docs.seam.co/capability-guides/access-systems/user-management) has access.',
         operationId: 'acsUsersListAccessibleEntrancesPost',
         requestBody: {
           content: {
@@ -49013,7 +49013,7 @@ const openapi: OpenAPISpec = {
     '/acs/users/remove_from_access_group': {
       delete: {
         description:
-          'Removes a specified [access system user](https://docs.seam.co/latest/capability-guides/access-systems/user-management) from a specified [access group](https://docs.seam.co/latest/capability-guides/access-systems/user-management/assigning-users-to-access-groups).',
+          'Removes a specified [access system user](https://docs.seam.co/capability-guides/access-systems/user-management) from a specified [access group](https://docs.seam.co/capability-guides/access-systems/user-management/assigning-users-to-access-groups).',
         operationId: 'acsUsersRemoveFromAccessGroupDelete',
         parameters: [
           {
@@ -49080,7 +49080,7 @@ const openapi: OpenAPISpec = {
       },
       post: {
         description:
-          'Removes a specified [access system user](https://docs.seam.co/latest/capability-guides/access-systems/user-management) from a specified [access group](https://docs.seam.co/latest/capability-guides/access-systems/user-management/assigning-users-to-access-groups).',
+          'Removes a specified [access system user](https://docs.seam.co/capability-guides/access-systems/user-management) from a specified [access group](https://docs.seam.co/capability-guides/access-systems/user-management/assigning-users-to-access-groups).',
         operationId: 'acsUsersRemoveFromAccessGroupPost',
         requestBody: {
           content: {
@@ -49144,7 +49144,7 @@ const openapi: OpenAPISpec = {
     '/acs/users/revoke_access_to_all_entrances': {
       post: {
         description:
-          'Revokes access to all [entrances](https://docs.seam.co/latest/api/acs/entrances) for a specified [access system user](https://docs.seam.co/latest/capability-guides/access-systems/user-management).',
+          'Revokes access to all [entrances](https://docs.seam.co/api/acs/entrances) for a specified [access system user](https://docs.seam.co/capability-guides/access-systems/user-management).',
         operationId: 'acsUsersRevokeAccessToAllEntrancesPost',
         requestBody: {
           content: {
@@ -49207,7 +49207,7 @@ const openapi: OpenAPISpec = {
     '/acs/users/suspend': {
       post: {
         description:
-          "[Suspends](https://docs.seam.co/latest/capability-guides/access-systems/user-management/suspending-and-unsuspending-users#suspend-an-acs-user) a specified [access system user](https://docs.seam.co/latest/capability-guides/access-systems/user-management). Suspending an access system user revokes their access temporarily. To restore an access system user's access, you can [unsuspend](https://docs.seam.co/latest/api/acs/users/unsuspend) them.",
+          "[Suspends](https://docs.seam.co/capability-guides/access-systems/user-management/suspending-and-unsuspending-users#suspend-an-acs-user) a specified [access system user](https://docs.seam.co/capability-guides/access-systems/user-management). Suspending an access system user revokes their access temporarily. To restore an access system user's access, you can [unsuspend](https://docs.seam.co/api/acs/users/unsuspend) them.",
         operationId: 'acsUsersSuspendPost',
         requestBody: {
           content: {
@@ -49270,7 +49270,7 @@ const openapi: OpenAPISpec = {
     '/acs/users/unmanaged/get': {
       get: {
         description:
-          'Returns a specified unmanaged [access system user](https://docs.seam.co/latest/capability-guides/access-systems/user-management).',
+          'Returns a specified unmanaged [access system user](https://docs.seam.co/capability-guides/access-systems/user-management).',
         operationId: 'acsUsersUnmanagedGetGet',
         parameters: [
           {
@@ -49322,7 +49322,7 @@ const openapi: OpenAPISpec = {
       },
       post: {
         description:
-          'Returns a specified unmanaged [access system user](https://docs.seam.co/latest/capability-guides/access-systems/user-management).',
+          'Returns a specified unmanaged [access system user](https://docs.seam.co/capability-guides/access-systems/user-management).',
         operationId: 'acsUsersUnmanagedGetPost',
         requestBody: {
           content: {
@@ -49381,7 +49381,7 @@ const openapi: OpenAPISpec = {
     '/acs/users/unmanaged/list': {
       get: {
         description:
-          'Returns a list of all unmanaged [access system users](https://docs.seam.co/latest/capability-guides/access-systems/user-management).',
+          'Returns a list of all unmanaged [access system users](https://docs.seam.co/capability-guides/access-systems/user-management).',
         operationId: 'acsUsersUnmanagedListGet',
         parameters: [
           {
@@ -49483,7 +49483,7 @@ const openapi: OpenAPISpec = {
       },
       post: {
         description:
-          'Returns a list of all unmanaged [access system users](https://docs.seam.co/latest/capability-guides/access-systems/user-management).',
+          'Returns a list of all unmanaged [access system users](https://docs.seam.co/capability-guides/access-systems/user-management).',
         operationId: 'acsUsersUnmanagedListPost',
         requestBody: {
           content: {
@@ -49573,7 +49573,7 @@ const openapi: OpenAPISpec = {
     '/acs/users/unsuspend': {
       post: {
         description:
-          '[Unsuspends](https://docs.seam.co/latest/capability-guides/access-systems/user-management/suspending-and-unsuspending-users#unsuspend-an-acs-user) a specified suspended [access system user](https://docs.seam.co/latest/capability-guides/access-systems/user-management). While [suspending an access system user](https://docs.seam.co/latest/api/acs/users/suspend) revokes their access temporarily, unsuspending the access system user restores their access.',
+          '[Unsuspends](https://docs.seam.co/capability-guides/access-systems/user-management/suspending-and-unsuspending-users#unsuspend-an-acs-user) a specified suspended [access system user](https://docs.seam.co/capability-guides/access-systems/user-management). While [suspending an access system user](https://docs.seam.co/api/acs/users/suspend) revokes their access temporarily, unsuspending the access system user restores their access.',
         operationId: 'acsUsersUnsuspendPost',
         requestBody: {
           content: {
@@ -49636,7 +49636,7 @@ const openapi: OpenAPISpec = {
     '/acs/users/update': {
       patch: {
         description:
-          'Updates the properties of a specified [access system user](https://docs.seam.co/latest/capability-guides/access-systems/user-management).',
+          'Updates the properties of a specified [access system user](https://docs.seam.co/capability-guides/access-systems/user-management).',
         operationId: 'acsUsersUpdatePatch',
         requestBody: {
           content: {
@@ -49684,20 +49684,20 @@ const openapi: OpenAPISpec = {
                   },
                   email_address: {
                     description:
-                      'Email address of the [access system user](https://docs.seam.co/latest/capability-guides/access-systems/user-management).',
+                      'Email address of the [access system user](https://docs.seam.co/capability-guides/access-systems/user-management).',
                     format: 'email',
                     type: 'string',
                   },
                   full_name: {
                     description:
-                      'Full name of the [access system user](https://docs.seam.co/latest/capability-guides/access-systems/user-management).',
+                      'Full name of the [access system user](https://docs.seam.co/capability-guides/access-systems/user-management).',
                     minLength: 1,
                     type: 'string',
                   },
                   hid_acs_system_id: { format: 'uuid', type: 'string' },
                   phone_number: {
                     description:
-                      'Phone number of the [access system user](https://docs.seam.co/latest/capability-guides/access-systems/user-management) in E.164 format (for example, `+15555550100`).',
+                      'Phone number of the [access system user](https://docs.seam.co/capability-guides/access-systems/user-management) in E.164 format (for example, `+15555550100`).',
                     type: 'string',
                   },
                   user_identity_id: {
@@ -49742,7 +49742,7 @@ const openapi: OpenAPISpec = {
       },
       post: {
         description:
-          'Updates the properties of a specified [access system user](https://docs.seam.co/latest/capability-guides/access-systems/user-management).',
+          'Updates the properties of a specified [access system user](https://docs.seam.co/capability-guides/access-systems/user-management).',
         operationId: 'acsUsersUpdatePost',
         requestBody: {
           content: {
@@ -49790,20 +49790,20 @@ const openapi: OpenAPISpec = {
                   },
                   email_address: {
                     description:
-                      'Email address of the [access system user](https://docs.seam.co/latest/capability-guides/access-systems/user-management).',
+                      'Email address of the [access system user](https://docs.seam.co/capability-guides/access-systems/user-management).',
                     format: 'email',
                     type: 'string',
                   },
                   full_name: {
                     description:
-                      'Full name of the [access system user](https://docs.seam.co/latest/capability-guides/access-systems/user-management).',
+                      'Full name of the [access system user](https://docs.seam.co/capability-guides/access-systems/user-management).',
                     minLength: 1,
                     type: 'string',
                   },
                   hid_acs_system_id: { format: 'uuid', type: 'string' },
                   phone_number: {
                     description:
-                      'Phone number of the [access system user](https://docs.seam.co/latest/capability-guides/access-systems/user-management) in E.164 format (for example, `+15555550100`).',
+                      'Phone number of the [access system user](https://docs.seam.co/capability-guides/access-systems/user-management) in E.164 format (for example, `+15555550100`).',
                     type: 'string',
                   },
                   user_identity_id: {
@@ -49850,7 +49850,7 @@ const openapi: OpenAPISpec = {
     '/action_attempts/get': {
       get: {
         description:
-          'Returns a specified [action attempt](https://docs.seam.co/latest/core-concepts/action-attempts).',
+          'Returns a specified [action attempt](https://docs.seam.co/core-concepts/action-attempts).',
         operationId: 'actionAttemptsGetGet',
         parameters: [
           {
@@ -49902,7 +49902,7 @@ const openapi: OpenAPISpec = {
       },
       post: {
         description:
-          'Returns a specified [action attempt](https://docs.seam.co/latest/core-concepts/action-attempts).',
+          'Returns a specified [action attempt](https://docs.seam.co/core-concepts/action-attempts).',
         operationId: 'actionAttemptsGetPost',
         requestBody: {
           content: {
@@ -49962,7 +49962,7 @@ const openapi: OpenAPISpec = {
     '/action_attempts/list': {
       get: {
         description:
-          'Returns a list of the [action attempts](https://docs.seam.co/latest/core-concepts/action-attempts) that you specify as an array of `action_attempt_id`s.',
+          'Returns a list of the [action attempts](https://docs.seam.co/core-concepts/action-attempts) that you specify as an array of `action_attempt_id`s.',
         operationId: 'actionAttemptsListGet',
         parameters: [
           {
@@ -50044,7 +50044,7 @@ const openapi: OpenAPISpec = {
       },
       post: {
         description:
-          'Returns a list of the [action attempts](https://docs.seam.co/latest/core-concepts/action-attempts) that you specify as an array of `action_attempt_id`s.',
+          'Returns a list of the [action attempts](https://docs.seam.co/core-concepts/action-attempts) that you specify as an array of `action_attempt_id`s.',
         operationId: 'actionAttemptsListPost',
         requestBody: {
           content: {
@@ -50123,7 +50123,7 @@ const openapi: OpenAPISpec = {
     '/bridges/get': {
       get: {
         description:
-          'Returns a specified [Seam Bridge](https://docs.seam.co/latest/capability-guides/seam-bridge).',
+          'Returns a specified [Seam Bridge](https://docs.seam.co/capability-guides/seam-bridge).',
         operationId: 'bridgesGetGet',
         parameters: [
           {
@@ -50145,7 +50145,7 @@ const openapi: OpenAPISpec = {
                   properties: {
                     bridge: {
                       description:
-                        'Represents [Seam Bridge](https://docs.seam.co/latest/capability-guides/seam-bridge).',
+                        'Represents [Seam Bridge](https://docs.seam.co/capability-guides/seam-bridge).',
                       properties: {
                         bridge_id: {
                           description: 'ID of Seam Bridge.',
@@ -50160,7 +50160,7 @@ const openapi: OpenAPISpec = {
                         },
                         workspace_id: {
                           description:
-                            'ID of the [workspace](https://docs.seam.co/latest/core-concepts/workspaces) that contains Seam Bridge.',
+                            'ID of the [workspace](https://docs.seam.co/core-concepts/workspaces) that contains Seam Bridge.',
                           format: 'uuid',
                           type: 'string',
                         },
@@ -50198,7 +50198,7 @@ const openapi: OpenAPISpec = {
       },
       post: {
         description:
-          'Returns a specified [Seam Bridge](https://docs.seam.co/latest/capability-guides/seam-bridge).',
+          'Returns a specified [Seam Bridge](https://docs.seam.co/capability-guides/seam-bridge).',
         operationId: 'bridgesGetPost',
         requestBody: {
           content: {
@@ -50225,7 +50225,7 @@ const openapi: OpenAPISpec = {
                   properties: {
                     bridge: {
                       description:
-                        'Represents [Seam Bridge](https://docs.seam.co/latest/capability-guides/seam-bridge).',
+                        'Represents [Seam Bridge](https://docs.seam.co/capability-guides/seam-bridge).',
                       properties: {
                         bridge_id: {
                           description: 'ID of Seam Bridge.',
@@ -50240,7 +50240,7 @@ const openapi: OpenAPISpec = {
                         },
                         workspace_id: {
                           description:
-                            'ID of the [workspace](https://docs.seam.co/latest/core-concepts/workspaces) that contains Seam Bridge.',
+                            'ID of the [workspace](https://docs.seam.co/core-concepts/workspaces) that contains Seam Bridge.',
                           format: 'uuid',
                           type: 'string',
                         },
@@ -50280,7 +50280,7 @@ const openapi: OpenAPISpec = {
     '/bridges/list': {
       get: {
         description:
-          'Returns a list of all [Seam Bridges](https://docs.seam.co/latest/capability-guides/seam-bridge).',
+          'Returns a list of all [Seam Bridges](https://docs.seam.co/capability-guides/seam-bridge).',
         operationId: 'bridgesListGet',
         parameters: [],
         responses: {
@@ -50292,7 +50292,7 @@ const openapi: OpenAPISpec = {
                     bridges: {
                       items: {
                         description:
-                          'Represents [Seam Bridge](https://docs.seam.co/latest/capability-guides/seam-bridge).',
+                          'Represents [Seam Bridge](https://docs.seam.co/capability-guides/seam-bridge).',
                         properties: {
                           bridge_id: {
                             description: 'ID of Seam Bridge.',
@@ -50307,7 +50307,7 @@ const openapi: OpenAPISpec = {
                           },
                           workspace_id: {
                             description:
-                              'ID of the [workspace](https://docs.seam.co/latest/core-concepts/workspaces) that contains Seam Bridge.',
+                              'ID of the [workspace](https://docs.seam.co/core-concepts/workspaces) that contains Seam Bridge.',
                             format: 'uuid',
                             type: 'string',
                           },
@@ -50347,7 +50347,7 @@ const openapi: OpenAPISpec = {
       },
       post: {
         description:
-          'Returns a list of all [Seam Bridges](https://docs.seam.co/latest/capability-guides/seam-bridge).',
+          'Returns a list of all [Seam Bridges](https://docs.seam.co/capability-guides/seam-bridge).',
         operationId: 'bridgesListPost',
         requestBody: {
           content: {
@@ -50363,7 +50363,7 @@ const openapi: OpenAPISpec = {
                     bridges: {
                       items: {
                         description:
-                          'Represents [Seam Bridge](https://docs.seam.co/latest/capability-guides/seam-bridge).',
+                          'Represents [Seam Bridge](https://docs.seam.co/capability-guides/seam-bridge).',
                         properties: {
                           bridge_id: {
                             description: 'ID of Seam Bridge.',
@@ -50378,7 +50378,7 @@ const openapi: OpenAPISpec = {
                           },
                           workspace_id: {
                             description:
-                              'ID of the [workspace](https://docs.seam.co/latest/core-concepts/workspaces) that contains Seam Bridge.',
+                              'ID of the [workspace](https://docs.seam.co/core-concepts/workspaces) that contains Seam Bridge.',
                             format: 'uuid',
                             type: 'string',
                           },
@@ -50420,7 +50420,7 @@ const openapi: OpenAPISpec = {
     '/client_sessions/create': {
       post: {
         description:
-          'Creates a new [client session](https://docs.seam.co/latest/core-concepts/authentication/client-session-tokens).',
+          'Creates a new [client session](https://docs.seam.co/core-concepts/authentication/client-session-tokens).',
         operationId: 'clientSessionsCreatePost',
         requestBody: {
           content: {
@@ -50429,13 +50429,13 @@ const openapi: OpenAPISpec = {
                 properties: {
                   connect_webview_ids: {
                     description:
-                      'IDs of the [Connect Webviews](https://docs.seam.co/latest/core-concepts/connect-webviews) for which you want to create a client session.',
+                      'IDs of the [Connect Webviews](https://docs.seam.co/core-concepts/connect-webviews) for which you want to create a client session.',
                     items: { type: 'string' },
                     type: 'array',
                   },
                   connected_account_ids: {
                     description:
-                      'IDs of the [connected accounts](https://docs.seam.co/latest/core-concepts/connected-accounts) for which you want to create a client session.',
+                      'IDs of the [connected accounts](https://docs.seam.co/core-concepts/connected-accounts) for which you want to create a client session.',
                     items: { type: 'string' },
                     type: 'array',
                   },
@@ -50464,14 +50464,14 @@ const openapi: OpenAPISpec = {
                   },
                   user_identity_id: {
                     description:
-                      'ID of the [user identity](https://docs.seam.co/latest/capability-guides/mobile-access/managing-mobile-app-user-accounts-with-user-identities#what-is-a-user-identity) for which you want to create a client session.',
+                      'ID of the [user identity](https://docs.seam.co/capability-guides/mobile-access/managing-mobile-app-user-accounts-with-user-identities#what-is-a-user-identity) for which you want to create a client session.',
                     format: 'uuid',
                     type: 'string',
                   },
                   user_identity_ids: {
                     deprecated: true,
                     description:
-                      'IDs of the [user identities](https://docs.seam.co/latest/capability-guides/mobile-access/managing-mobile-app-user-accounts-with-user-identities#what-is-a-user-identity) that you want to associate with the client session.',
+                      'IDs of the [user identities](https://docs.seam.co/capability-guides/mobile-access/managing-mobile-app-user-accounts-with-user-identities#what-is-a-user-identity) that you want to associate with the client session.',
                     items: { format: 'uuid', type: 'string' },
                     maxItems: 1,
                     minItems: 1,
@@ -50521,7 +50521,7 @@ const openapi: OpenAPISpec = {
       },
       put: {
         description:
-          'Creates a new [client session](https://docs.seam.co/latest/core-concepts/authentication/client-session-tokens).',
+          'Creates a new [client session](https://docs.seam.co/core-concepts/authentication/client-session-tokens).',
         operationId: 'clientSessionsCreatePut',
         requestBody: {
           content: {
@@ -50530,13 +50530,13 @@ const openapi: OpenAPISpec = {
                 properties: {
                   connect_webview_ids: {
                     description:
-                      'IDs of the [Connect Webviews](https://docs.seam.co/latest/core-concepts/connect-webviews) for which you want to create a client session.',
+                      'IDs of the [Connect Webviews](https://docs.seam.co/core-concepts/connect-webviews) for which you want to create a client session.',
                     items: { type: 'string' },
                     type: 'array',
                   },
                   connected_account_ids: {
                     description:
-                      'IDs of the [connected accounts](https://docs.seam.co/latest/core-concepts/connected-accounts) for which you want to create a client session.',
+                      'IDs of the [connected accounts](https://docs.seam.co/core-concepts/connected-accounts) for which you want to create a client session.',
                     items: { type: 'string' },
                     type: 'array',
                   },
@@ -50565,14 +50565,14 @@ const openapi: OpenAPISpec = {
                   },
                   user_identity_id: {
                     description:
-                      'ID of the [user identity](https://docs.seam.co/latest/capability-guides/mobile-access/managing-mobile-app-user-accounts-with-user-identities#what-is-a-user-identity) for which you want to create a client session.',
+                      'ID of the [user identity](https://docs.seam.co/capability-guides/mobile-access/managing-mobile-app-user-accounts-with-user-identities#what-is-a-user-identity) for which you want to create a client session.',
                     format: 'uuid',
                     type: 'string',
                   },
                   user_identity_ids: {
                     deprecated: true,
                     description:
-                      'IDs of the [user identities](https://docs.seam.co/latest/capability-guides/mobile-access/managing-mobile-app-user-accounts-with-user-identities#what-is-a-user-identity) that you want to associate with the client session.',
+                      'IDs of the [user identities](https://docs.seam.co/capability-guides/mobile-access/managing-mobile-app-user-accounts-with-user-identities#what-is-a-user-identity) that you want to associate with the client session.',
                     items: { format: 'uuid', type: 'string' },
                     maxItems: 1,
                     minItems: 1,
@@ -50624,7 +50624,7 @@ const openapi: OpenAPISpec = {
     '/client_sessions/delete': {
       delete: {
         description:
-          'Deletes a [client session](https://docs.seam.co/latest/core-concepts/authentication/client-session-tokens).',
+          'Deletes a [client session](https://docs.seam.co/core-concepts/authentication/client-session-tokens).',
         operationId: 'clientSessionsDeleteDelete',
         parameters: [
           {
@@ -50668,7 +50668,7 @@ const openapi: OpenAPISpec = {
       },
       post: {
         description:
-          'Deletes a [client session](https://docs.seam.co/latest/core-concepts/authentication/client-session-tokens).',
+          'Deletes a [client session](https://docs.seam.co/core-concepts/authentication/client-session-tokens).',
         operationId: 'clientSessionsDeletePost',
         requestBody: {
           content: {
@@ -50720,7 +50720,7 @@ const openapi: OpenAPISpec = {
     '/client_sessions/get': {
       get: {
         description:
-          'Returns a specified [client session](https://docs.seam.co/latest/core-concepts/authentication/client-session-tokens).',
+          'Returns a specified [client session](https://docs.seam.co/core-concepts/authentication/client-session-tokens).',
         operationId: 'clientSessionsGetGet',
         parameters: [
           {
@@ -50779,7 +50779,7 @@ const openapi: OpenAPISpec = {
       },
       post: {
         description:
-          'Returns a specified [client session](https://docs.seam.co/latest/core-concepts/authentication/client-session-tokens).',
+          'Returns a specified [client session](https://docs.seam.co/core-concepts/authentication/client-session-tokens).',
         operationId: 'clientSessionsGetPost',
         requestBody: {
           content: {
@@ -50842,7 +50842,7 @@ const openapi: OpenAPISpec = {
     '/client_sessions/get_or_create': {
       post: {
         description:
-          'Returns a [client session](https://docs.seam.co/latest/core-concepts/authentication/client-session-tokens) with specific characteristics or creates a new client session with these characteristics if it does not yet exist.',
+          'Returns a [client session](https://docs.seam.co/core-concepts/authentication/client-session-tokens) with specific characteristics or creates a new client session with these characteristics if it does not yet exist.',
         operationId: 'clientSessionsGetOrCreatePost',
         requestBody: {
           content: {
@@ -50851,13 +50851,13 @@ const openapi: OpenAPISpec = {
                 properties: {
                   connect_webview_ids: {
                     description:
-                      'IDs of the [Connect Webviews](https://docs.seam.co/latest/core-concepts/connect-webviews) that you want to associate with the client session (or that are already associated with the existing client session).',
+                      'IDs of the [Connect Webviews](https://docs.seam.co/core-concepts/connect-webviews) that you want to associate with the client session (or that are already associated with the existing client session).',
                     items: { type: 'string' },
                     type: 'array',
                   },
                   connected_account_ids: {
                     description:
-                      'IDs of the [connected accounts](https://docs.seam.co/latest/api/connected_accounts) that you want to associate with the client session (or that are already associated with the existing client session).',
+                      'IDs of the [connected accounts](https://docs.seam.co/api/connected_accounts) that you want to associate with the client session (or that are already associated with the existing client session).',
                     items: { type: 'string' },
                     type: 'array',
                   },
@@ -50875,14 +50875,14 @@ const openapi: OpenAPISpec = {
                   },
                   user_identity_id: {
                     description:
-                      'ID of the [user identity](https://docs.seam.co/latest/capability-guides/mobile-access/managing-mobile-app-user-accounts-with-user-identities#what-is-a-user-identity) that you want to associate with the client session (or that are already associated with the existing client session).',
+                      'ID of the [user identity](https://docs.seam.co/capability-guides/mobile-access/managing-mobile-app-user-accounts-with-user-identities#what-is-a-user-identity) that you want to associate with the client session (or that are already associated with the existing client session).',
                     format: 'uuid',
                     type: 'string',
                   },
                   user_identity_ids: {
                     deprecated: true,
                     description:
-                      'IDs of the [user identities](https://docs.seam.co/latest/capability-guides/mobile-access/managing-mobile-app-user-accounts-with-user-identities#what-is-a-user-identity) that you want to associate with the client session.',
+                      'IDs of the [user identities](https://docs.seam.co/capability-guides/mobile-access/managing-mobile-app-user-accounts-with-user-identities#what-is-a-user-identity) that you want to associate with the client session.',
                     items: { format: 'uuid', type: 'string' },
                     maxItems: 1,
                     minItems: 1,
@@ -50934,7 +50934,7 @@ const openapi: OpenAPISpec = {
     '/client_sessions/grant_access': {
       patch: {
         description:
-          'Grants a [client session](https://docs.seam.co/latest/core-concepts/authentication/client-session-tokens) access to one or more resources, such as [Connect Webviews](https://docs.seam.co/latest/core-concepts/connect-webviews), [user identities](https://docs.seam.co/latest/capability-guides/mobile-access/managing-mobile-app-user-accounts-with-user-identities#what-is-a-user-identity), and so on.',
+          'Grants a [client session](https://docs.seam.co/core-concepts/authentication/client-session-tokens) access to one or more resources, such as [Connect Webviews](https://docs.seam.co/core-concepts/connect-webviews), [user identities](https://docs.seam.co/capability-guides/mobile-access/managing-mobile-app-user-accounts-with-user-identities#what-is-a-user-identity), and so on.',
         operationId: 'clientSessionsGrantAccessPatch',
         requestBody: {
           content: {
@@ -50948,13 +50948,13 @@ const openapi: OpenAPISpec = {
                   },
                   connect_webview_ids: {
                     description:
-                      'IDs of the [Connect Webviews](https://docs.seam.co/latest/core-concepts/connect-webviews) that you want to associate with the client session.',
+                      'IDs of the [Connect Webviews](https://docs.seam.co/core-concepts/connect-webviews) that you want to associate with the client session.',
                     items: { type: 'string' },
                     type: 'array',
                   },
                   connected_account_ids: {
                     description:
-                      'IDs of the [connected accounts](https://docs.seam.co/latest/core-concepts/connected-accounts) that you want to associate with the client session.',
+                      'IDs of the [connected accounts](https://docs.seam.co/core-concepts/connected-accounts) that you want to associate with the client session.',
                     items: { type: 'string' },
                     type: 'array',
                   },
@@ -50965,13 +50965,13 @@ const openapi: OpenAPISpec = {
                   },
                   user_identity_id: {
                     description:
-                      'ID of the [user identity](https://docs.seam.co/latest/capability-guides/mobile-access/managing-mobile-app-user-accounts-with-user-identities#what-is-a-user-identity) that you want to associate with the client session.',
+                      'ID of the [user identity](https://docs.seam.co/capability-guides/mobile-access/managing-mobile-app-user-accounts-with-user-identities#what-is-a-user-identity) that you want to associate with the client session.',
                     type: 'string',
                   },
                   user_identity_ids: {
                     deprecated: true,
                     description:
-                      'IDs of the [user identities](https://docs.seam.co/latest/capability-guides/mobile-access/managing-mobile-app-user-accounts-with-user-identities#what-is-a-user-identity) that you want to associate with the client session.',
+                      'IDs of the [user identities](https://docs.seam.co/capability-guides/mobile-access/managing-mobile-app-user-accounts-with-user-identities#what-is-a-user-identity) that you want to associate with the client session.',
                     items: { type: 'string' },
                     maxItems: 1,
                     minItems: 1,
@@ -51019,7 +51019,7 @@ const openapi: OpenAPISpec = {
       },
       post: {
         description:
-          'Grants a [client session](https://docs.seam.co/latest/core-concepts/authentication/client-session-tokens) access to one or more resources, such as [Connect Webviews](https://docs.seam.co/latest/core-concepts/connect-webviews), [user identities](https://docs.seam.co/latest/capability-guides/mobile-access/managing-mobile-app-user-accounts-with-user-identities#what-is-a-user-identity), and so on.',
+          'Grants a [client session](https://docs.seam.co/core-concepts/authentication/client-session-tokens) access to one or more resources, such as [Connect Webviews](https://docs.seam.co/core-concepts/connect-webviews), [user identities](https://docs.seam.co/capability-guides/mobile-access/managing-mobile-app-user-accounts-with-user-identities#what-is-a-user-identity), and so on.',
         operationId: 'clientSessionsGrantAccessPost',
         requestBody: {
           content: {
@@ -51033,13 +51033,13 @@ const openapi: OpenAPISpec = {
                   },
                   connect_webview_ids: {
                     description:
-                      'IDs of the [Connect Webviews](https://docs.seam.co/latest/core-concepts/connect-webviews) that you want to associate with the client session.',
+                      'IDs of the [Connect Webviews](https://docs.seam.co/core-concepts/connect-webviews) that you want to associate with the client session.',
                     items: { type: 'string' },
                     type: 'array',
                   },
                   connected_account_ids: {
                     description:
-                      'IDs of the [connected accounts](https://docs.seam.co/latest/core-concepts/connected-accounts) that you want to associate with the client session.',
+                      'IDs of the [connected accounts](https://docs.seam.co/core-concepts/connected-accounts) that you want to associate with the client session.',
                     items: { type: 'string' },
                     type: 'array',
                   },
@@ -51050,13 +51050,13 @@ const openapi: OpenAPISpec = {
                   },
                   user_identity_id: {
                     description:
-                      'ID of the [user identity](https://docs.seam.co/latest/capability-guides/mobile-access/managing-mobile-app-user-accounts-with-user-identities#what-is-a-user-identity) that you want to associate with the client session.',
+                      'ID of the [user identity](https://docs.seam.co/capability-guides/mobile-access/managing-mobile-app-user-accounts-with-user-identities#what-is-a-user-identity) that you want to associate with the client session.',
                     type: 'string',
                   },
                   user_identity_ids: {
                     deprecated: true,
                     description:
-                      'IDs of the [user identities](https://docs.seam.co/latest/capability-guides/mobile-access/managing-mobile-app-user-accounts-with-user-identities#what-is-a-user-identity) that you want to associate with the client session.',
+                      'IDs of the [user identities](https://docs.seam.co/capability-guides/mobile-access/managing-mobile-app-user-accounts-with-user-identities#what-is-a-user-identity) that you want to associate with the client session.',
                     items: { type: 'string' },
                     maxItems: 1,
                     minItems: 1,
@@ -51106,7 +51106,7 @@ const openapi: OpenAPISpec = {
     '/client_sessions/list': {
       get: {
         description:
-          'Returns a list of all [client sessions](https://docs.seam.co/latest/core-concepts/authentication/client-session-tokens).',
+          'Returns a list of all [client sessions](https://docs.seam.co/core-concepts/authentication/client-session-tokens).',
         operationId: 'clientSessionsListGet',
         parameters: [
           {
@@ -51132,7 +51132,7 @@ const openapi: OpenAPISpec = {
             name: 'connect_webview_id',
             schema: {
               description:
-                'ID of the [Connect Webview](https://docs.seam.co/latest/core-concepts/connect-webviews) for which you want to retrieve client sessions.',
+                'ID of the [Connect Webview](https://docs.seam.co/core-concepts/connect-webviews) for which you want to retrieve client sessions.',
               type: 'string',
             },
           },
@@ -51150,7 +51150,7 @@ const openapi: OpenAPISpec = {
             name: 'user_identity_id',
             schema: {
               description:
-                'ID of the [user identity](https://docs.seam.co/latest/capability-guides/mobile-access/managing-mobile-app-user-accounts-with-user-identities#what-is-a-user-identity) for which you want to retrieve client sessions.',
+                'ID of the [user identity](https://docs.seam.co/capability-guides/mobile-access/managing-mobile-app-user-accounts-with-user-identities#what-is-a-user-identity) for which you want to retrieve client sessions.',
               type: 'string',
             },
           },
@@ -51192,7 +51192,7 @@ const openapi: OpenAPISpec = {
       },
       post: {
         description:
-          'Returns a list of all [client sessions](https://docs.seam.co/latest/core-concepts/authentication/client-session-tokens).',
+          'Returns a list of all [client sessions](https://docs.seam.co/core-concepts/authentication/client-session-tokens).',
         operationId: 'clientSessionsListPost',
         requestBody: {
           content: {
@@ -51206,7 +51206,7 @@ const openapi: OpenAPISpec = {
                   },
                   connect_webview_id: {
                     description:
-                      'ID of the [Connect Webview](https://docs.seam.co/latest/core-concepts/connect-webviews) for which you want to retrieve client sessions.',
+                      'ID of the [Connect Webview](https://docs.seam.co/core-concepts/connect-webviews) for which you want to retrieve client sessions.',
                     type: 'string',
                   },
                   user_identifier_key: {
@@ -51216,7 +51216,7 @@ const openapi: OpenAPISpec = {
                   },
                   user_identity_id: {
                     description:
-                      'ID of the [user identity](https://docs.seam.co/latest/capability-guides/mobile-access/managing-mobile-app-user-accounts-with-user-identities#what-is-a-user-identity) for which you want to retrieve client sessions.',
+                      'ID of the [user identity](https://docs.seam.co/capability-guides/mobile-access/managing-mobile-app-user-accounts-with-user-identities#what-is-a-user-identity) for which you want to retrieve client sessions.',
                     type: 'string',
                   },
                   without_user_identifier_key: {
@@ -51269,7 +51269,7 @@ const openapi: OpenAPISpec = {
     '/client_sessions/revoke': {
       post: {
         description:
-          'Revokes a [client session](https://docs.seam.co/latest/core-concepts/authentication/client-session-tokens).\n\nNote that [deleting a client session](https://docs.seam.co/latest/api/client_sessions/delete) is a separate action.',
+          'Revokes a [client session](https://docs.seam.co/core-concepts/authentication/client-session-tokens).\n\nNote that [deleting a client session](https://docs.seam.co/api/client_sessions/delete) is a separate action.',
         operationId: 'clientSessionsRevokePost',
         requestBody: {
           content: {
@@ -51321,7 +51321,7 @@ const openapi: OpenAPISpec = {
     '/connect_webviews/create': {
       post: {
         description:
-          'Creates a new [Connect Webview](https://docs.seam.co/latest/core-concepts/connect-webviews).\n\nTo enable a user to connect their devices or systems to Seam, they must sign in to their device or system account. To enable a user to sign in, you create a `connect_webview`. After creating the Connect Webview, you receive a URL that you can use to display the visual component of this Connect Webview for your user. You can open an iframe or new window to display the Connect Webview.\n\nYou should make a new `connect_webview` for each unique login request. Each `connect_webview` tracks the user that signed in with it. You receive an error if you reuse a Connect Webview for the same user twice or if you use the same Connect Webview for multiple users.\n\nSee also: [Connect Webview Process](https://docs.seam.co/latest/core-concepts/connect-webviews/connect-webview-process).',
+          'Creates a new [Connect Webview](https://docs.seam.co/core-concepts/connect-webviews).\n\nTo enable a user to connect their devices or systems to Seam, they must sign in to their device or system account. To enable a user to sign in, you create a `connect_webview`. After creating the Connect Webview, you receive a URL that you can use to display the visual component of this Connect Webview for your user. You can open an iframe or new window to display the Connect Webview.\n\nYou should make a new `connect_webview` for each unique login request. Each `connect_webview` tracks the user that signed in with it. You receive an error if you reuse a Connect Webview for the same user twice or if you use the same Connect Webview for multiple users.\n\nSee also: [Connect Webview Process](https://docs.seam.co/core-concepts/connect-webviews/connect-webview-process).',
         operationId: 'connectWebviewsCreatePost',
         requestBody: {
           content: {
@@ -51347,7 +51347,7 @@ const openapi: OpenAPISpec = {
                   },
                   accepted_providers: {
                     description:
-                      'Accepted device provider keys as an alternative to `provider_category`. Use this parameter to specify accepted providers explicitly. See [Customize the Brands to Display in Your Connect Webviews](https://docs.seam.co/latest/core-concepts/connect-webviews/customizing-connect-webviews#customize-the-brands-to-display-in-your-connect-webviews). To list all provider keys, use [`/devices/list_device_providers`](https://docs.seam.co/latest/api/devices/list_device_providers) with no filters.',
+                      'Accepted device provider keys as an alternative to `provider_category`. Use this parameter to specify accepted providers explicitly. See [Customize the Brands to Display in Your Connect Webviews](https://docs.seam.co/core-concepts/connect-webviews/customizing-connect-webviews#customize-the-brands-to-display-in-your-connect-webviews). To list all provider keys, use [`/devices/list_device_providers`](https://docs.seam.co/api/devices/list_device_providers) with no filters.',
                     items: {
                       enum: [
                         'hotek',
@@ -51416,7 +51416,7 @@ const openapi: OpenAPISpec = {
                   },
                   automatically_manage_new_devices: {
                     description:
-                      'Indicates whether newly-added devices should appear as [managed devices](https://docs.seam.co/latest/core-concepts/devices/managed-and-unmanaged-devices). See also: [Customize the Behavior Settings of Your Connect Webviews](https://docs.seam.co/latest/core-concepts/connect-webviews/customizing-connect-webviews#customize-the-behavior-settings-of-your-connect-webviews).',
+                      'Indicates whether newly-added devices should appear as [managed devices](https://docs.seam.co/core-concepts/devices/managed-and-unmanaged-devices). See also: [Customize the Behavior Settings of Your Connect Webviews](https://docs.seam.co/core-concepts/connect-webviews/customizing-connect-webviews#customize-the-behavior-settings-of-your-connect-webviews).',
                     type: 'boolean',
                   },
                   custom_metadata: {
@@ -51428,7 +51428,7 @@ const openapi: OpenAPISpec = {
                       ],
                     },
                     description:
-                      'Custom metadata that you want to associate with the Connect Webview. Supports up to 50 JSON key:value pairs. [Adding custom metadata to a Connect Webview](https://docs.seam.co/latest/core-concepts/connect-webviews/attaching-custom-data-to-the-connect-webview) enables you to store custom information, like customer details or internal IDs from your application. The custom metadata is then transferred to any [connected accounts](https://docs.seam.co/latest/core-concepts/connected-accounts) that were connected using the Connect Webview, making it easy to find and filter these resources in your [workspace](https://docs.seam.co/latest/core-concepts/workspaces). You can also [filter Connect Webviews by custom metadata](https://docs.seam.co/latest/core-concepts/connect-webviews/filtering-connect-webviews-by-custom-metadata).',
+                      'Custom metadata that you want to associate with the Connect Webview. Supports up to 50 JSON key:value pairs. [Adding custom metadata to a Connect Webview](https://docs.seam.co/core-concepts/connect-webviews/attaching-custom-data-to-the-connect-webview) enables you to store custom information, like customer details or internal IDs from your application. The custom metadata is then transferred to any [connected accounts](https://docs.seam.co/core-concepts/connected-accounts) that were connected using the Connect Webview, making it easy to find and filter these resources in your [workspace](https://docs.seam.co/core-concepts/workspaces). You can also [filter Connect Webviews by custom metadata](https://docs.seam.co/core-concepts/connect-webviews/filtering-connect-webviews-by-custom-metadata).',
                     type: 'object',
                   },
                   custom_redirect_failure_url: {
@@ -51460,7 +51460,7 @@ const openapi: OpenAPISpec = {
                   },
                   provider_category: {
                     description:
-                      'Specifies the category of providers that you want to include. To list all providers within a category, use [`/devices/list_device_providers`](https://docs.seam.co/latest/api/devices/list_device_providers) with the desired `provider_category` filter.',
+                      'Specifies the category of providers that you want to include. To list all providers within a category, use [`/devices/list_device_providers`](https://docs.seam.co/api/devices/list_device_providers) with the desired `provider_category` filter.',
                     enum: [
                       'stable',
                       'consumer_smartlocks',
@@ -51477,7 +51477,7 @@ const openapi: OpenAPISpec = {
                   wait_for_device_creation: {
                     default: false,
                     description:
-                      'Indicates whether Seam should finish syncing all devices in a newly-connected account before completing the associated Connect Webview. See also: [Customize the Behavior Settings of Your Connect Webviews](https://docs.seam.co/latest/core-concepts/connect-webviews/customizing-connect-webviews#customize-the-behavior-settings-of-your-connect-webviews).',
+                      'Indicates whether Seam should finish syncing all devices in a newly-connected account before completing the associated Connect Webview. See also: [Customize the Behavior Settings of Your Connect Webviews](https://docs.seam.co/core-concepts/connect-webviews/customizing-connect-webviews#customize-the-behavior-settings-of-your-connect-webviews).',
                     type: 'boolean',
                   },
                 },
@@ -51526,7 +51526,7 @@ const openapi: OpenAPISpec = {
     '/connect_webviews/delete': {
       delete: {
         description:
-          'Deletes a [Connect Webview](https://docs.seam.co/latest/core-concepts/connect-webviews).\n\nYou do not need to delete a Connect Webview once a user completes it. Instead, you can simply ignore completed Connect Webviews.',
+          'Deletes a [Connect Webview](https://docs.seam.co/core-concepts/connect-webviews).\n\nYou do not need to delete a Connect Webview once a user completes it. Instead, you can simply ignore completed Connect Webviews.',
         operationId: 'connectWebviewsDeleteDelete',
         requestBody: {
           content: {
@@ -51576,7 +51576,7 @@ const openapi: OpenAPISpec = {
       },
       post: {
         description:
-          'Deletes a [Connect Webview](https://docs.seam.co/latest/core-concepts/connect-webviews).\n\nYou do not need to delete a Connect Webview once a user completes it. Instead, you can simply ignore completed Connect Webviews.',
+          'Deletes a [Connect Webview](https://docs.seam.co/core-concepts/connect-webviews).\n\nYou do not need to delete a Connect Webview once a user completes it. Instead, you can simply ignore completed Connect Webviews.',
         operationId: 'connectWebviewsDeletePost',
         requestBody: {
           content: {
@@ -51628,7 +51628,7 @@ const openapi: OpenAPISpec = {
     '/connect_webviews/get': {
       get: {
         description:
-          "Returns a specified [Connect Webview](https://docs.seam.co/latest/core-concepts/connect-webviews).\n\nUnless you're using a `custom_redirect_url`, you should poll a newly-created `connect_webview` to find out if the user has signed in or to get details about what devices they've connected.",
+          "Returns a specified [Connect Webview](https://docs.seam.co/core-concepts/connect-webviews).\n\nUnless you're using a `custom_redirect_url`, you should poll a newly-created `connect_webview` to find out if the user has signed in or to get details about what devices they've connected.",
         operationId: 'connectWebviewsGetGet',
         parameters: [
           {
@@ -51680,7 +51680,7 @@ const openapi: OpenAPISpec = {
       },
       post: {
         description:
-          "Returns a specified [Connect Webview](https://docs.seam.co/latest/core-concepts/connect-webviews).\n\nUnless you're using a `custom_redirect_url`, you should poll a newly-created `connect_webview` to find out if the user has signed in or to get details about what devices they've connected.",
+          "Returns a specified [Connect Webview](https://docs.seam.co/core-concepts/connect-webviews).\n\nUnless you're using a `custom_redirect_url`, you should poll a newly-created `connect_webview` to find out if the user has signed in or to get details about what devices they've connected.",
         operationId: 'connectWebviewsGetPost',
         requestBody: {
           content: {
@@ -51740,7 +51740,7 @@ const openapi: OpenAPISpec = {
     '/connect_webviews/list': {
       get: {
         description:
-          'Returns a list of all [Connect Webviews](https://docs.seam.co/latest/core-concepts/connect-webviews).',
+          'Returns a list of all [Connect Webviews](https://docs.seam.co/core-concepts/connect-webviews).',
         operationId: 'connectWebviewsListGet',
         parameters: [
           {
@@ -51769,7 +51769,7 @@ const openapi: OpenAPISpec = {
                 oneOf: [{ type: 'string' }, { type: 'boolean' }],
               },
               description:
-                'Custom metadata pairs by which you want to [filter Connect Webviews](https://docs.seam.co/latest/core-concepts/connect-webviews/filtering-connect-webviews-by-custom-metadata). Returns Connect Webviews with `custom_metadata` that contains all of the provided key:value pairs.',
+                'Custom metadata pairs by which you want to [filter Connect Webviews](https://docs.seam.co/core-concepts/connect-webviews/filtering-connect-webviews-by-custom-metadata). Returns Connect Webviews with `custom_metadata` that contains all of the provided key:value pairs.',
               type: 'object',
             },
           },
@@ -51844,7 +51844,7 @@ const openapi: OpenAPISpec = {
       },
       post: {
         description:
-          'Returns a list of all [Connect Webviews](https://docs.seam.co/latest/core-concepts/connect-webviews).',
+          'Returns a list of all [Connect Webviews](https://docs.seam.co/core-concepts/connect-webviews).',
         operationId: 'connectWebviewsListPost',
         requestBody: {
           content: {
@@ -51856,7 +51856,7 @@ const openapi: OpenAPISpec = {
                       oneOf: [{ type: 'string' }, { type: 'boolean' }],
                     },
                     description:
-                      'Custom metadata pairs by which you want to [filter Connect Webviews](https://docs.seam.co/latest/core-concepts/connect-webviews/filtering-connect-webviews-by-custom-metadata). Returns Connect Webviews with `custom_metadata` that contains all of the provided key:value pairs.',
+                      'Custom metadata pairs by which you want to [filter Connect Webviews](https://docs.seam.co/core-concepts/connect-webviews/filtering-connect-webviews-by-custom-metadata). Returns Connect Webviews with `custom_metadata` that contains all of the provided key:value pairs.',
                     type: 'object',
                   },
                   customer_key: {
@@ -51936,7 +51936,7 @@ const openapi: OpenAPISpec = {
     '/connected_accounts/delete': {
       delete: {
         description:
-          'Deletes a specified [connected account](https://docs.seam.co/latest/core-concepts/connected-accounts).\n\nDeleting a connected account triggers a `connected_account.deleted` event and removes the connected account and all data associated with the connected account from Seam, including devices, events, access codes, and so on. For every deleted resource, Seam sends a corresponding deleted event, but the resource is not deleted from the provider.\n\nFor example, if you delete a connected account with a device that has an access code, Seam sends a `connected_account.deleted` event, a `device.deleted` event, and an `access_code.deleted` event, but Seam does not remove the access code from the device.',
+          'Deletes a specified [connected account](https://docs.seam.co/core-concepts/connected-accounts).\n\nDeleting a connected account triggers a `connected_account.deleted` event and removes the connected account and all data associated with the connected account from Seam, including devices, events, access codes, and so on. For every deleted resource, Seam sends a corresponding deleted event, but the resource is not deleted from the provider.\n\nFor example, if you delete a connected account with a device that has an access code, Seam sends a `connected_account.deleted` event, a `device.deleted` event, and an `access_code.deleted` event, but Seam does not remove the access code from the device.',
         operationId: 'connectedAccountsDeleteDelete',
         requestBody: {
           content: {
@@ -51992,7 +51992,7 @@ const openapi: OpenAPISpec = {
       },
       post: {
         description:
-          'Deletes a specified [connected account](https://docs.seam.co/latest/core-concepts/connected-accounts).\n\nDeleting a connected account triggers a `connected_account.deleted` event and removes the connected account and all data associated with the connected account from Seam, including devices, events, access codes, and so on. For every deleted resource, Seam sends a corresponding deleted event, but the resource is not deleted from the provider.\n\nFor example, if you delete a connected account with a device that has an access code, Seam sends a `connected_account.deleted` event, a `device.deleted` event, and an `access_code.deleted` event, but Seam does not remove the access code from the device.',
+          'Deletes a specified [connected account](https://docs.seam.co/core-concepts/connected-accounts).\n\nDeleting a connected account triggers a `connected_account.deleted` event and removes the connected account and all data associated with the connected account from Seam, including devices, events, access codes, and so on. For every deleted resource, Seam sends a corresponding deleted event, but the resource is not deleted from the provider.\n\nFor example, if you delete a connected account with a device that has an access code, Seam sends a `connected_account.deleted` event, a `device.deleted` event, and an `access_code.deleted` event, but Seam does not remove the access code from the device.',
         operationId: 'connectedAccountsDeletePost',
         requestBody: {
           content: {
@@ -52050,7 +52050,7 @@ const openapi: OpenAPISpec = {
     '/connected_accounts/get': {
       get: {
         description:
-          'Returns a specified [connected account](https://docs.seam.co/latest/core-concepts/connected-accounts).',
+          'Returns a specified [connected account](https://docs.seam.co/core-concepts/connected-accounts).',
         operationId: 'connectedAccountsGetGet',
         responses: {
           200: {
@@ -52090,7 +52090,7 @@ const openapi: OpenAPISpec = {
       },
       post: {
         description:
-          'Returns a specified [connected account](https://docs.seam.co/latest/core-concepts/connected-accounts).',
+          'Returns a specified [connected account](https://docs.seam.co/core-concepts/connected-accounts).',
         operationId: 'connectedAccountsGetPost',
         requestBody: {
           content: {
@@ -52166,7 +52166,7 @@ const openapi: OpenAPISpec = {
     '/connected_accounts/list': {
       get: {
         description:
-          'Returns a list of all [connected accounts](https://docs.seam.co/latest/core-concepts/connected-accounts).',
+          'Returns a list of all [connected accounts](https://docs.seam.co/core-concepts/connected-accounts).',
         operationId: 'connectedAccountsListGet',
         parameters: [
           {
@@ -52280,7 +52280,7 @@ const openapi: OpenAPISpec = {
       },
       post: {
         description:
-          'Returns a list of all [connected accounts](https://docs.seam.co/latest/core-concepts/connected-accounts).',
+          'Returns a list of all [connected accounts](https://docs.seam.co/core-concepts/connected-accounts).',
         operationId: 'connectedAccountsListPost',
         requestBody: {
           content: {
@@ -52378,7 +52378,7 @@ const openapi: OpenAPISpec = {
     '/connected_accounts/simulate/disconnect': {
       post: {
         description:
-          'Simulates a connected account becoming disconnected from Seam. Only applicable for [sandbox workspaces](https://docs.seam.co/latest/core-concepts/workspaces#sandbox-workspaces).',
+          'Simulates a connected account becoming disconnected from Seam. Only applicable for [sandbox workspaces](https://docs.seam.co/core-concepts/workspaces#sandbox-workspaces).',
         operationId: 'connectedAccountsSimulateDisconnectPost',
         requestBody: {
           content: {
@@ -52431,7 +52431,7 @@ const openapi: OpenAPISpec = {
     '/connected_accounts/sync': {
       post: {
         description:
-          'Request a [connected account](https://docs.seam.co/latest/core-concepts/connected-accounts) sync attempt for the specified `connected_account_id`.',
+          'Request a [connected account](https://docs.seam.co/core-concepts/connected-accounts) sync attempt for the specified `connected_account_id`.',
         operationId: 'connectedAccountsSyncPost',
         requestBody: {
           content: {
@@ -52483,7 +52483,7 @@ const openapi: OpenAPISpec = {
     '/connected_accounts/update': {
       patch: {
         description:
-          'Updates a [connected account](https://docs.seam.co/latest/core-concepts/connected-accounts).',
+          'Updates a [connected account](https://docs.seam.co/core-concepts/connected-accounts).',
         operationId: 'connectedAccountsUpdatePatch',
         requestBody: {
           content: {
@@ -52509,7 +52509,7 @@ const openapi: OpenAPISpec = {
                   },
                   automatically_manage_new_devices: {
                     description:
-                      'Indicates whether newly-added devices should appear as [managed devices](https://docs.seam.co/latest/core-concepts/devices/managed-and-unmanaged-devices).',
+                      'Indicates whether newly-added devices should appear as [managed devices](https://docs.seam.co/core-concepts/devices/managed-and-unmanaged-devices).',
                     type: 'boolean',
                   },
                   connected_account_id: {
@@ -52527,7 +52527,7 @@ const openapi: OpenAPISpec = {
                       ],
                     },
                     description:
-                      'Custom metadata that you want to associate with the connected account. Entirely replaces the existing custom metadata object. If a new Connect Webview contains custom metadata and is used to reconnect a connected account, the custom metadata from the Connect Webview will entirely replace the entire custom metadata object on the connected account. Supports up to 50 JSON key:value pairs. [Adding custom metadata to a connected account](https://docs.seam.co/latest/core-concepts/connected-accounts/adding-custom-metadata-to-a-connected-account) enables you to store custom information, like customer details or internal IDs from your application. Then, you can [filter connected accounts by the desired metadata](https://docs.seam.co/latest/core-concepts/connected-accounts/filtering-connected-accounts-by-custom-metadata).',
+                      'Custom metadata that you want to associate with the connected account. Entirely replaces the existing custom metadata object. If a new Connect Webview contains custom metadata and is used to reconnect a connected account, the custom metadata from the Connect Webview will entirely replace the entire custom metadata object on the connected account. Supports up to 50 JSON key:value pairs. [Adding custom metadata to a connected account](https://docs.seam.co/core-concepts/connected-accounts/adding-custom-metadata-to-a-connected-account) enables you to store custom information, like customer details or internal IDs from your application. Then, you can [filter connected accounts by the desired metadata](https://docs.seam.co/core-concepts/connected-accounts/filtering-connected-accounts-by-custom-metadata).',
                     type: 'object',
                   },
                   customer_key: {
@@ -52585,7 +52585,7 @@ const openapi: OpenAPISpec = {
       },
       post: {
         description:
-          'Updates a [connected account](https://docs.seam.co/latest/core-concepts/connected-accounts).',
+          'Updates a [connected account](https://docs.seam.co/core-concepts/connected-accounts).',
         operationId: 'connectedAccountsUpdatePost',
         requestBody: {
           content: {
@@ -52611,7 +52611,7 @@ const openapi: OpenAPISpec = {
                   },
                   automatically_manage_new_devices: {
                     description:
-                      'Indicates whether newly-added devices should appear as [managed devices](https://docs.seam.co/latest/core-concepts/devices/managed-and-unmanaged-devices).',
+                      'Indicates whether newly-added devices should appear as [managed devices](https://docs.seam.co/core-concepts/devices/managed-and-unmanaged-devices).',
                     type: 'boolean',
                   },
                   connected_account_id: {
@@ -52629,7 +52629,7 @@ const openapi: OpenAPISpec = {
                       ],
                     },
                     description:
-                      'Custom metadata that you want to associate with the connected account. Entirely replaces the existing custom metadata object. If a new Connect Webview contains custom metadata and is used to reconnect a connected account, the custom metadata from the Connect Webview will entirely replace the entire custom metadata object on the connected account. Supports up to 50 JSON key:value pairs. [Adding custom metadata to a connected account](https://docs.seam.co/latest/core-concepts/connected-accounts/adding-custom-metadata-to-a-connected-account) enables you to store custom information, like customer details or internal IDs from your application. Then, you can [filter connected accounts by the desired metadata](https://docs.seam.co/latest/core-concepts/connected-accounts/filtering-connected-accounts-by-custom-metadata).',
+                      'Custom metadata that you want to associate with the connected account. Entirely replaces the existing custom metadata object. If a new Connect Webview contains custom metadata and is used to reconnect a connected account, the custom metadata from the Connect Webview will entirely replace the entire custom metadata object on the connected account. Supports up to 50 JSON key:value pairs. [Adding custom metadata to a connected account](https://docs.seam.co/core-concepts/connected-accounts/adding-custom-metadata-to-a-connected-account) enables you to store custom information, like customer details or internal IDs from your application. Then, you can [filter connected accounts by the desired metadata](https://docs.seam.co/core-concepts/connected-accounts/filtering-connected-accounts-by-custom-metadata).',
                     type: 'object',
                   },
                   customer_key: {
@@ -55281,7 +55281,7 @@ const openapi: OpenAPISpec = {
     '/devices/delete': {
       delete: {
         description:
-          'Deletes a specified [device](https://docs.seam.co/latest/core-concepts/devices).',
+          'Deletes a specified [device](https://docs.seam.co/core-concepts/devices).',
         operationId: 'devicesDeleteDelete',
         parameters: [
           {
@@ -55329,7 +55329,7 @@ const openapi: OpenAPISpec = {
       },
       post: {
         description:
-          'Deletes a specified [device](https://docs.seam.co/latest/core-concepts/devices).',
+          'Deletes a specified [device](https://docs.seam.co/core-concepts/devices).',
         operationId: 'devicesDeletePost',
         requestBody: {
           content: {
@@ -55384,7 +55384,7 @@ const openapi: OpenAPISpec = {
     '/devices/get': {
       get: {
         description:
-          'Returns a specified [device](https://docs.seam.co/latest/core-concepts/devices).\n\nYou must specify either `device_id` or `name`.',
+          'Returns a specified [device](https://docs.seam.co/core-concepts/devices).\n\nYou must specify either `device_id` or `name`.',
         operationId: 'devicesGetGet',
         parameters: [
           {
@@ -55441,7 +55441,7 @@ const openapi: OpenAPISpec = {
       },
       post: {
         description:
-          'Returns a specified [device](https://docs.seam.co/latest/core-concepts/devices).\n\nYou must specify either `device_id` or `name`.',
+          'Returns a specified [device](https://docs.seam.co/core-concepts/devices).\n\nYou must specify either `device_id` or `name`.',
         operationId: 'devicesGetPost',
         requestBody: {
           content: {
@@ -55501,7 +55501,7 @@ const openapi: OpenAPISpec = {
     '/devices/list': {
       get: {
         description:
-          'Returns a list of all [devices](https://docs.seam.co/latest/core-concepts/devices).',
+          'Returns a list of all [devices](https://docs.seam.co/core-concepts/devices).',
         operationId: 'devicesListGet',
         parameters: [
           {
@@ -55802,7 +55802,7 @@ const openapi: OpenAPISpec = {
                 oneOf: [{ type: 'string' }, { type: 'boolean' }],
               },
               description:
-                'Set of key:value [custom metadata](https://docs.seam.co/latest/core-concepts/devices/adding-custom-metadata-to-a-device) pairs for which you want to list devices.',
+                'Set of key:value [custom metadata](https://docs.seam.co/core-concepts/devices/adding-custom-metadata-to-a-device) pairs for which you want to list devices.',
               type: 'object',
             },
           },
@@ -55954,7 +55954,7 @@ const openapi: OpenAPISpec = {
       },
       post: {
         description:
-          'Returns a list of all [devices](https://docs.seam.co/latest/core-concepts/devices).',
+          'Returns a list of all [devices](https://docs.seam.co/core-concepts/devices).',
         operationId: 'devicesListPost',
         requestBody: {
           content: {
@@ -55990,7 +55990,7 @@ const openapi: OpenAPISpec = {
                       oneOf: [{ type: 'string' }, { type: 'boolean' }],
                     },
                     description:
-                      'Set of key:value [custom metadata](https://docs.seam.co/latest/core-concepts/devices/adding-custom-metadata-to-a-device) pairs for which you want to list devices.',
+                      'Set of key:value [custom metadata](https://docs.seam.co/core-concepts/devices/adding-custom-metadata-to-a-device) pairs for which you want to list devices.',
                     type: 'object',
                   },
                   customer_key: {
@@ -56353,7 +56353,7 @@ const openapi: OpenAPISpec = {
     '/devices/list_device_providers': {
       get: {
         description:
-          'Returns a list of all device providers.\n\nThe information that this endpoint returns for each provider includes a set of [capability flags](https://docs.seam.co/latest/capability-guides/device-and-system-capabilities#capability-flags), such as `device_provider.can_remotely_unlock`. If at least one supported device from a provider has a specific capability, the corresponding capability flag is `true`.\n\nWhen you create a [Connect Webview](https://docs.seam.co/latest/core-concepts/connect-webviews), you can customize the providers—that is, the brands—that it displays. In the `/connect_webviews/create` request, include the desired set of device provider keys in the `accepted_providers` parameter. See also [Customize the Brands to Display in Your Connect Webviews](https://docs.seam.co/latest/core-concepts/connect-webviews/customizing-connect-webviews#customize-the-brands-to-display-in-your-connect-webviews).',
+          'Returns a list of all device providers.\n\nThe information that this endpoint returns for each provider includes a set of [capability flags](https://docs.seam.co/capability-guides/device-and-system-capabilities#capability-flags), such as `device_provider.can_remotely_unlock`. If at least one supported device from a provider has a specific capability, the corresponding capability flag is `true`.\n\nWhen you create a [Connect Webview](https://docs.seam.co/core-concepts/connect-webviews), you can customize the providers—that is, the brands—that it displays. In the `/connect_webviews/create` request, include the desired set of device provider keys in the `accepted_providers` parameter. See also [Customize the Brands to Display in Your Connect Webviews](https://docs.seam.co/core-concepts/connect-webviews/customizing-connect-webviews#customize-the-brands-to-display-in-your-connect-webviews).',
         operationId: 'devicesListDeviceProvidersGet',
         parameters: [
           {
@@ -56413,7 +56413,7 @@ const openapi: OpenAPISpec = {
       },
       post: {
         description:
-          'Returns a list of all device providers.\n\nThe information that this endpoint returns for each provider includes a set of [capability flags](https://docs.seam.co/latest/capability-guides/device-and-system-capabilities#capability-flags), such as `device_provider.can_remotely_unlock`. If at least one supported device from a provider has a specific capability, the corresponding capability flag is `true`.\n\nWhen you create a [Connect Webview](https://docs.seam.co/latest/core-concepts/connect-webviews), you can customize the providers—that is, the brands—that it displays. In the `/connect_webviews/create` request, include the desired set of device provider keys in the `accepted_providers` parameter. See also [Customize the Brands to Display in Your Connect Webviews](https://docs.seam.co/latest/core-concepts/connect-webviews/customizing-connect-webviews#customize-the-brands-to-display-in-your-connect-webviews).',
+          'Returns a list of all device providers.\n\nThe information that this endpoint returns for each provider includes a set of [capability flags](https://docs.seam.co/capability-guides/device-and-system-capabilities#capability-flags), such as `device_provider.can_remotely_unlock`. If at least one supported device from a provider has a specific capability, the corresponding capability flag is `true`.\n\nWhen you create a [Connect Webview](https://docs.seam.co/core-concepts/connect-webviews), you can customize the providers—that is, the brands—that it displays. In the `/connect_webviews/create` request, include the desired set of device provider keys in the `accepted_providers` parameter. See also [Customize the Brands to Display in Your Connect Webviews](https://docs.seam.co/core-concepts/connect-webviews/customizing-connect-webviews#customize-the-brands-to-display-in-your-connect-webviews).',
         operationId: 'devicesListDeviceProvidersPost',
         requestBody: {
           content: {
@@ -57872,7 +57872,7 @@ const openapi: OpenAPISpec = {
     '/devices/simulate/connect': {
       post: {
         description:
-          'Simulates connecting a device to Seam. Only applicable for [sandbox devices](https://docs.seam.co/latest/core-concepts/workspaces#sandbox-workspaces). See also [Testing Your App Against Device Disconnection and Removal](https://docs.seam.co/latest/core-concepts/devices/testing-your-app-against-device-disconnection-and-removal).',
+          'Simulates connecting a device to Seam. Only applicable for [sandbox devices](https://docs.seam.co/core-concepts/workspaces#sandbox-workspaces). See also [Testing Your App Against Device Disconnection and Removal](https://docs.seam.co/core-concepts/devices/testing-your-app-against-device-disconnection-and-removal).',
         operationId: 'devicesSimulateConnectPost',
         requestBody: {
           content: {
@@ -57978,7 +57978,7 @@ const openapi: OpenAPISpec = {
     '/devices/simulate/disconnect': {
       post: {
         description:
-          'Simulates disconnecting a device from Seam. Only applicable for [sandbox devices](https://docs.seam.co/latest/core-concepts/workspaces#sandbox-workspaces). See also [Testing Your App Against Device Disconnection and Removal](https://docs.seam.co/latest/core-concepts/devices/testing-your-app-against-device-disconnection-and-removal).',
+          'Simulates disconnecting a device from Seam. Only applicable for [sandbox devices](https://docs.seam.co/core-concepts/workspaces#sandbox-workspaces). See also [Testing Your App Against Device Disconnection and Removal](https://docs.seam.co/core-concepts/devices/testing-your-app-against-device-disconnection-and-removal).',
         operationId: 'devicesSimulateDisconnectPost',
         requestBody: {
           content: {
@@ -58133,7 +58133,7 @@ const openapi: OpenAPISpec = {
     '/devices/simulate/remove': {
       post: {
         description:
-          'Simulates removing a device from Seam. Only applicable for [sandbox devices](https://docs.seam.co/latest/core-concepts/workspaces#sandbox-workspaces). See also [Testing Your App Against Device Disconnection and Removal](https://docs.seam.co/latest/core-concepts/devices/testing-your-app-against-device-disconnection-and-removal).',
+          'Simulates removing a device from Seam. Only applicable for [sandbox devices](https://docs.seam.co/core-concepts/workspaces#sandbox-workspaces). See also [Testing Your App Against Device Disconnection and Removal](https://docs.seam.co/core-concepts/devices/testing-your-app-against-device-disconnection-and-removal).',
         operationId: 'devicesSimulateRemovePost',
         requestBody: {
           content: {
@@ -58186,7 +58186,7 @@ const openapi: OpenAPISpec = {
     '/devices/unmanaged/get': {
       get: {
         description:
-          'Returns a specified [unmanaged device](https://docs.seam.co/latest/core-concepts/devices/managed-and-unmanaged-devices).\n\nAn unmanaged device has a limited set of visible properties and a subset of supported events. You cannot control an unmanaged device. Any [access codes](https://docs.seam.co/latest/capability-guides/smart-locks/access-codes/migrating-existing-access-codes) on an unmanaged device are unmanaged. To control an unmanaged device with Seam, [convert it to a managed device](https://docs.seam.co/latest/core-concepts/devices/managed-and-unmanaged-devices#convert-an-unmanaged-device-to-managed).\n\nYou must specify either `device_id` or `name`.',
+          'Returns a specified [unmanaged device](https://docs.seam.co/core-concepts/devices/managed-and-unmanaged-devices).\n\nAn unmanaged device has a limited set of visible properties and a subset of supported events. You cannot control an unmanaged device. Any [access codes](https://docs.seam.co/capability-guides/smart-locks/access-codes/migrating-existing-access-codes) on an unmanaged device are unmanaged. To control an unmanaged device with Seam, [convert it to a managed device](https://docs.seam.co/core-concepts/devices/managed-and-unmanaged-devices#convert-an-unmanaged-device-to-managed).\n\nYou must specify either `device_id` or `name`.',
         operationId: 'devicesUnmanagedGetGet',
         parameters: [
           {
@@ -58242,7 +58242,7 @@ const openapi: OpenAPISpec = {
       },
       post: {
         description:
-          'Returns a specified [unmanaged device](https://docs.seam.co/latest/core-concepts/devices/managed-and-unmanaged-devices).\n\nAn unmanaged device has a limited set of visible properties and a subset of supported events. You cannot control an unmanaged device. Any [access codes](https://docs.seam.co/latest/capability-guides/smart-locks/access-codes/migrating-existing-access-codes) on an unmanaged device are unmanaged. To control an unmanaged device with Seam, [convert it to a managed device](https://docs.seam.co/latest/core-concepts/devices/managed-and-unmanaged-devices#convert-an-unmanaged-device-to-managed).\n\nYou must specify either `device_id` or `name`.',
+          'Returns a specified [unmanaged device](https://docs.seam.co/core-concepts/devices/managed-and-unmanaged-devices).\n\nAn unmanaged device has a limited set of visible properties and a subset of supported events. You cannot control an unmanaged device. Any [access codes](https://docs.seam.co/capability-guides/smart-locks/access-codes/migrating-existing-access-codes) on an unmanaged device are unmanaged. To control an unmanaged device with Seam, [convert it to a managed device](https://docs.seam.co/core-concepts/devices/managed-and-unmanaged-devices#convert-an-unmanaged-device-to-managed).\n\nYou must specify either `device_id` or `name`.',
         operationId: 'devicesUnmanagedGetPost',
         requestBody: {
           content: {
@@ -58303,7 +58303,7 @@ const openapi: OpenAPISpec = {
     '/devices/unmanaged/list': {
       get: {
         description:
-          'Returns a list of all [unmanaged devices](https://docs.seam.co/latest/core-concepts/devices/managed-and-unmanaged-devices).\n\nAn unmanaged device has a limited set of visible properties and a subset of supported events. You cannot control an unmanaged device. Any [access codes](https://docs.seam.co/latest/capability-guides/smart-locks/access-codes/migrating-existing-access-codes) on an unmanaged device are unmanaged. To control an unmanaged device with Seam, [convert it to a managed device](https://docs.seam.co/latest/core-concepts/devices/managed-and-unmanaged-devices#convert-an-unmanaged-device-to-managed).',
+          'Returns a list of all [unmanaged devices](https://docs.seam.co/core-concepts/devices/managed-and-unmanaged-devices).\n\nAn unmanaged device has a limited set of visible properties and a subset of supported events. You cannot control an unmanaged device. Any [access codes](https://docs.seam.co/capability-guides/smart-locks/access-codes/migrating-existing-access-codes) on an unmanaged device are unmanaged. To control an unmanaged device with Seam, [convert it to a managed device](https://docs.seam.co/core-concepts/devices/managed-and-unmanaged-devices#convert-an-unmanaged-device-to-managed).',
         operationId: 'devicesUnmanagedListGet',
         parameters: [
           {
@@ -58593,7 +58593,7 @@ const openapi: OpenAPISpec = {
                 oneOf: [{ type: 'string' }, { type: 'boolean' }],
               },
               description:
-                'Set of key:value [custom metadata](https://docs.seam.co/latest/core-concepts/devices/adding-custom-metadata-to-a-device) pairs for which you want to list devices.',
+                'Set of key:value [custom metadata](https://docs.seam.co/core-concepts/devices/adding-custom-metadata-to-a-device) pairs for which you want to list devices.',
               type: 'object',
             },
           },
@@ -58755,7 +58755,7 @@ const openapi: OpenAPISpec = {
       },
       post: {
         description:
-          'Returns a list of all [unmanaged devices](https://docs.seam.co/latest/core-concepts/devices/managed-and-unmanaged-devices).\n\nAn unmanaged device has a limited set of visible properties and a subset of supported events. You cannot control an unmanaged device. Any [access codes](https://docs.seam.co/latest/capability-guides/smart-locks/access-codes/migrating-existing-access-codes) on an unmanaged device are unmanaged. To control an unmanaged device with Seam, [convert it to a managed device](https://docs.seam.co/latest/core-concepts/devices/managed-and-unmanaged-devices#convert-an-unmanaged-device-to-managed).',
+          'Returns a list of all [unmanaged devices](https://docs.seam.co/core-concepts/devices/managed-and-unmanaged-devices).\n\nAn unmanaged device has a limited set of visible properties and a subset of supported events. You cannot control an unmanaged device. Any [access codes](https://docs.seam.co/capability-guides/smart-locks/access-codes/migrating-existing-access-codes) on an unmanaged device are unmanaged. To control an unmanaged device with Seam, [convert it to a managed device](https://docs.seam.co/core-concepts/devices/managed-and-unmanaged-devices#convert-an-unmanaged-device-to-managed).',
         operationId: 'devicesUnmanagedListPost',
         requestBody: {
           content: {
@@ -58791,7 +58791,7 @@ const openapi: OpenAPISpec = {
                       oneOf: [{ type: 'string' }, { type: 'boolean' }],
                     },
                     description:
-                      'Set of key:value [custom metadata](https://docs.seam.co/latest/core-concepts/devices/adding-custom-metadata-to-a-device) pairs for which you want to list devices.',
+                      'Set of key:value [custom metadata](https://docs.seam.co/core-concepts/devices/adding-custom-metadata-to-a-device) pairs for which you want to list devices.',
                     type: 'object',
                   },
                   customer_key: {
@@ -59153,7 +59153,7 @@ const openapi: OpenAPISpec = {
     '/devices/unmanaged/update': {
       patch: {
         description:
-          'Updates a specified [unmanaged device](https://docs.seam.co/latest/core-concepts/devices/managed-and-unmanaged-devices). To convert an unmanaged device to managed, set `is_managed` to `true`.\n\nAn unmanaged device has a limited set of visible properties and a subset of supported events. You cannot control an unmanaged device. Any [access codes](https://docs.seam.co/latest/capability-guides/smart-locks/access-codes/migrating-existing-access-codes) on an unmanaged device are unmanaged. To control an unmanaged device with Seam, [convert it to a managed device](https://docs.seam.co/latest/core-concepts/devices/managed-and-unmanaged-devices#convert-an-unmanaged-device-to-managed).',
+          'Updates a specified [unmanaged device](https://docs.seam.co/core-concepts/devices/managed-and-unmanaged-devices). To convert an unmanaged device to managed, set `is_managed` to `true`.\n\nAn unmanaged device has a limited set of visible properties and a subset of supported events. You cannot control an unmanaged device. Any [access codes](https://docs.seam.co/capability-guides/smart-locks/access-codes/migrating-existing-access-codes) on an unmanaged device are unmanaged. To control an unmanaged device with Seam, [convert it to a managed device](https://docs.seam.co/core-concepts/devices/managed-and-unmanaged-devices#convert-an-unmanaged-device-to-managed).',
         operationId: 'devicesUnmanagedUpdatePatch',
         requestBody: {
           content: {
@@ -59221,7 +59221,7 @@ const openapi: OpenAPISpec = {
       },
       post: {
         description:
-          'Updates a specified [unmanaged device](https://docs.seam.co/latest/core-concepts/devices/managed-and-unmanaged-devices). To convert an unmanaged device to managed, set `is_managed` to `true`.\n\nAn unmanaged device has a limited set of visible properties and a subset of supported events. You cannot control an unmanaged device. Any [access codes](https://docs.seam.co/latest/capability-guides/smart-locks/access-codes/migrating-existing-access-codes) on an unmanaged device are unmanaged. To control an unmanaged device with Seam, [convert it to a managed device](https://docs.seam.co/latest/core-concepts/devices/managed-and-unmanaged-devices#convert-an-unmanaged-device-to-managed).',
+          'Updates a specified [unmanaged device](https://docs.seam.co/core-concepts/devices/managed-and-unmanaged-devices). To convert an unmanaged device to managed, set `is_managed` to `true`.\n\nAn unmanaged device has a limited set of visible properties and a subset of supported events. You cannot control an unmanaged device. Any [access codes](https://docs.seam.co/capability-guides/smart-locks/access-codes/migrating-existing-access-codes) on an unmanaged device are unmanaged. To control an unmanaged device with Seam, [convert it to a managed device](https://docs.seam.co/core-concepts/devices/managed-and-unmanaged-devices#convert-an-unmanaged-device-to-managed).',
         operationId: 'devicesUnmanagedUpdatePost',
         requestBody: {
           content: {
@@ -59291,7 +59291,7 @@ const openapi: OpenAPISpec = {
     '/devices/update': {
       patch: {
         description:
-          "Updates a specified [device](https://docs.seam.co/latest/core-concepts/devices).\n\nYou can add or change [custom metadata](https://docs.seam.co/latest/core-concepts/devices/adding-custom-metadata-to-a-device) for a device, change the device's name, or [convert a managed device to unmanaged](https://docs.seam.co/latest/core-concepts/devices/managed-and-unmanaged-devices).",
+          "Updates a specified [device](https://docs.seam.co/core-concepts/devices).\n\nYou can add or change [custom metadata](https://docs.seam.co/core-concepts/devices/adding-custom-metadata-to-a-device) for a device, change the device's name, or [convert a managed device to unmanaged](https://docs.seam.co/core-concepts/devices/managed-and-unmanaged-devices).",
         operationId: 'devicesUpdatePatch',
         requestBody: {
           content: {
@@ -59307,7 +59307,7 @@ const openapi: OpenAPISpec = {
                       ],
                     },
                     description:
-                      'Custom metadata that you want to associate with the device. Supports up to 50 JSON key:value pairs. [Adding custom metadata to a device](https://docs.seam.co/latest/core-concepts/devices/adding-custom-metadata-to-a-device) enables you to store custom information, like customer details or internal IDs from your application. Then, you can [filter devices by the desired metadata](https://docs.seam.co/latest/core-concepts/devices/filtering-devices-by-custom-metadata).',
+                      'Custom metadata that you want to associate with the device. Supports up to 50 JSON key:value pairs. [Adding custom metadata to a device](https://docs.seam.co/core-concepts/devices/adding-custom-metadata-to-a-device) enables you to store custom information, like customer details or internal IDs from your application. Then, you can [filter devices by the desired metadata](https://docs.seam.co/core-concepts/devices/filtering-devices-by-custom-metadata).',
                     type: 'object',
                   },
                   device_id: {
@@ -59375,7 +59375,7 @@ const openapi: OpenAPISpec = {
       },
       post: {
         description:
-          "Updates a specified [device](https://docs.seam.co/latest/core-concepts/devices).\n\nYou can add or change [custom metadata](https://docs.seam.co/latest/core-concepts/devices/adding-custom-metadata-to-a-device) for a device, change the device's name, or [convert a managed device to unmanaged](https://docs.seam.co/latest/core-concepts/devices/managed-and-unmanaged-devices).",
+          "Updates a specified [device](https://docs.seam.co/core-concepts/devices).\n\nYou can add or change [custom metadata](https://docs.seam.co/core-concepts/devices/adding-custom-metadata-to-a-device) for a device, change the device's name, or [convert a managed device to unmanaged](https://docs.seam.co/core-concepts/devices/managed-and-unmanaged-devices).",
         operationId: 'devicesUpdatePost',
         requestBody: {
           content: {
@@ -59391,7 +59391,7 @@ const openapi: OpenAPISpec = {
                       ],
                     },
                     description:
-                      'Custom metadata that you want to associate with the device. Supports up to 50 JSON key:value pairs. [Adding custom metadata to a device](https://docs.seam.co/latest/core-concepts/devices/adding-custom-metadata-to-a-device) enables you to store custom information, like customer details or internal IDs from your application. Then, you can [filter devices by the desired metadata](https://docs.seam.co/latest/core-concepts/devices/filtering-devices-by-custom-metadata).',
+                      'Custom metadata that you want to associate with the device. Supports up to 50 JSON key:value pairs. [Adding custom metadata to a device](https://docs.seam.co/core-concepts/devices/adding-custom-metadata-to-a-device) enables you to store custom information, like customer details or internal IDs from your application. Then, you can [filter devices by the desired metadata](https://docs.seam.co/core-concepts/devices/filtering-devices-by-custom-metadata).',
                     type: 'object',
                   },
                   device_id: {
@@ -59461,7 +59461,7 @@ const openapi: OpenAPISpec = {
     '/events/get': {
       get: {
         description:
-          'Returns a specified event. This endpoint returns the same event that would be sent to a [webhook](https://docs.seam.co/latest/developer-tools/webhooks), but it enables you to retrieve an event that already took place.',
+          'Returns a specified event. This endpoint returns the same event that would be sent to a [webhook](https://docs.seam.co/developer-tools/webhooks), but it enables you to retrieve an event that already took place.',
         operationId: 'eventsGetGet',
         parameters: [
           {
@@ -59530,7 +59530,7 @@ const openapi: OpenAPISpec = {
       },
       post: {
         description:
-          'Returns a specified event. This endpoint returns the same event that would be sent to a [webhook](https://docs.seam.co/latest/developer-tools/webhooks), but it enables you to retrieve an event that already took place.',
+          'Returns a specified event. This endpoint returns the same event that would be sent to a [webhook](https://docs.seam.co/developer-tools/webhooks), but it enables you to retrieve an event that already took place.',
         operationId: 'eventsGetPost',
         requestBody: {
           content: {
@@ -59598,7 +59598,7 @@ const openapi: OpenAPISpec = {
     '/events/list': {
       get: {
         description:
-          'Returns a list of all events. This endpoint returns the same events that would be sent to a [webhook](https://docs.seam.co/latest/developer-tools/webhooks), but it enables you to filter or see events that already took place.',
+          'Returns a list of all events. This endpoint returns the same events that would be sent to a [webhook](https://docs.seam.co/developer-tools/webhooks), but it enables you to filter or see events that already took place.',
         operationId: 'eventsListGet',
         parameters: [
           {
@@ -60134,7 +60134,7 @@ const openapi: OpenAPISpec = {
       },
       post: {
         description:
-          'Returns a list of all events. This endpoint returns the same events that would be sent to a [webhook](https://docs.seam.co/latest/developer-tools/webhooks), but it enables you to filter or see events that already took place.',
+          'Returns a list of all events. This endpoint returns the same events that would be sent to a [webhook](https://docs.seam.co/developer-tools/webhooks), but it enables you to filter or see events that already took place.',
         operationId: 'eventsListPost',
         requestBody: {
           content: {
@@ -60572,7 +60572,7 @@ const openapi: OpenAPISpec = {
     '/instant_keys/delete': {
       delete: {
         description:
-          'Deletes a specified [Instant Key](https://docs.seam.co/latest/capability-guides/instant-keys).',
+          'Deletes a specified [Instant Key](https://docs.seam.co/capability-guides/instant-keys).',
         operationId: 'instantKeysDeleteDelete',
         parameters: [
           {
@@ -60616,7 +60616,7 @@ const openapi: OpenAPISpec = {
       },
       post: {
         description:
-          'Deletes a specified [Instant Key](https://docs.seam.co/latest/capability-guides/instant-keys).',
+          'Deletes a specified [Instant Key](https://docs.seam.co/capability-guides/instant-keys).',
         operationId: 'instantKeysDeletePost',
         requestBody: {
           content: {
@@ -60668,7 +60668,7 @@ const openapi: OpenAPISpec = {
     '/instant_keys/get': {
       get: {
         description:
-          'Gets an [instant key](https://docs.seam.co/latest/capability-guides/instant-keys).',
+          'Gets an [instant key](https://docs.seam.co/capability-guides/instant-keys).',
         operationId: 'instantKeysGetGet',
         parameters: [
           {
@@ -60724,7 +60724,7 @@ const openapi: OpenAPISpec = {
       },
       post: {
         description:
-          'Gets an [instant key](https://docs.seam.co/latest/capability-guides/instant-keys).',
+          'Gets an [instant key](https://docs.seam.co/capability-guides/instant-keys).',
         operationId: 'instantKeysGetPost',
         requestBody: {
           content: {
@@ -60783,7 +60783,7 @@ const openapi: OpenAPISpec = {
     '/instant_keys/list': {
       get: {
         description:
-          'Returns a list of all [instant keys](https://docs.seam.co/latest/capability-guides/instant-keys).',
+          'Returns a list of all [instant keys](https://docs.seam.co/capability-guides/instant-keys).',
         operationId: 'instantKeysListGet',
         parameters: [
           {
@@ -60834,7 +60834,7 @@ const openapi: OpenAPISpec = {
       },
       post: {
         description:
-          'Returns a list of all [instant keys](https://docs.seam.co/latest/capability-guides/instant-keys).',
+          'Returns a list of all [instant keys](https://docs.seam.co/capability-guides/instant-keys).',
         operationId: 'instantKeysListPost',
         requestBody: {
           content: {
@@ -60892,7 +60892,7 @@ const openapi: OpenAPISpec = {
     '/locks/configure_auto_lock': {
       post: {
         description:
-          'Configures the auto-lock setting for a specified [lock](https://docs.seam.co/latest/capability-guides/smart-locks).',
+          'Configures the auto-lock setting for a specified [lock](https://docs.seam.co/capability-guides/smart-locks).',
         operationId: 'locksConfigureAutoLockPost',
         requestBody: {
           content: {
@@ -60964,7 +60964,7 @@ const openapi: OpenAPISpec = {
     '/locks/get': {
       get: {
         description:
-          'Returns a specified [lock](https://docs.seam.co/latest/capability-guides/smart-locks).',
+          'Returns a specified [lock](https://docs.seam.co/capability-guides/smart-locks).',
         operationId: 'locksGetGet',
         parameters: [
           {
@@ -61022,7 +61022,7 @@ const openapi: OpenAPISpec = {
       },
       post: {
         description:
-          'Returns a specified [lock](https://docs.seam.co/latest/capability-guides/smart-locks).',
+          'Returns a specified [lock](https://docs.seam.co/capability-guides/smart-locks).',
         operationId: 'locksGetPost',
         requestBody: {
           content: {
@@ -61083,7 +61083,7 @@ const openapi: OpenAPISpec = {
     '/locks/list': {
       get: {
         description:
-          'Returns a list of all [locks](https://docs.seam.co/latest/capability-guides/smart-locks).',
+          'Returns a list of all [locks](https://docs.seam.co/capability-guides/smart-locks).',
         operationId: 'locksListGet',
         parameters: [
           {
@@ -61292,7 +61292,7 @@ const openapi: OpenAPISpec = {
                 oneOf: [{ type: 'string' }, { type: 'boolean' }],
               },
               description:
-                'Set of key:value [custom metadata](https://docs.seam.co/latest/core-concepts/devices/adding-custom-metadata-to-a-device) pairs for which you want to list devices.',
+                'Set of key:value [custom metadata](https://docs.seam.co/core-concepts/devices/adding-custom-metadata-to-a-device) pairs for which you want to list devices.',
               type: 'object',
             },
           },
@@ -61446,7 +61446,7 @@ const openapi: OpenAPISpec = {
       },
       post: {
         description:
-          'Returns a list of all [locks](https://docs.seam.co/latest/capability-guides/smart-locks).',
+          'Returns a list of all [locks](https://docs.seam.co/capability-guides/smart-locks).',
         operationId: 'locksListPost',
         requestBody: {
           content: {
@@ -61482,7 +61482,7 @@ const openapi: OpenAPISpec = {
                       oneOf: [{ type: 'string' }, { type: 'boolean' }],
                     },
                     description:
-                      'Set of key:value [custom metadata](https://docs.seam.co/latest/core-concepts/devices/adding-custom-metadata-to-a-device) pairs for which you want to list devices.',
+                      'Set of key:value [custom metadata](https://docs.seam.co/core-concepts/devices/adding-custom-metadata-to-a-device) pairs for which you want to list devices.',
                     type: 'object',
                   },
                   customer_key: {
@@ -61752,7 +61752,7 @@ const openapi: OpenAPISpec = {
     '/locks/lock_door': {
       post: {
         description:
-          'Locks a [lock](https://docs.seam.co/latest/capability-guides/smart-locks). See also [Locking and Unlocking Smart Locks](https://docs.seam.co/latest/capability-guides/smart-locks/lock-and-unlock).',
+          'Locks a [lock](https://docs.seam.co/capability-guides/smart-locks). See also [Locking and Unlocking Smart Locks](https://docs.seam.co/capability-guides/smart-locks/lock-and-unlock).',
         operationId: 'locksLockDoorPost',
         requestBody: {
           content: {
@@ -61817,7 +61817,7 @@ const openapi: OpenAPISpec = {
     '/locks/simulate/keypad_code_entry': {
       post: {
         description:
-          'Simulates the entry of a code on a keypad. You can only perform this action for [August](https://docs.seam.co/latest/device-and-system-integration-guides/august-locks) devices within [sandbox workspaces](https://docs.seam.co/latest/core-concepts/workspaces#sandbox-workspaces).',
+          'Simulates the entry of a code on a keypad. You can only perform this action for [August](https://docs.seam.co/device-and-system-integration-guides/august-locks) devices within [sandbox workspaces](https://docs.seam.co/core-concepts/workspaces#sandbox-workspaces).',
         operationId: 'locksSimulateKeypadCodeEntryPost',
         requestBody: {
           content: {
@@ -61881,7 +61881,7 @@ const openapi: OpenAPISpec = {
     '/locks/simulate/manual_lock_via_keypad': {
       post: {
         description:
-          'Simulates a manual lock action using a keypad. You can only perform this action for [August](https://docs.seam.co/latest/device-and-system-integration-guides/august-locks) devices within [sandbox workspaces](https://docs.seam.co/latest/core-concepts/workspaces#sandbox-workspaces).',
+          'Simulates a manual lock action using a keypad. You can only perform this action for [August](https://docs.seam.co/device-and-system-integration-guides/august-locks) devices within [sandbox workspaces](https://docs.seam.co/core-concepts/workspaces#sandbox-workspaces).',
         operationId: 'locksSimulateManualLockViaKeypadPost',
         requestBody: {
           content: {
@@ -61940,7 +61940,7 @@ const openapi: OpenAPISpec = {
     '/locks/unlock_door': {
       post: {
         description:
-          'Unlocks a [lock](https://docs.seam.co/latest/capability-guides/smart-locks). See also [Locking and Unlocking Smart Locks](https://docs.seam.co/latest/capability-guides/smart-locks/lock-and-unlock).',
+          'Unlocks a [lock](https://docs.seam.co/capability-guides/smart-locks). See also [Locking and Unlocking Smart Locks](https://docs.seam.co/capability-guides/smart-locks/lock-and-unlock).',
         operationId: 'locksUnlockDoorPost',
         requestBody: {
           content: {
@@ -62005,7 +62005,7 @@ const openapi: OpenAPISpec = {
     '/noise_sensors/list': {
       get: {
         description:
-          'Returns a list of all [noise sensors](https://docs.seam.co/latest/capability-guides/noise-sensors).',
+          'Returns a list of all [noise sensors](https://docs.seam.co/capability-guides/noise-sensors).',
         operationId: 'noiseSensorsListGet',
         parameters: [
           {
@@ -62128,7 +62128,7 @@ const openapi: OpenAPISpec = {
                 oneOf: [{ type: 'string' }, { type: 'boolean' }],
               },
               description:
-                'Set of key:value [custom metadata](https://docs.seam.co/latest/core-concepts/devices/adding-custom-metadata-to-a-device) pairs for which you want to list devices.',
+                'Set of key:value [custom metadata](https://docs.seam.co/core-concepts/devices/adding-custom-metadata-to-a-device) pairs for which you want to list devices.',
               type: 'object',
             },
           },
@@ -62282,7 +62282,7 @@ const openapi: OpenAPISpec = {
       },
       post: {
         description:
-          'Returns a list of all [noise sensors](https://docs.seam.co/latest/capability-guides/noise-sensors).',
+          'Returns a list of all [noise sensors](https://docs.seam.co/capability-guides/noise-sensors).',
         operationId: 'noiseSensorsListPost',
         requestBody: {
           content: {
@@ -62318,7 +62318,7 @@ const openapi: OpenAPISpec = {
                       oneOf: [{ type: 'string' }, { type: 'boolean' }],
                     },
                     description:
-                      'Set of key:value [custom metadata](https://docs.seam.co/latest/core-concepts/devices/adding-custom-metadata-to-a-device) pairs for which you want to list devices.',
+                      'Set of key:value [custom metadata](https://docs.seam.co/core-concepts/devices/adding-custom-metadata-to-a-device) pairs for which you want to list devices.',
                     type: 'object',
                   },
                   customer_key: {
@@ -62499,7 +62499,7 @@ const openapi: OpenAPISpec = {
     '/noise_sensors/noise_thresholds/create': {
       post: {
         description:
-          'Creates a new [noise threshold](https://docs.seam.co/latest/capability-guides/noise-sensors/configure-noise-threshold-settings) for a [noise sensor](https://docs.seam.co/latest/capability-guides/noise-sensors). Thresholds represent the limits of noise tolerated at a property, which can be customized for each hour of the day. Each device has its own default thresholds, but you can use the Seam API to modify them.',
+          'Creates a new [noise threshold](https://docs.seam.co/capability-guides/noise-sensors/configure-noise-threshold-settings) for a [noise sensor](https://docs.seam.co/capability-guides/noise-sensors). Thresholds represent the limits of noise tolerated at a property, which can be customized for each hour of the day. Each device has its own default thresholds, but you can use the Seam API to modify them.',
         operationId: 'noiseSensorsNoiseThresholdsCreatePost',
         requestBody: {
           content: {
@@ -62529,7 +62529,7 @@ const openapi: OpenAPISpec = {
                   },
                   noise_threshold_nrs: {
                     description:
-                      'Noise level in Noiseaware Noise Risk Score (NRS) for the new noise threshold. This parameter is only relevant for [Noiseaware sensors](https://docs.seam.co/latest/device-and-system-integration-guides/noiseaware-sensors).',
+                      'Noise level in Noiseaware Noise Risk Score (NRS) for the new noise threshold. This parameter is only relevant for [Noiseaware sensors](https://docs.seam.co/device-and-system-integration-guides/noiseaware-sensors).',
                     format: 'float',
                     type: 'number',
                   },
@@ -62592,7 +62592,7 @@ const openapi: OpenAPISpec = {
     '/noise_sensors/noise_thresholds/delete': {
       delete: {
         description:
-          'Deletes a [noise threshold](https://docs.seam.co/latest/capability-guides/noise-sensors/configure-noise-threshold-settings) from a [noise sensor](https://docs.seam.co/latest/capability-guides/noise-sensors).',
+          'Deletes a [noise threshold](https://docs.seam.co/capability-guides/noise-sensors/configure-noise-threshold-settings) from a [noise sensor](https://docs.seam.co/capability-guides/noise-sensors).',
         operationId: 'noiseSensorsNoiseThresholdsDeleteDelete',
         requestBody: {
           content: {
@@ -62659,7 +62659,7 @@ const openapi: OpenAPISpec = {
       },
       post: {
         description:
-          'Deletes a [noise threshold](https://docs.seam.co/latest/capability-guides/noise-sensors/configure-noise-threshold-settings) from a [noise sensor](https://docs.seam.co/latest/capability-guides/noise-sensors).',
+          'Deletes a [noise threshold](https://docs.seam.co/capability-guides/noise-sensors/configure-noise-threshold-settings) from a [noise sensor](https://docs.seam.co/capability-guides/noise-sensors).',
         operationId: 'noiseSensorsNoiseThresholdsDeletePost',
         requestBody: {
           content: {
@@ -62728,7 +62728,7 @@ const openapi: OpenAPISpec = {
     '/noise_sensors/noise_thresholds/get': {
       get: {
         description:
-          'Returns a specified [noise threshold](https://docs.seam.co/latest/capability-guides/noise-sensors/configure-noise-threshold-settings) for a [noise sensor](https://docs.seam.co/latest/capability-guides/noise-sensors).',
+          'Returns a specified [noise threshold](https://docs.seam.co/capability-guides/noise-sensors/configure-noise-threshold-settings) for a [noise sensor](https://docs.seam.co/capability-guides/noise-sensors).',
         operationId: 'noiseSensorsNoiseThresholdsGetGet',
         parameters: [
           {
@@ -62778,7 +62778,7 @@ const openapi: OpenAPISpec = {
       },
       post: {
         description:
-          'Returns a specified [noise threshold](https://docs.seam.co/latest/capability-guides/noise-sensors/configure-noise-threshold-settings) for a [noise sensor](https://docs.seam.co/latest/capability-guides/noise-sensors).',
+          'Returns a specified [noise threshold](https://docs.seam.co/capability-guides/noise-sensors/configure-noise-threshold-settings) for a [noise sensor](https://docs.seam.co/capability-guides/noise-sensors).',
         operationId: 'noiseSensorsNoiseThresholdsGetPost',
         requestBody: {
           content: {
@@ -62836,7 +62836,7 @@ const openapi: OpenAPISpec = {
     '/noise_sensors/noise_thresholds/list': {
       get: {
         description:
-          'Returns a list of all [noise thresholds](https://docs.seam.co/latest/capability-guides/noise-sensors/configure-noise-threshold-settings) for a [noise sensor](https://docs.seam.co/latest/capability-guides/noise-sensors).',
+          'Returns a list of all [noise thresholds](https://docs.seam.co/capability-guides/noise-sensors/configure-noise-threshold-settings) for a [noise sensor](https://docs.seam.co/capability-guides/noise-sensors).',
         operationId: 'noiseSensorsNoiseThresholdsListGet',
         parameters: [
           {
@@ -62901,7 +62901,7 @@ const openapi: OpenAPISpec = {
       },
       post: {
         description:
-          'Returns a list of all [noise thresholds](https://docs.seam.co/latest/capability-guides/noise-sensors/configure-noise-threshold-settings) for a [noise sensor](https://docs.seam.co/latest/capability-guides/noise-sensors).',
+          'Returns a list of all [noise thresholds](https://docs.seam.co/capability-guides/noise-sensors/configure-noise-threshold-settings) for a [noise sensor](https://docs.seam.co/capability-guides/noise-sensors).',
         operationId: 'noiseSensorsNoiseThresholdsListPost',
         requestBody: {
           content: {
@@ -62968,7 +62968,7 @@ const openapi: OpenAPISpec = {
     '/noise_sensors/noise_thresholds/update': {
       patch: {
         description:
-          'Updates a [noise threshold](https://docs.seam.co/latest/capability-guides/noise-sensors/configure-noise-threshold-settings) for a [noise sensor](https://docs.seam.co/latest/capability-guides/noise-sensors).',
+          'Updates a [noise threshold](https://docs.seam.co/capability-guides/noise-sensors/configure-noise-threshold-settings) for a [noise sensor](https://docs.seam.co/capability-guides/noise-sensors).',
         operationId: 'noiseSensorsNoiseThresholdsUpdatePatch',
         requestBody: {
           content: {
@@ -63005,7 +63005,7 @@ const openapi: OpenAPISpec = {
                   },
                   noise_threshold_nrs: {
                     description:
-                      'Noise level in Noiseaware Noise Risk Score (NRS) for the noise threshold. This parameter is only relevant for [Noiseaware sensors](https://docs.seam.co/latest/device-and-system-integration-guides/noiseaware-sensors).',
+                      'Noise level in Noiseaware Noise Risk Score (NRS) for the noise threshold. This parameter is only relevant for [Noiseaware sensors](https://docs.seam.co/device-and-system-integration-guides/noiseaware-sensors).',
                     format: 'float',
                     type: 'number',
                   },
@@ -63062,7 +63062,7 @@ const openapi: OpenAPISpec = {
       },
       post: {
         description:
-          'Updates a [noise threshold](https://docs.seam.co/latest/capability-guides/noise-sensors/configure-noise-threshold-settings) for a [noise sensor](https://docs.seam.co/latest/capability-guides/noise-sensors).',
+          'Updates a [noise threshold](https://docs.seam.co/capability-guides/noise-sensors/configure-noise-threshold-settings) for a [noise sensor](https://docs.seam.co/capability-guides/noise-sensors).',
         operationId: 'noiseSensorsNoiseThresholdsUpdatePost',
         requestBody: {
           content: {
@@ -63099,7 +63099,7 @@ const openapi: OpenAPISpec = {
                   },
                   noise_threshold_nrs: {
                     description:
-                      'Noise level in Noiseaware Noise Risk Score (NRS) for the noise threshold. This parameter is only relevant for [Noiseaware sensors](https://docs.seam.co/latest/device-and-system-integration-guides/noiseaware-sensors).',
+                      'Noise level in Noiseaware Noise Risk Score (NRS) for the noise threshold. This parameter is only relevant for [Noiseaware sensors](https://docs.seam.co/device-and-system-integration-guides/noiseaware-sensors).',
                     format: 'float',
                     type: 'number',
                   },
@@ -63156,7 +63156,7 @@ const openapi: OpenAPISpec = {
       },
       put: {
         description:
-          'Updates a [noise threshold](https://docs.seam.co/latest/capability-guides/noise-sensors/configure-noise-threshold-settings) for a [noise sensor](https://docs.seam.co/latest/capability-guides/noise-sensors).',
+          'Updates a [noise threshold](https://docs.seam.co/capability-guides/noise-sensors/configure-noise-threshold-settings) for a [noise sensor](https://docs.seam.co/capability-guides/noise-sensors).',
         operationId: 'noiseSensorsNoiseThresholdsUpdatePut',
         requestBody: {
           content: {
@@ -63193,7 +63193,7 @@ const openapi: OpenAPISpec = {
                   },
                   noise_threshold_nrs: {
                     description:
-                      'Noise level in Noiseaware Noise Risk Score (NRS) for the noise threshold. This parameter is only relevant for [Noiseaware sensors](https://docs.seam.co/latest/device-and-system-integration-guides/noiseaware-sensors).',
+                      'Noise level in Noiseaware Noise Risk Score (NRS) for the noise threshold. This parameter is only relevant for [Noiseaware sensors](https://docs.seam.co/device-and-system-integration-guides/noiseaware-sensors).',
                     format: 'float',
                     type: 'number',
                   },
@@ -63252,7 +63252,7 @@ const openapi: OpenAPISpec = {
     '/noise_sensors/simulate/trigger_noise_threshold': {
       post: {
         description:
-          'Simulates the triggering of a [noise threshold](https://docs.seam.co/latest/capability-guides/noise-sensors/configure-noise-threshold-settings) for a [noise sensor](https://docs.seam.co/latest/capability-guides/noise-sensors) in a [sandbox workspace](https://docs.seam.co/latest/core-concepts/workspaces#sandbox-workspaces).',
+          'Simulates the triggering of a [noise threshold](https://docs.seam.co/capability-guides/noise-sensors/configure-noise-threshold-settings) for a [noise sensor](https://docs.seam.co/capability-guides/noise-sensors) in a [sandbox workspace](https://docs.seam.co/core-concepts/workspaces#sandbox-workspaces).',
         operationId: 'noiseSensorsSimulateTriggerNoiseThresholdPost',
         requestBody: {
           content: {
@@ -63304,7 +63304,7 @@ const openapi: OpenAPISpec = {
     '/phones/deactivate': {
       delete: {
         description:
-          'Deactivates a phone, which is useful, for example, if a user has lost their phone. For more information, see [App User Lost Phone Process](https://docs.seam.co/latest/capability-guides/mobile-access/managing-phones-for-a-user-identity#app-user-lost-phone-process).',
+          'Deactivates a phone, which is useful, for example, if a user has lost their phone. For more information, see [App User Lost Phone Process](https://docs.seam.co/capability-guides/mobile-access/managing-phones-for-a-user-identity#app-user-lost-phone-process).',
         operationId: 'phonesDeactivateDelete',
         requestBody: {
           content: {
@@ -63354,7 +63354,7 @@ const openapi: OpenAPISpec = {
       },
       post: {
         description:
-          'Deactivates a phone, which is useful, for example, if a user has lost their phone. For more information, see [App User Lost Phone Process](https://docs.seam.co/latest/capability-guides/mobile-access/managing-phones-for-a-user-identity#app-user-lost-phone-process).',
+          'Deactivates a phone, which is useful, for example, if a user has lost their phone. For more information, see [App User Lost Phone Process](https://docs.seam.co/capability-guides/mobile-access/managing-phones-for-a-user-identity#app-user-lost-phone-process).',
         operationId: 'phonesDeactivatePost',
         requestBody: {
           content: {
@@ -63406,7 +63406,7 @@ const openapi: OpenAPISpec = {
     '/phones/get': {
       get: {
         description:
-          'Returns a specified [phone](https://docs.seam.co/latest/capability-guides/mobile-access/managing-phones-for-a-user-identity).',
+          'Returns a specified [phone](https://docs.seam.co/capability-guides/mobile-access/managing-phones-for-a-user-identity).',
         operationId: 'phonesGetGet',
         parameters: [
           {
@@ -63454,7 +63454,7 @@ const openapi: OpenAPISpec = {
       },
       post: {
         description:
-          'Returns a specified [phone](https://docs.seam.co/latest/capability-guides/mobile-access/managing-phones-for-a-user-identity).',
+          'Returns a specified [phone](https://docs.seam.co/capability-guides/mobile-access/managing-phones-for-a-user-identity).',
         operationId: 'phonesGetPost',
         requestBody: {
           content: {
@@ -63509,7 +63509,7 @@ const openapi: OpenAPISpec = {
     '/phones/list': {
       get: {
         description:
-          'Returns a list of all [phones](https://docs.seam.co/latest/capability-guides/mobile-access/managing-phones-for-a-user-identity). To filter the list of returned phones by a specific owner user identity or credential, include the `owner_user_identity_id` or `acs_credential_id`, respectively, in the request body.',
+          'Returns a list of all [phones](https://docs.seam.co/capability-guides/mobile-access/managing-phones-for-a-user-identity). To filter the list of returned phones by a specific owner user identity or credential, include the `owner_user_identity_id` or `acs_credential_id`, respectively, in the request body.',
         operationId: 'phonesListGet',
         parameters: [
           {
@@ -63527,7 +63527,7 @@ const openapi: OpenAPISpec = {
             name: 'acs_credential_id',
             schema: {
               description:
-                'ID of the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials) by which you want to filter the list of returned phones.',
+                'ID of the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials) by which you want to filter the list of returned phones.',
               format: 'uuid',
               type: 'string',
             },
@@ -63570,7 +63570,7 @@ const openapi: OpenAPISpec = {
       },
       post: {
         description:
-          'Returns a list of all [phones](https://docs.seam.co/latest/capability-guides/mobile-access/managing-phones-for-a-user-identity). To filter the list of returned phones by a specific owner user identity or credential, include the `owner_user_identity_id` or `acs_credential_id`, respectively, in the request body.',
+          'Returns a list of all [phones](https://docs.seam.co/capability-guides/mobile-access/managing-phones-for-a-user-identity). To filter the list of returned phones by a specific owner user identity or credential, include the `owner_user_identity_id` or `acs_credential_id`, respectively, in the request body.',
         operationId: 'phonesListPost',
         requestBody: {
           content: {
@@ -63579,7 +63579,7 @@ const openapi: OpenAPISpec = {
                 properties: {
                   acs_credential_id: {
                     description:
-                      'ID of the [credential](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials) by which you want to filter the list of returned phones.',
+                      'ID of the [credential](https://docs.seam.co/capability-guides/access-systems/managing-credentials) by which you want to filter the list of returned phones.',
                     format: 'uuid',
                     type: 'string',
                   },
@@ -63634,7 +63634,7 @@ const openapi: OpenAPISpec = {
     '/phones/simulate/create_sandbox_phone': {
       post: {
         description:
-          'Creates a new simulated phone in a [sandbox workspace](https://docs.seam.co/latest/core-concepts/workspaces#sandbox-workspaces). See also [Creating a Simulated Phone for a User Identity](https://docs.seam.co/latest/capability-guides/mobile-access/developing-in-a-sandbox-workspace#creating-a-simulated-phone-for-a-user-identity).',
+          'Creates a new simulated phone in a [sandbox workspace](https://docs.seam.co/core-concepts/workspaces#sandbox-workspaces). See also [Creating a Simulated Phone for a User Identity](https://docs.seam.co/capability-guides/mobile-access/developing-in-a-sandbox-workspace#creating-a-simulated-phone-for-a-user-identity).',
         operationId: 'phonesSimulateCreateSandboxPhonePost',
         requestBody: {
           content: {
@@ -63773,7 +63773,7 @@ const openapi: OpenAPISpec = {
     '/seam/bridge/v1/bridge_client_sessions/create': {
       post: {
         description:
-          'Creates a new [Seam Bridge](https://docs.seam.co/latest/capability-guides/seam-bridge) client session.',
+          'Creates a new [Seam Bridge](https://docs.seam.co/capability-guides/seam-bridge) client session.',
         operationId: 'seamBridgeV1BridgeClientSessionsCreatePost',
         requestBody: {
           content: {
@@ -63846,7 +63846,7 @@ const openapi: OpenAPISpec = {
     '/seam/bridge/v1/bridge_client_sessions/get': {
       get: {
         description:
-          'Returns the [Seam Bridge](https://docs.seam.co/latest/capability-guides/seam-bridge) client session associated with the client session token used for authentication.',
+          'Returns the [Seam Bridge](https://docs.seam.co/capability-guides/seam-bridge) client session associated with the client session token used for authentication.',
         operationId: 'seamBridgeV1BridgeClientSessionsGetGet',
         responses: {
           200: {
@@ -63886,7 +63886,7 @@ const openapi: OpenAPISpec = {
       },
       post: {
         description:
-          'Returns the [Seam Bridge](https://docs.seam.co/latest/capability-guides/seam-bridge) client session associated with the client session token used for authentication.',
+          'Returns the [Seam Bridge](https://docs.seam.co/capability-guides/seam-bridge) client session associated with the client session token used for authentication.',
         operationId: 'seamBridgeV1BridgeClientSessionsGetPost',
         responses: {
           200: {
@@ -63928,7 +63928,7 @@ const openapi: OpenAPISpec = {
     '/seam/bridge/v1/bridge_client_sessions/refresh_tailscale_auth_key': {
       post: {
         description:
-          'Refreshes the Tailscale auth key for the [Seam Bridge](https://docs.seam.co/latest/capability-guides/seam-bridge) client session associated with the client session token used for authentication.',
+          'Refreshes the Tailscale auth key for the [Seam Bridge](https://docs.seam.co/capability-guides/seam-bridge) client session associated with the client session token used for authentication.',
         operationId:
           'seamBridgeV1BridgeClientSessionsRefreshTailscaleAuthKeyPost',
         responses: {
@@ -63973,7 +63973,7 @@ const openapi: OpenAPISpec = {
     '/seam/bridge/v1/bridge_client_sessions/refresh_telemetry_token': {
       post: {
         description:
-          'Returns the [Seam Bridge](https://docs.seam.co/latest/capability-guides/seam-bridge) client session associated with the client session token used for authentication and refreshed telemetry token.',
+          'Returns the [Seam Bridge](https://docs.seam.co/capability-guides/seam-bridge) client session associated with the client session token used for authentication and refreshed telemetry token.',
         operationId:
           'seamBridgeV1BridgeClientSessionsRefreshTelemetryTokenPost',
         responses: {
@@ -64018,7 +64018,7 @@ const openapi: OpenAPISpec = {
     '/seam/bridge/v1/bridge_client_sessions/regenerate_pairing_code': {
       post: {
         description:
-          'Generate a new pairing code and return the updated [Seam Bridge](https://docs.seam.co/latest/capability-guides/seam-bridge) client session.',
+          'Generate a new pairing code and return the updated [Seam Bridge](https://docs.seam.co/capability-guides/seam-bridge) client session.',
         operationId:
           'seamBridgeV1BridgeClientSessionsRegeneratePairingCodePost',
         responses: {
@@ -64062,7 +64062,7 @@ const openapi: OpenAPISpec = {
     '/seam/bridge/v1/bridge_client_sessions/report_status': {
       post: {
         description:
-          'Report the status of a [Seam Bridge](https://docs.seam.co/latest/capability-guides/seam-bridge) client.',
+          'Report the status of a [Seam Bridge](https://docs.seam.co/capability-guides/seam-bridge) client.',
         operationId: 'seamBridgeV1BridgeClientSessionsReportStatusPost',
         requestBody: {
           content: {
@@ -64120,7 +64120,7 @@ const openapi: OpenAPISpec = {
     '/seam/bridge/v1/bridge_connected_systems/list': {
       get: {
         description:
-          'Returns the [Seam Bridge](https://docs.seam.co/latest/capability-guides/seam-bridge)-connected systems associated with the client session token used for authentication.',
+          'Returns the [Seam Bridge](https://docs.seam.co/capability-guides/seam-bridge)-connected systems associated with the client session token used for authentication.',
         operationId: 'seamBridgeV1BridgeConnectedSystemsListGet',
         responses: {
           200: {
@@ -64163,7 +64163,7 @@ const openapi: OpenAPISpec = {
       },
       post: {
         description:
-          'Returns the [Seam Bridge](https://docs.seam.co/latest/capability-guides/seam-bridge)-connected systems associated with the client session token used for authentication.',
+          'Returns the [Seam Bridge](https://docs.seam.co/capability-guides/seam-bridge)-connected systems associated with the client session token used for authentication.',
         operationId: 'seamBridgeV1BridgeConnectedSystemsListPost',
         responses: {
           200: {
@@ -64208,7 +64208,7 @@ const openapi: OpenAPISpec = {
     '/seam/connect_webview/v1/get_current_pane': {
       get: {
         description:
-          'Returns the current render pane for a [Connect Webview](https://docs.seam.co/latest/core-concepts/connect-webviews).',
+          'Returns the current render pane for a [Connect Webview](https://docs.seam.co/core-concepts/connect-webviews).',
         operationId: 'seamConnectWebviewV1GetCurrentPaneGet',
         parameters: [
           {
@@ -64250,7 +64250,7 @@ const openapi: OpenAPISpec = {
       },
       post: {
         description:
-          'Returns the current render pane for a [Connect Webview](https://docs.seam.co/latest/core-concepts/connect-webviews).',
+          'Returns the current render pane for a [Connect Webview](https://docs.seam.co/core-concepts/connect-webviews).',
         operationId: 'seamConnectWebviewV1GetCurrentPanePost',
         requestBody: {
           content: {
@@ -64299,7 +64299,7 @@ const openapi: OpenAPISpec = {
     '/seam/connect_webview/v1/reset': {
       post: {
         description:
-          'Resets an errored [Connect Webview](https://docs.seam.co/latest/core-concepts/connect-webviews) so its login flow can be retried.',
+          'Resets an errored [Connect Webview](https://docs.seam.co/core-concepts/connect-webviews) so its login flow can be retried.',
         operationId: 'seamConnectWebviewV1ResetPost',
         requestBody: {
           content: {
@@ -64345,7 +64345,7 @@ const openapi: OpenAPISpec = {
     '/seam/connect_webview/v1/submit': {
       post: {
         description:
-          'Submits pane arguments to advance a [Connect Webview](https://docs.seam.co/latest/core-concepts/connect-webviews) login state machine.',
+          'Submits pane arguments to advance a [Connect Webview](https://docs.seam.co/core-concepts/connect-webviews) login state machine.',
         operationId: 'seamConnectWebviewV1SubmitPost',
         requestBody: {
           content: {
@@ -75707,7 +75707,7 @@ const openapi: OpenAPISpec = {
     '/seam/mobile_sdk/v1/acs/credentials/list': {
       get: {
         description:
-          'Returns a list of all [credentials](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials).',
+          'Returns a list of all [credentials](https://docs.seam.co/capability-guides/access-systems/managing-credentials).',
         operationId: 'seamMobileSdkV1AcsCredentialsListGet',
         parameters: [],
         responses: {
@@ -75750,7 +75750,7 @@ const openapi: OpenAPISpec = {
       },
       post: {
         description:
-          'Returns a list of all [credentials](https://docs.seam.co/latest/capability-guides/access-systems/managing-credentials).',
+          'Returns a list of all [credentials](https://docs.seam.co/capability-guides/access-systems/managing-credentials).',
         operationId: 'seamMobileSdkV1AcsCredentialsListPost',
         requestBody: {
           content: {
@@ -76193,7 +76193,7 @@ const openapi: OpenAPISpec = {
     '/spaces/add_acs_entrances': {
       post: {
         description:
-          'Adds [entrances](https://docs.seam.co/latest/capability-guides/access-systems/retrieving-entrance-details) to a specific space.',
+          'Adds [entrances](https://docs.seam.co/capability-guides/access-systems/retrieving-entrance-details) to a specific space.',
         operationId: 'spacesAddAcsEntrancesPost',
         requestBody: {
           content: {
@@ -76251,7 +76251,7 @@ const openapi: OpenAPISpec = {
       },
       put: {
         description:
-          'Adds [entrances](https://docs.seam.co/latest/capability-guides/access-systems/retrieving-entrance-details) to a specific space.',
+          'Adds [entrances](https://docs.seam.co/capability-guides/access-systems/retrieving-entrance-details) to a specific space.',
         operationId: 'spacesAddAcsEntrancesPut',
         requestBody: {
           content: {
@@ -76311,7 +76311,7 @@ const openapi: OpenAPISpec = {
     '/spaces/add_connected_account': {
       post: {
         description:
-          'Adds a [connected account](https://docs.seam.co/latest/core-concepts/connected-accounts) to a specific space.',
+          'Adds a [connected account](https://docs.seam.co/core-concepts/connected-accounts) to a specific space.',
         operationId: 'spacesAddConnectedAccountPost',
         requestBody: {
           content: {
@@ -76368,7 +76368,7 @@ const openapi: OpenAPISpec = {
       },
       put: {
         description:
-          'Adds a [connected account](https://docs.seam.co/latest/core-concepts/connected-accounts) to a specific space.',
+          'Adds a [connected account](https://docs.seam.co/core-concepts/connected-accounts) to a specific space.',
         operationId: 'spacesAddConnectedAccountPut',
         requestBody: {
           content: {
@@ -77311,7 +77311,7 @@ const openapi: OpenAPISpec = {
     '/spaces/remove_acs_entrances': {
       delete: {
         description:
-          'Removes [entrances](https://docs.seam.co/latest/capability-guides/access-systems/retrieving-entrance-details) from a specific space.',
+          'Removes [entrances](https://docs.seam.co/capability-guides/access-systems/retrieving-entrance-details) from a specific space.',
         operationId: 'spacesRemoveAcsEntrancesDelete',
         parameters: [
           {
@@ -77368,7 +77368,7 @@ const openapi: OpenAPISpec = {
       },
       post: {
         description:
-          'Removes [entrances](https://docs.seam.co/latest/capability-guides/access-systems/retrieving-entrance-details) from a specific space.',
+          'Removes [entrances](https://docs.seam.co/capability-guides/access-systems/retrieving-entrance-details) from a specific space.',
         operationId: 'spacesRemoveAcsEntrancesPost',
         requestBody: {
           content: {
@@ -77427,7 +77427,7 @@ const openapi: OpenAPISpec = {
     '/spaces/remove_connected_account': {
       delete: {
         description:
-          'Removes a [connected account](https://docs.seam.co/latest/core-concepts/connected-accounts) from a specific space.',
+          'Removes a [connected account](https://docs.seam.co/core-concepts/connected-accounts) from a specific space.',
         operationId: 'spacesRemoveConnectedAccountDelete',
         parameters: [
           {
@@ -77484,7 +77484,7 @@ const openapi: OpenAPISpec = {
       },
       post: {
         description:
-          'Removes a [connected account](https://docs.seam.co/latest/core-concepts/connected-accounts) from a specific space.',
+          'Removes a [connected account](https://docs.seam.co/core-concepts/connected-accounts) from a specific space.',
         operationId: 'spacesRemoveConnectedAccountPost',
         requestBody: {
           content: {
@@ -77865,7 +77865,7 @@ const openapi: OpenAPISpec = {
     '/thermostats/activate_climate_preset': {
       post: {
         description:
-          'Activates a specified [climate preset](https://docs.seam.co/latest/capability-guides/thermostats/creating-and-managing-climate-presets) for a specified [thermostat](https://docs.seam.co/latest/capability-guides/thermostats).',
+          'Activates a specified [climate preset](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-climate-presets) for a specified [thermostat](https://docs.seam.co/capability-guides/thermostats).',
         operationId: 'thermostatsActivateClimatePresetPost',
         requestBody: {
           content: {
@@ -77929,7 +77929,7 @@ const openapi: OpenAPISpec = {
     '/thermostats/cool': {
       post: {
         description:
-          'Sets a specified [thermostat](https://docs.seam.co/latest/capability-guides/thermostats) to [cool mode](https://docs.seam.co/latest/capability-guides/thermostats/configure-current-climate-settings).',
+          'Sets a specified [thermostat](https://docs.seam.co/capability-guides/thermostats) to [cool mode](https://docs.seam.co/capability-guides/thermostats/configure-current-climate-settings).',
         operationId: 'thermostatsCoolPost',
         requestBody: {
           content: {
@@ -77938,13 +77938,13 @@ const openapi: OpenAPISpec = {
                 properties: {
                   cooling_set_point_celsius: {
                     description:
-                      '[Cooling set point](https://docs.seam.co/latest/capability-guides/thermostats/understanding-thermostat-concepts/set-points) in °C that you want to set for the thermostat. You must set one of the `cooling_set_point` parameters.',
+                      '[Cooling set point](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/set-points) in °C that you want to set for the thermostat. You must set one of the `cooling_set_point` parameters.',
                     format: 'float',
                     type: 'number',
                   },
                   cooling_set_point_fahrenheit: {
                     description:
-                      '[Cooling set point](https://docs.seam.co/latest/capability-guides/thermostats/understanding-thermostat-concepts/set-points) in °F that you want to set for the thermostat. You must set one of the `cooling_set_point` parameters.',
+                      '[Cooling set point](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/set-points) in °F that you want to set for the thermostat. You must set one of the `cooling_set_point` parameters.',
                     format: 'float',
                     type: 'number',
                   },
@@ -78006,7 +78006,7 @@ const openapi: OpenAPISpec = {
     '/thermostats/create_climate_preset': {
       post: {
         description:
-          'Creates a [climate preset](https://docs.seam.co/latest/capability-guides/thermostats/creating-and-managing-climate-presets) for a specified [thermostat](https://docs.seam.co/latest/capability-guides/thermostats).',
+          'Creates a [climate preset](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-climate-presets) for a specified [thermostat](https://docs.seam.co/capability-guides/thermostats).',
         operationId: 'thermostatsCreateClimatePresetPost',
         requestBody: {
           content: {
@@ -78015,7 +78015,7 @@ const openapi: OpenAPISpec = {
                 properties: {
                   climate_preset_key: {
                     description:
-                      'Unique key to identify the [climate preset](https://docs.seam.co/latest/capability-guides/thermostats/creating-and-managing-climate-presets).',
+                      'Unique key to identify the [climate preset](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-climate-presets).',
                     type: 'string',
                   },
                   climate_preset_mode: {
@@ -78033,13 +78033,13 @@ const openapi: OpenAPISpec = {
                   },
                   cooling_set_point_celsius: {
                     description:
-                      'Temperature to which the thermostat should cool (in °C). See also [Set Points](https://docs.seam.co/latest/capability-guides/thermostats/understanding-thermostat-concepts/set-points).',
+                      'Temperature to which the thermostat should cool (in °C). See also [Set Points](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/set-points).',
                     format: 'float',
                     type: 'number',
                   },
                   cooling_set_point_fahrenheit: {
                     description:
-                      'Temperature to which the thermostat should cool (in °F). See also [Set Points](https://docs.seam.co/latest/capability-guides/thermostats/understanding-thermostat-concepts/set-points).',
+                      'Temperature to which the thermostat should cool (in °F). See also [Set Points](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/set-points).',
                     format: 'float',
                     type: 'number',
                   },
@@ -78075,25 +78075,25 @@ const openapi: OpenAPISpec = {
                   },
                   fan_mode_setting: {
                     description:
-                      'Desired [fan mode setting](https://docs.seam.co/latest/capability-guides/thermostats/configure-current-climate-settings#fan-mode-settings), such as `on`, `auto`, or `circulate`.',
+                      'Desired [fan mode setting](https://docs.seam.co/capability-guides/thermostats/configure-current-climate-settings#fan-mode-settings), such as `on`, `auto`, or `circulate`.',
                     enum: ['auto', 'on', 'circulate'],
                     type: 'string',
                   },
                   heating_set_point_celsius: {
                     description:
-                      'Temperature to which the thermostat should heat (in °C). See also [Set Points](https://docs.seam.co/latest/capability-guides/thermostats/understanding-thermostat-concepts/set-points).',
+                      'Temperature to which the thermostat should heat (in °C). See also [Set Points](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/set-points).',
                     format: 'float',
                     type: 'number',
                   },
                   heating_set_point_fahrenheit: {
                     description:
-                      'Temperature to which the thermostat should heat (in °F). See also [Set Points](https://docs.seam.co/latest/capability-guides/thermostats/understanding-thermostat-concepts/set-points).',
+                      'Temperature to which the thermostat should heat (in °F). See also [Set Points](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/set-points).',
                     format: 'float',
                     type: 'number',
                   },
                   hvac_mode_setting: {
                     description:
-                      'Desired [HVAC mode](https://docs.seam.co/latest/capability-guides/thermostats/understanding-thermostat-concepts/hvac-mode) setting, such as `heat`, `cool`, `heat_cool`, or `off`.',
+                      'Desired [HVAC mode](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/hvac-mode) setting, such as `heat`, `cool`, `heat_cool`, or `off`.',
                     enum: ['off', 'heat', 'cool', 'heat_cool', 'eco'],
                     type: 'string',
                   },
@@ -78109,7 +78109,7 @@ const openapi: OpenAPISpec = {
                   name: {
                     default: null,
                     description:
-                      'User-friendly name to identify the [climate preset](https://docs.seam.co/latest/capability-guides/thermostats/creating-and-managing-climate-presets).',
+                      'User-friendly name to identify the [climate preset](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-climate-presets).',
                     nullable: true,
                     type: 'string',
                   },
@@ -78179,7 +78179,7 @@ const openapi: OpenAPISpec = {
                       properties: {
                         climate_preset_key: {
                           description:
-                            'Key of the [climate preset](https://docs.seam.co/latest/capability-guides/thermostats/creating-and-managing-climate-presets) to activate at the `starts_at_time`.',
+                            'Key of the [climate preset](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-climate-presets) to activate at the `starts_at_time`.',
                           type: 'string',
                         },
                         starts_at_time: {
@@ -78358,7 +78358,7 @@ const openapi: OpenAPISpec = {
                       properties: {
                         climate_preset_key: {
                           description:
-                            'Key of the [climate preset](https://docs.seam.co/latest/capability-guides/thermostats/creating-and-managing-climate-presets) to activate at the `starts_at_time`.',
+                            'Key of the [climate preset](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-climate-presets) to activate at the `starts_at_time`.',
                           type: 'string',
                         },
                         starts_at_time: {
@@ -78445,7 +78445,7 @@ const openapi: OpenAPISpec = {
                       properties: {
                         climate_preset_key: {
                           description:
-                            'Key of the [climate preset](https://docs.seam.co/latest/capability-guides/thermostats/creating-and-managing-climate-presets) to activate at the `starts_at_time`.',
+                            'Key of the [climate preset](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-climate-presets) to activate at the `starts_at_time`.',
                           type: 'string',
                         },
                         starts_at_time: {
@@ -78513,7 +78513,7 @@ const openapi: OpenAPISpec = {
     '/thermostats/delete_climate_preset': {
       delete: {
         description:
-          'Deletes a specified [climate preset](https://docs.seam.co/latest/capability-guides/thermostats/creating-and-managing-climate-presets) for a specified [thermostat](https://docs.seam.co/latest/capability-guides/thermostats).',
+          'Deletes a specified [climate preset](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-climate-presets) for a specified [thermostat](https://docs.seam.co/capability-guides/thermostats).',
         operationId: 'thermostatsDeleteClimatePresetDelete',
         requestBody: {
           content: {
@@ -78569,7 +78569,7 @@ const openapi: OpenAPISpec = {
       },
       post: {
         description:
-          'Deletes a specified [climate preset](https://docs.seam.co/latest/capability-guides/thermostats/creating-and-managing-climate-presets) for a specified [thermostat](https://docs.seam.co/latest/capability-guides/thermostats).',
+          'Deletes a specified [climate preset](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-climate-presets) for a specified [thermostat](https://docs.seam.co/capability-guides/thermostats).',
         operationId: 'thermostatsDeleteClimatePresetPost',
         requestBody: {
           content: {
@@ -78627,7 +78627,7 @@ const openapi: OpenAPISpec = {
     '/thermostats/get': {
       get: {
         description:
-          'Returns a specified [thermostat](https://docs.seam.co/latest/capability-guides/thermostats). **Deprecated:** Will be removed. Use `/devices/get` instead.',
+          'Returns a specified [thermostat](https://docs.seam.co/capability-guides/thermostats). **Deprecated:** Will be removed. Use `/devices/get` instead.',
         operationId: 'thermostatsGetGet',
         parameters: [
           {
@@ -78686,7 +78686,7 @@ const openapi: OpenAPISpec = {
       },
       post: {
         description:
-          'Returns a specified [thermostat](https://docs.seam.co/latest/capability-guides/thermostats). **Deprecated:** Will be removed. Use `/devices/get` instead.',
+          'Returns a specified [thermostat](https://docs.seam.co/capability-guides/thermostats). **Deprecated:** Will be removed. Use `/devices/get` instead.',
         operationId: 'thermostatsGetPost',
         requestBody: {
           content: {
@@ -78749,7 +78749,7 @@ const openapi: OpenAPISpec = {
     '/thermostats/heat': {
       post: {
         description:
-          'Sets a specified [thermostat](https://docs.seam.co/latest/capability-guides/thermostats) to [heat mode](https://docs.seam.co/latest/capability-guides/thermostats/configure-current-climate-settings).',
+          'Sets a specified [thermostat](https://docs.seam.co/capability-guides/thermostats) to [heat mode](https://docs.seam.co/capability-guides/thermostats/configure-current-climate-settings).',
         operationId: 'thermostatsHeatPost',
         requestBody: {
           content: {
@@ -78764,13 +78764,13 @@ const openapi: OpenAPISpec = {
                   },
                   heating_set_point_celsius: {
                     description:
-                      '[Heating set point](https://docs.seam.co/latest/capability-guides/thermostats/understanding-thermostat-concepts/set-points) in °C that you want to set for the thermostat. You must set one of the `heating_set_point` parameters.',
+                      '[Heating set point](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/set-points) in °C that you want to set for the thermostat. You must set one of the `heating_set_point` parameters.',
                     format: 'float',
                     type: 'number',
                   },
                   heating_set_point_fahrenheit: {
                     description:
-                      '[Heating set point](https://docs.seam.co/latest/capability-guides/thermostats/understanding-thermostat-concepts/set-points) in °F that you want to set for the thermostat. You must set one of the `heating_set_point` parameters.',
+                      '[Heating set point](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/set-points) in °F that you want to set for the thermostat. You must set one of the `heating_set_point` parameters.',
                     format: 'float',
                     type: 'number',
                   },
@@ -78826,7 +78826,7 @@ const openapi: OpenAPISpec = {
     '/thermostats/heat_cool': {
       post: {
         description:
-          'Sets a specified [thermostat](https://docs.seam.co/latest/capability-guides/thermostats) to [heat-cool ("auto") mode](https://docs.seam.co/latest/capability-guides/thermostats/configure-current-climate-settings).',
+          'Sets a specified [thermostat](https://docs.seam.co/capability-guides/thermostats) to [heat-cool ("auto") mode](https://docs.seam.co/capability-guides/thermostats/configure-current-climate-settings).',
         operationId: 'thermostatsHeatCoolPost',
         requestBody: {
           content: {
@@ -78835,13 +78835,13 @@ const openapi: OpenAPISpec = {
                 properties: {
                   cooling_set_point_celsius: {
                     description:
-                      '[Cooling set point](https://docs.seam.co/latest/capability-guides/thermostats/understanding-thermostat-concepts/set-points) in °C that you want to set for the thermostat. You must set one of the `cooling_set_point` parameters.',
+                      '[Cooling set point](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/set-points) in °C that you want to set for the thermostat. You must set one of the `cooling_set_point` parameters.',
                     format: 'float',
                     type: 'number',
                   },
                   cooling_set_point_fahrenheit: {
                     description:
-                      '[Cooling set point](https://docs.seam.co/latest/capability-guides/thermostats/understanding-thermostat-concepts/set-points) in °F that you want to set for the thermostat. You must set one of the `cooling_set_point` parameters.',
+                      '[Cooling set point](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/set-points) in °F that you want to set for the thermostat. You must set one of the `cooling_set_point` parameters.',
                     format: 'float',
                     type: 'number',
                   },
@@ -78853,13 +78853,13 @@ const openapi: OpenAPISpec = {
                   },
                   heating_set_point_celsius: {
                     description:
-                      '[Heating set point](https://docs.seam.co/latest/capability-guides/thermostats/understanding-thermostat-concepts/set-points) in °C that you want to set for the thermostat. You must set one of the `heating_set_point` parameters.',
+                      '[Heating set point](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/set-points) in °C that you want to set for the thermostat. You must set one of the `heating_set_point` parameters.',
                     format: 'float',
                     type: 'number',
                   },
                   heating_set_point_fahrenheit: {
                     description:
-                      '[Heating set point](https://docs.seam.co/latest/capability-guides/thermostats/understanding-thermostat-concepts/set-points) in °F that you want to set for the thermostat. You must set one of the `heating_set_point` parameters.',
+                      '[Heating set point](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/set-points) in °F that you want to set for the thermostat. You must set one of the `heating_set_point` parameters.',
                     format: 'float',
                     type: 'number',
                   },
@@ -78915,7 +78915,7 @@ const openapi: OpenAPISpec = {
     '/thermostats/list': {
       get: {
         description:
-          'Returns a list of all [thermostats](https://docs.seam.co/latest/capability-guides/thermostats).',
+          'Returns a list of all [thermostats](https://docs.seam.co/capability-guides/thermostats).',
         operationId: 'thermostatsListGet',
         parameters: [
           {
@@ -79059,7 +79059,7 @@ const openapi: OpenAPISpec = {
                 oneOf: [{ type: 'string' }, { type: 'boolean' }],
               },
               description:
-                'Set of key:value [custom metadata](https://docs.seam.co/latest/core-concepts/devices/adding-custom-metadata-to-a-device) pairs for which you want to list devices.',
+                'Set of key:value [custom metadata](https://docs.seam.co/core-concepts/devices/adding-custom-metadata-to-a-device) pairs for which you want to list devices.',
               type: 'object',
             },
           },
@@ -79213,7 +79213,7 @@ const openapi: OpenAPISpec = {
       },
       post: {
         description:
-          'Returns a list of all [thermostats](https://docs.seam.co/latest/capability-guides/thermostats).',
+          'Returns a list of all [thermostats](https://docs.seam.co/capability-guides/thermostats).',
         operationId: 'thermostatsListPost',
         requestBody: {
           content: {
@@ -79249,7 +79249,7 @@ const openapi: OpenAPISpec = {
                       oneOf: [{ type: 'string' }, { type: 'boolean' }],
                     },
                     description:
-                      'Set of key:value [custom metadata](https://docs.seam.co/latest/core-concepts/devices/adding-custom-metadata-to-a-device) pairs for which you want to list devices.',
+                      'Set of key:value [custom metadata](https://docs.seam.co/core-concepts/devices/adding-custom-metadata-to-a-device) pairs for which you want to list devices.',
                     type: 'object',
                   },
                   customer_key: {
@@ -79451,7 +79451,7 @@ const openapi: OpenAPISpec = {
     '/thermostats/off': {
       post: {
         description:
-          'Sets a specified [thermostat](https://docs.seam.co/latest/capability-guides/thermostats) to ["off" mode](https://docs.seam.co/latest/capability-guides/thermostats/configure-current-climate-settings).',
+          'Sets a specified [thermostat](https://docs.seam.co/capability-guides/thermostats) to ["off" mode](https://docs.seam.co/capability-guides/thermostats/configure-current-climate-settings).',
         operationId: 'thermostatsOffPost',
         requestBody: {
           content: {
@@ -79516,7 +79516,7 @@ const openapi: OpenAPISpec = {
     '/thermostats/schedules/create': {
       post: {
         description:
-          'Creates a new [thermostat schedule](https://docs.seam.co/latest/capability-guides/thermostats/creating-and-managing-thermostat-schedules) for a specified [thermostat](https://docs.seam.co/latest/capability-guides/thermostats).',
+          'Creates a new [thermostat schedule](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-thermostat-schedules) for a specified [thermostat](https://docs.seam.co/capability-guides/thermostats).',
         operationId: 'thermostatsSchedulesCreatePost',
         requestBody: {
           content: {
@@ -79525,7 +79525,7 @@ const openapi: OpenAPISpec = {
                 properties: {
                   climate_preset_key: {
                     description:
-                      'Key of the [climate preset](https://docs.seam.co/latest/capability-guides/thermostats/creating-and-managing-climate-presets) to use for the new thermostat schedule.',
+                      'Key of the [climate preset](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-climate-presets) to use for the new thermostat schedule.',
                     type: 'string',
                   },
                   device_id: {
@@ -79540,12 +79540,12 @@ const openapi: OpenAPISpec = {
                   },
                   is_override_allowed: {
                     description:
-                      "Indicates whether a person at the thermostat or using the API can change the thermostat's settings while the new schedule is active. See also [Specifying Manual Override Permissions](https://docs.seam.co/latest/capability-guides/thermostats/creating-and-managing-thermostat-schedules#specifying-manual-override-permissions).",
+                      "Indicates whether a person at the thermostat or using the API can change the thermostat's settings while the new schedule is active. See also [Specifying Manual Override Permissions](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-thermostat-schedules#specifying-manual-override-permissions).",
                     type: 'boolean',
                   },
                   max_override_period_minutes: {
                     description:
-                      "Number of minutes for which a person at the thermostat or using the API can change the thermostat's settings after the activation of the scheduled climate preset. See also [Specifying Manual Override Permissions](https://docs.seam.co/latest/capability-guides/thermostats/creating-and-managing-thermostat-schedules#specifying-manual-override-permissions).",
+                      "Number of minutes for which a person at the thermostat or using the API can change the thermostat's settings after the activation of the scheduled climate preset. See also [Specifying Manual Override Permissions](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-thermostat-schedules#specifying-manual-override-permissions).",
                     exclusiveMinimum: true,
                     minimum: 0,
                     nullable: true,
@@ -79612,7 +79612,7 @@ const openapi: OpenAPISpec = {
     '/thermostats/schedules/delete': {
       delete: {
         description:
-          'Deletes a [thermostat schedule](https://docs.seam.co/latest/capability-guides/thermostats/creating-and-managing-thermostat-schedules) for a specified [thermostat](https://docs.seam.co/latest/capability-guides/thermostats).',
+          'Deletes a [thermostat schedule](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-thermostat-schedules) for a specified [thermostat](https://docs.seam.co/capability-guides/thermostats).',
         operationId: 'thermostatsSchedulesDeleteDelete',
         parameters: [
           {
@@ -79658,7 +79658,7 @@ const openapi: OpenAPISpec = {
       },
       post: {
         description:
-          'Deletes a [thermostat schedule](https://docs.seam.co/latest/capability-guides/thermostats/creating-and-managing-thermostat-schedules) for a specified [thermostat](https://docs.seam.co/latest/capability-guides/thermostats).',
+          'Deletes a [thermostat schedule](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-thermostat-schedules) for a specified [thermostat](https://docs.seam.co/capability-guides/thermostats).',
         operationId: 'thermostatsSchedulesDeletePost',
         requestBody: {
           content: {
@@ -79711,7 +79711,7 @@ const openapi: OpenAPISpec = {
     '/thermostats/schedules/get': {
       get: {
         description:
-          'Returns a specified [thermostat schedule](https://docs.seam.co/latest/capability-guides/thermostats/creating-and-managing-thermostat-schedules).',
+          'Returns a specified [thermostat schedule](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-thermostat-schedules).',
         operationId: 'thermostatsSchedulesGetGet',
         parameters: [
           {
@@ -79763,7 +79763,7 @@ const openapi: OpenAPISpec = {
       },
       post: {
         description:
-          'Returns a specified [thermostat schedule](https://docs.seam.co/latest/capability-guides/thermostats/creating-and-managing-thermostat-schedules).',
+          'Returns a specified [thermostat schedule](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-thermostat-schedules).',
         operationId: 'thermostatsSchedulesGetPost',
         requestBody: {
           content: {
@@ -79822,7 +79822,7 @@ const openapi: OpenAPISpec = {
     '/thermostats/schedules/list': {
       get: {
         description:
-          'Returns a list of all [thermostat schedules](https://docs.seam.co/latest/capability-guides/thermostats/creating-and-managing-thermostat-schedules) for a specified [thermostat](https://docs.seam.co/latest/capability-guides/thermostats).',
+          'Returns a list of all [thermostat schedules](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-thermostat-schedules) for a specified [thermostat](https://docs.seam.co/capability-guides/thermostats).',
         operationId: 'thermostatsSchedulesListGet',
         parameters: [
           {
@@ -79888,7 +79888,7 @@ const openapi: OpenAPISpec = {
       },
       post: {
         description:
-          'Returns a list of all [thermostat schedules](https://docs.seam.co/latest/capability-guides/thermostats/creating-and-managing-thermostat-schedules) for a specified [thermostat](https://docs.seam.co/latest/capability-guides/thermostats).',
+          'Returns a list of all [thermostat schedules](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-thermostat-schedules) for a specified [thermostat](https://docs.seam.co/capability-guides/thermostats).',
         operationId: 'thermostatsSchedulesListPost',
         requestBody: {
           content: {
@@ -79956,7 +79956,7 @@ const openapi: OpenAPISpec = {
     '/thermostats/schedules/update': {
       patch: {
         description:
-          'Updates a specified [thermostat schedule](https://docs.seam.co/latest/capability-guides/thermostats/creating-and-managing-thermostat-schedules).',
+          'Updates a specified [thermostat schedule](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-thermostat-schedules).',
         operationId: 'thermostatsSchedulesUpdatePatch',
         requestBody: {
           content: {
@@ -79965,7 +79965,7 @@ const openapi: OpenAPISpec = {
                 properties: {
                   climate_preset_key: {
                     description:
-                      'Key of the [climate preset](https://docs.seam.co/latest/capability-guides/thermostats/creating-and-managing-climate-presets) to use for the thermostat schedule.',
+                      'Key of the [climate preset](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-climate-presets) to use for the thermostat schedule.',
                     type: 'string',
                   },
                   ends_at: {
@@ -79975,12 +79975,12 @@ const openapi: OpenAPISpec = {
                   },
                   is_override_allowed: {
                     description:
-                      "Indicates whether a person at the thermostat or using the API can change the thermostat's settings while the schedule is active. See also [Specifying Manual Override Permissions](https://docs.seam.co/latest/capability-guides/thermostats/creating-and-managing-thermostat-schedules#specifying-manual-override-permissions).",
+                      "Indicates whether a person at the thermostat or using the API can change the thermostat's settings while the schedule is active. See also [Specifying Manual Override Permissions](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-thermostat-schedules#specifying-manual-override-permissions).",
                     type: 'boolean',
                   },
                   max_override_period_minutes: {
                     description:
-                      "Number of minutes for which a person at the thermostat or using the API can change the thermostat's settings after the activation of the scheduled climate preset. See also [Specifying Manual Override Permissions](https://docs.seam.co/latest/capability-guides/thermostats/creating-and-managing-thermostat-schedules#specifying-manual-override-permissions).",
+                      "Number of minutes for which a person at the thermostat or using the API can change the thermostat's settings after the activation of the scheduled climate preset. See also [Specifying Manual Override Permissions](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-thermostat-schedules#specifying-manual-override-permissions).",
                     exclusiveMinimum: true,
                     minimum: 0,
                     nullable: true,
@@ -80039,7 +80039,7 @@ const openapi: OpenAPISpec = {
       },
       post: {
         description:
-          'Updates a specified [thermostat schedule](https://docs.seam.co/latest/capability-guides/thermostats/creating-and-managing-thermostat-schedules).',
+          'Updates a specified [thermostat schedule](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-thermostat-schedules).',
         operationId: 'thermostatsSchedulesUpdatePost',
         requestBody: {
           content: {
@@ -80048,7 +80048,7 @@ const openapi: OpenAPISpec = {
                 properties: {
                   climate_preset_key: {
                     description:
-                      'Key of the [climate preset](https://docs.seam.co/latest/capability-guides/thermostats/creating-and-managing-climate-presets) to use for the thermostat schedule.',
+                      'Key of the [climate preset](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-climate-presets) to use for the thermostat schedule.',
                     type: 'string',
                   },
                   ends_at: {
@@ -80058,12 +80058,12 @@ const openapi: OpenAPISpec = {
                   },
                   is_override_allowed: {
                     description:
-                      "Indicates whether a person at the thermostat or using the API can change the thermostat's settings while the schedule is active. See also [Specifying Manual Override Permissions](https://docs.seam.co/latest/capability-guides/thermostats/creating-and-managing-thermostat-schedules#specifying-manual-override-permissions).",
+                      "Indicates whether a person at the thermostat or using the API can change the thermostat's settings while the schedule is active. See also [Specifying Manual Override Permissions](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-thermostat-schedules#specifying-manual-override-permissions).",
                     type: 'boolean',
                   },
                   max_override_period_minutes: {
                     description:
-                      "Number of minutes for which a person at the thermostat or using the API can change the thermostat's settings after the activation of the scheduled climate preset. See also [Specifying Manual Override Permissions](https://docs.seam.co/latest/capability-guides/thermostats/creating-and-managing-thermostat-schedules#specifying-manual-override-permissions).",
+                      "Number of minutes for which a person at the thermostat or using the API can change the thermostat's settings after the activation of the scheduled climate preset. See also [Specifying Manual Override Permissions](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-thermostat-schedules#specifying-manual-override-permissions).",
                     exclusiveMinimum: true,
                     minimum: 0,
                     nullable: true,
@@ -80124,7 +80124,7 @@ const openapi: OpenAPISpec = {
     '/thermostats/set_fallback_climate_preset': {
       post: {
         description:
-          'Sets a specified [climate preset](https://docs.seam.co/latest/capability-guides/thermostats/creating-and-managing-climate-presets) as the ["fallback"](https://docs.seam.co/latest/capability-guides/thermostats/creating-and-managing-climate-presets/setting-the-fallback-climate-preset) preset for a specified [thermostat](https://docs.seam.co/latest/capability-guides/thermostats).',
+          'Sets a specified [climate preset](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-climate-presets) as the ["fallback"](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-climate-presets/setting-the-fallback-climate-preset) preset for a specified [thermostat](https://docs.seam.co/capability-guides/thermostats).',
         operationId: 'thermostatsSetFallbackClimatePresetPost',
         requestBody: {
           content: {
@@ -80181,7 +80181,7 @@ const openapi: OpenAPISpec = {
     '/thermostats/set_fan_mode': {
       post: {
         description:
-          'Sets the [fan mode setting](https://docs.seam.co/latest/capability-guides/thermostats/configure-current-climate-settings#fan-mode-settings) for a specified [thermostat](https://docs.seam.co/latest/capability-guides/thermostats).',
+          'Sets the [fan mode setting](https://docs.seam.co/capability-guides/thermostats/configure-current-climate-settings#fan-mode-settings) for a specified [thermostat](https://docs.seam.co/capability-guides/thermostats).',
         operationId: 'thermostatsSetFanModePost',
         requestBody: {
           content: {
@@ -80202,7 +80202,7 @@ const openapi: OpenAPISpec = {
                   },
                   fan_mode_setting: {
                     description:
-                      '[Fan mode setting](https://docs.seam.co/latest/capability-guides/thermostats/configure-current-climate-settings#fan-mode-settings) that you want to set for the thermostat.',
+                      '[Fan mode setting](https://docs.seam.co/capability-guides/thermostats/configure-current-climate-settings#fan-mode-settings) that you want to set for the thermostat.',
                     enum: ['auto', 'on', 'circulate'],
                     type: 'string',
                   },
@@ -80258,7 +80258,7 @@ const openapi: OpenAPISpec = {
     '/thermostats/set_hvac_mode': {
       post: {
         description:
-          'Sets the [HVAC mode](https://docs.seam.co/latest/capability-guides/thermostats/configure-current-climate-settings) for a specified [thermostat](https://docs.seam.co/latest/capability-guides/thermostats).',
+          'Sets the [HVAC mode](https://docs.seam.co/capability-guides/thermostats/configure-current-climate-settings) for a specified [thermostat](https://docs.seam.co/capability-guides/thermostats).',
         operationId: 'thermostatsSetHvacModePost',
         requestBody: {
           content: {
@@ -80283,13 +80283,13 @@ const openapi: OpenAPISpec = {
                     properties: {
                       cooling_set_point_celsius: {
                         description:
-                          '[Cooling set point](https://docs.seam.co/latest/capability-guides/thermostats/understanding-thermostat-concepts/set-points) in °C that you want to set for the thermostat. You must set one of the `cooling_set_point` parameters.',
+                          '[Cooling set point](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/set-points) in °C that you want to set for the thermostat. You must set one of the `cooling_set_point` parameters.',
                         format: 'float',
                         type: 'number',
                       },
                       cooling_set_point_fahrenheit: {
                         description:
-                          '[Cooling set point](https://docs.seam.co/latest/capability-guides/thermostats/understanding-thermostat-concepts/set-points) in °F that you want to set for the thermostat. You must set one of the `cooling_set_point` parameters.',
+                          '[Cooling set point](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/set-points) in °F that you want to set for the thermostat. You must set one of the `cooling_set_point` parameters.',
                         format: 'float',
                         type: 'number',
                       },
@@ -80314,13 +80314,13 @@ const openapi: OpenAPISpec = {
                       },
                       heating_set_point_celsius: {
                         description:
-                          '[Heating set point](https://docs.seam.co/latest/capability-guides/thermostats/understanding-thermostat-concepts/set-points) in °C that you want to set for the thermostat. You must set one of the `heating_set_point` parameters.',
+                          '[Heating set point](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/set-points) in °C that you want to set for the thermostat. You must set one of the `heating_set_point` parameters.',
                         format: 'float',
                         type: 'number',
                       },
                       heating_set_point_fahrenheit: {
                         description:
-                          '[Heating set point](https://docs.seam.co/latest/capability-guides/thermostats/understanding-thermostat-concepts/set-points) in °F that you want to set for the thermostat. You must set one of the `heating_set_point` parameters.',
+                          '[Heating set point](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/set-points) in °F that you want to set for the thermostat. You must set one of the `heating_set_point` parameters.',
                         format: 'float',
                         type: 'number',
                       },
@@ -80333,13 +80333,13 @@ const openapi: OpenAPISpec = {
                     properties: {
                       cooling_set_point_celsius: {
                         description:
-                          '[Cooling set point](https://docs.seam.co/latest/capability-guides/thermostats/understanding-thermostat-concepts/set-points) in °C that you want to set for the thermostat. You must set one of the `cooling_set_point` parameters.',
+                          '[Cooling set point](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/set-points) in °C that you want to set for the thermostat. You must set one of the `cooling_set_point` parameters.',
                         format: 'float',
                         type: 'number',
                       },
                       cooling_set_point_fahrenheit: {
                         description:
-                          '[Cooling set point](https://docs.seam.co/latest/capability-guides/thermostats/understanding-thermostat-concepts/set-points) in °F that you want to set for the thermostat. You must set one of the `cooling_set_point` parameters.',
+                          '[Cooling set point](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/set-points) in °F that you want to set for the thermostat. You must set one of the `cooling_set_point` parameters.',
                         format: 'float',
                         type: 'number',
                       },
@@ -80351,13 +80351,13 @@ const openapi: OpenAPISpec = {
                       },
                       heating_set_point_celsius: {
                         description:
-                          '[Heating set point](https://docs.seam.co/latest/capability-guides/thermostats/understanding-thermostat-concepts/set-points) in °C that you want to set for the thermostat. You must set one of the `heating_set_point` parameters.',
+                          '[Heating set point](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/set-points) in °C that you want to set for the thermostat. You must set one of the `heating_set_point` parameters.',
                         format: 'float',
                         type: 'number',
                       },
                       heating_set_point_fahrenheit: {
                         description:
-                          '[Heating set point](https://docs.seam.co/latest/capability-guides/thermostats/understanding-thermostat-concepts/set-points) in °F that you want to set for the thermostat. You must set one of the `heating_set_point` parameters.',
+                          '[Heating set point](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/set-points) in °F that you want to set for the thermostat. You must set one of the `heating_set_point` parameters.',
                         format: 'float',
                         type: 'number',
                       },
@@ -80427,7 +80427,7 @@ const openapi: OpenAPISpec = {
     '/thermostats/set_temperature_threshold': {
       patch: {
         description:
-          'Sets a [temperature threshold](https://docs.seam.co/latest/capability-guides/thermostats/setting-and-monitoring-temperature-thresholds) for a specified thermostat. Seam emits a `thermostat.temperature_threshold_exceeded` event and adds a warning on a thermostat if it reports a temperature outside the threshold range.',
+          'Sets a [temperature threshold](https://docs.seam.co/capability-guides/thermostats/setting-and-monitoring-temperature-thresholds) for a specified thermostat. Seam emits a `thermostat.temperature_threshold_exceeded` event and adds a warning on a thermostat if it reports a temperature outside the threshold range.',
         operationId: 'thermostatsSetTemperatureThresholdPatch',
         requestBody: {
           content: {
@@ -80509,7 +80509,7 @@ const openapi: OpenAPISpec = {
       },
       post: {
         description:
-          'Sets a [temperature threshold](https://docs.seam.co/latest/capability-guides/thermostats/setting-and-monitoring-temperature-thresholds) for a specified thermostat. Seam emits a `thermostat.temperature_threshold_exceeded` event and adds a warning on a thermostat if it reports a temperature outside the threshold range.',
+          'Sets a [temperature threshold](https://docs.seam.co/capability-guides/thermostats/setting-and-monitoring-temperature-thresholds) for a specified thermostat. Seam emits a `thermostat.temperature_threshold_exceeded` event and adds a warning on a thermostat if it reports a temperature outside the threshold range.',
         operationId: 'thermostatsSetTemperatureThresholdPost',
         requestBody: {
           content: {
@@ -80593,7 +80593,7 @@ const openapi: OpenAPISpec = {
     '/thermostats/simulate/hvac_mode_adjusted': {
       post: {
         description:
-          'Simulates having adjusted the [HVAC mode](https://docs.seam.co/latest/capability-guides/thermostats/understanding-thermostat-concepts/hvac-mode) for a [thermostat](https://docs.seam.co/latest/capability-guides/thermostats). Only applicable for [sandbox devices](https://docs.seam.co/latest/core-concepts/workspaces#sandbox-workspaces). See also [Testing Your Thermostat App with Simulate Endpoints](https://docs.seam.co/latest/capability-guides/thermostats/testing-your-thermostat-app-with-simulate-endpoints).',
+          'Simulates having adjusted the [HVAC mode](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/hvac-mode) for a [thermostat](https://docs.seam.co/capability-guides/thermostats). Only applicable for [sandbox devices](https://docs.seam.co/core-concepts/workspaces#sandbox-workspaces). See also [Testing Your Thermostat App with Simulate Endpoints](https://docs.seam.co/capability-guides/thermostats/testing-your-thermostat-app-with-simulate-endpoints).',
         operationId: 'thermostatsSimulateHvacModeAdjustedPost',
         requestBody: {
           content: {
@@ -80622,13 +80622,13 @@ const openapi: OpenAPISpec = {
                     properties: {
                       cooling_set_point_celsius: {
                         description:
-                          'Cooling [set point](https://docs.seam.co/latest/capability-guides/thermostats/understanding-thermostat-concepts/set-points) in °C that you want to simulate. You must set `cooling_set_point_celsius` or `cooling_set_point_fahrenheit`.',
+                          'Cooling [set point](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/set-points) in °C that you want to simulate. You must set `cooling_set_point_celsius` or `cooling_set_point_fahrenheit`.',
                         format: 'float',
                         type: 'number',
                       },
                       cooling_set_point_fahrenheit: {
                         description:
-                          'Cooling [set point](https://docs.seam.co/latest/capability-guides/thermostats/understanding-thermostat-concepts/set-points) in °F that you want to simulate. You must set `cooling_set_point_fahrenheit` or `cooling_set_point_celsius`.',
+                          'Cooling [set point](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/set-points) in °F that you want to simulate. You must set `cooling_set_point_fahrenheit` or `cooling_set_point_celsius`.',
                         format: 'float',
                         type: 'number',
                       },
@@ -80657,13 +80657,13 @@ const openapi: OpenAPISpec = {
                       },
                       heating_set_point_celsius: {
                         description:
-                          'Heating [set point](https://docs.seam.co/latest/capability-guides/thermostats/understanding-thermostat-concepts/set-points) in °C that you want to simulate. You must set `heating_set_point_celsius` or `heating_set_point_fahrenheit`.',
+                          'Heating [set point](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/set-points) in °C that you want to simulate. You must set `heating_set_point_celsius` or `heating_set_point_fahrenheit`.',
                         format: 'float',
                         type: 'number',
                       },
                       heating_set_point_fahrenheit: {
                         description:
-                          'Heating [set point](https://docs.seam.co/latest/capability-guides/thermostats/understanding-thermostat-concepts/set-points) in °F that you want to simulate. You must set `heating_set_point_fahrenheit` or `heating_set_point_celsius`.',
+                          'Heating [set point](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/set-points) in °F that you want to simulate. You must set `heating_set_point_fahrenheit` or `heating_set_point_celsius`.',
                         format: 'float',
                         type: 'number',
                       },
@@ -80680,13 +80680,13 @@ const openapi: OpenAPISpec = {
                     properties: {
                       cooling_set_point_celsius: {
                         description:
-                          'Cooling [set point](https://docs.seam.co/latest/capability-guides/thermostats/understanding-thermostat-concepts/set-points) in °C that you want to simulate. You must set `cooling_set_point_celsius` or `cooling_set_point_fahrenheit`.',
+                          'Cooling [set point](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/set-points) in °C that you want to simulate. You must set `cooling_set_point_celsius` or `cooling_set_point_fahrenheit`.',
                         format: 'float',
                         type: 'number',
                       },
                       cooling_set_point_fahrenheit: {
                         description:
-                          'Cooling [set point](https://docs.seam.co/latest/capability-guides/thermostats/understanding-thermostat-concepts/set-points) in °F that you want to simulate. You must set `cooling_set_point_fahrenheit` or `cooling_set_point_celsius`.',
+                          'Cooling [set point](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/set-points) in °F that you want to simulate. You must set `cooling_set_point_fahrenheit` or `cooling_set_point_celsius`.',
                         format: 'float',
                         type: 'number',
                       },
@@ -80698,13 +80698,13 @@ const openapi: OpenAPISpec = {
                       },
                       heating_set_point_celsius: {
                         description:
-                          'Heating [set point](https://docs.seam.co/latest/capability-guides/thermostats/understanding-thermostat-concepts/set-points) in °C that you want to simulate. You must set `heating_set_point_celsius` or `heating_set_point_fahrenheit`.',
+                          'Heating [set point](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/set-points) in °C that you want to simulate. You must set `heating_set_point_celsius` or `heating_set_point_fahrenheit`.',
                         format: 'float',
                         type: 'number',
                       },
                       heating_set_point_fahrenheit: {
                         description:
-                          'Heating [set point](https://docs.seam.co/latest/capability-guides/thermostats/understanding-thermostat-concepts/set-points) in °F that you want to simulate. You must set `heating_set_point_fahrenheit` or `heating_set_point_celsius`.',
+                          'Heating [set point](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/set-points) in °F that you want to simulate. You must set `heating_set_point_fahrenheit` or `heating_set_point_celsius`.',
                         format: 'float',
                         type: 'number',
                       },
@@ -80754,7 +80754,7 @@ const openapi: OpenAPISpec = {
     '/thermostats/simulate/temperature_reached': {
       post: {
         description:
-          'Simulates a [thermostat](https://docs.seam.co/latest/capability-guides/thermostats) reaching a specified temperature. Only applicable for [sandbox devices](https://docs.seam.co/latest/core-concepts/workspaces#sandbox-workspaces). See also [Testing Your Thermostat App with Simulate Endpoints](https://docs.seam.co/latest/capability-guides/thermostats/testing-your-thermostat-app-with-simulate-endpoints).',
+          'Simulates a [thermostat](https://docs.seam.co/capability-guides/thermostats) reaching a specified temperature. Only applicable for [sandbox devices](https://docs.seam.co/core-concepts/workspaces#sandbox-workspaces). See also [Testing Your Thermostat App with Simulate Endpoints](https://docs.seam.co/capability-guides/thermostats/testing-your-thermostat-app-with-simulate-endpoints).',
         operationId: 'thermostatsSimulateTemperatureReachedPost',
         requestBody: {
           content: {
@@ -80818,7 +80818,7 @@ const openapi: OpenAPISpec = {
     '/thermostats/update_climate_preset': {
       patch: {
         description:
-          'Updates a specified [climate preset](https://docs.seam.co/latest/capability-guides/thermostats/creating-and-managing-climate-presets) for a specified [thermostat](https://docs.seam.co/latest/capability-guides/thermostats).',
+          'Updates a specified [climate preset](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-climate-presets) for a specified [thermostat](https://docs.seam.co/capability-guides/thermostats).',
         operationId: 'thermostatsUpdateClimatePresetPatch',
         requestBody: {
           content: {
@@ -80827,7 +80827,7 @@ const openapi: OpenAPISpec = {
                 properties: {
                   climate_preset_key: {
                     description:
-                      'Unique key to identify the [climate preset](https://docs.seam.co/latest/capability-guides/thermostats/creating-and-managing-climate-presets).',
+                      'Unique key to identify the [climate preset](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-climate-presets).',
                     type: 'string',
                   },
                   climate_preset_mode: {
@@ -80845,13 +80845,13 @@ const openapi: OpenAPISpec = {
                   },
                   cooling_set_point_celsius: {
                     description:
-                      'Temperature to which the thermostat should cool (in °C). See also [Set Points](https://docs.seam.co/latest/capability-guides/thermostats/understanding-thermostat-concepts/set-points).',
+                      'Temperature to which the thermostat should cool (in °C). See also [Set Points](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/set-points).',
                     format: 'float',
                     type: 'number',
                   },
                   cooling_set_point_fahrenheit: {
                     description:
-                      'Temperature to which the thermostat should cool (in °F). See also [Set Points](https://docs.seam.co/latest/capability-guides/thermostats/understanding-thermostat-concepts/set-points).',
+                      'Temperature to which the thermostat should cool (in °F). See also [Set Points](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/set-points).',
                     format: 'float',
                     type: 'number',
                   },
@@ -80887,32 +80887,32 @@ const openapi: OpenAPISpec = {
                   },
                   fan_mode_setting: {
                     description:
-                      'Desired [fan mode setting](https://docs.seam.co/latest/capability-guides/thermostats/configure-current-climate-settings#fan-mode-settings), such as `on`, `auto`, or `circulate`.',
+                      'Desired [fan mode setting](https://docs.seam.co/capability-guides/thermostats/configure-current-climate-settings#fan-mode-settings), such as `on`, `auto`, or `circulate`.',
                     enum: ['auto', 'on', 'circulate'],
                     type: 'string',
                   },
                   heating_set_point_celsius: {
                     description:
-                      'Temperature to which the thermostat should heat (in °C). See also [Set Points](https://docs.seam.co/latest/capability-guides/thermostats/understanding-thermostat-concepts/set-points).',
+                      'Temperature to which the thermostat should heat (in °C). See also [Set Points](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/set-points).',
                     format: 'float',
                     type: 'number',
                   },
                   heating_set_point_fahrenheit: {
                     description:
-                      'Temperature to which the thermostat should heat (in °F). See also [Set Points](https://docs.seam.co/latest/capability-guides/thermostats/understanding-thermostat-concepts/set-points).',
+                      'Temperature to which the thermostat should heat (in °F). See also [Set Points](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/set-points).',
                     format: 'float',
                     type: 'number',
                   },
                   hvac_mode_setting: {
                     description:
-                      'Desired [HVAC mode](https://docs.seam.co/latest/capability-guides/thermostats/understanding-thermostat-concepts/hvac-mode) setting, such as `heat`, `cool`, `heat_cool`, or `off`.',
+                      'Desired [HVAC mode](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/hvac-mode) setting, such as `heat`, `cool`, `heat_cool`, or `off`.',
                     enum: ['off', 'heat', 'cool', 'heat_cool', 'eco'],
                     type: 'string',
                   },
                   manual_override_allowed: {
                     deprecated: true,
                     description:
-                      "Indicates whether a person at the thermostat can change the thermostat's settings. See [Specifying Manual Override Permissions](https://docs.seam.co/latest/capability-guides/thermostats/creating-and-managing-thermostat-schedules#specifying-manual-override-permissions).",
+                      "Indicates whether a person at the thermostat can change the thermostat's settings. See [Specifying Manual Override Permissions](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-thermostat-schedules#specifying-manual-override-permissions).",
                     type: 'boolean',
                     'x-deprecated':
                       "Use 'thermostat_schedule.is_override_allowed'",
@@ -80920,7 +80920,7 @@ const openapi: OpenAPISpec = {
                   name: {
                     default: null,
                     description:
-                      'User-friendly name to identify the [climate preset](https://docs.seam.co/latest/capability-guides/thermostats/creating-and-managing-climate-presets).',
+                      'User-friendly name to identify the [climate preset](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-climate-presets).',
                     nullable: true,
                     type: 'string',
                   },
@@ -80962,7 +80962,7 @@ const openapi: OpenAPISpec = {
       },
       post: {
         description:
-          'Updates a specified [climate preset](https://docs.seam.co/latest/capability-guides/thermostats/creating-and-managing-climate-presets) for a specified [thermostat](https://docs.seam.co/latest/capability-guides/thermostats).',
+          'Updates a specified [climate preset](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-climate-presets) for a specified [thermostat](https://docs.seam.co/capability-guides/thermostats).',
         operationId: 'thermostatsUpdateClimatePresetPost',
         requestBody: {
           content: {
@@ -80971,7 +80971,7 @@ const openapi: OpenAPISpec = {
                 properties: {
                   climate_preset_key: {
                     description:
-                      'Unique key to identify the [climate preset](https://docs.seam.co/latest/capability-guides/thermostats/creating-and-managing-climate-presets).',
+                      'Unique key to identify the [climate preset](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-climate-presets).',
                     type: 'string',
                   },
                   climate_preset_mode: {
@@ -80989,13 +80989,13 @@ const openapi: OpenAPISpec = {
                   },
                   cooling_set_point_celsius: {
                     description:
-                      'Temperature to which the thermostat should cool (in °C). See also [Set Points](https://docs.seam.co/latest/capability-guides/thermostats/understanding-thermostat-concepts/set-points).',
+                      'Temperature to which the thermostat should cool (in °C). See also [Set Points](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/set-points).',
                     format: 'float',
                     type: 'number',
                   },
                   cooling_set_point_fahrenheit: {
                     description:
-                      'Temperature to which the thermostat should cool (in °F). See also [Set Points](https://docs.seam.co/latest/capability-guides/thermostats/understanding-thermostat-concepts/set-points).',
+                      'Temperature to which the thermostat should cool (in °F). See also [Set Points](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/set-points).',
                     format: 'float',
                     type: 'number',
                   },
@@ -81031,32 +81031,32 @@ const openapi: OpenAPISpec = {
                   },
                   fan_mode_setting: {
                     description:
-                      'Desired [fan mode setting](https://docs.seam.co/latest/capability-guides/thermostats/configure-current-climate-settings#fan-mode-settings), such as `on`, `auto`, or `circulate`.',
+                      'Desired [fan mode setting](https://docs.seam.co/capability-guides/thermostats/configure-current-climate-settings#fan-mode-settings), such as `on`, `auto`, or `circulate`.',
                     enum: ['auto', 'on', 'circulate'],
                     type: 'string',
                   },
                   heating_set_point_celsius: {
                     description:
-                      'Temperature to which the thermostat should heat (in °C). See also [Set Points](https://docs.seam.co/latest/capability-guides/thermostats/understanding-thermostat-concepts/set-points).',
+                      'Temperature to which the thermostat should heat (in °C). See also [Set Points](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/set-points).',
                     format: 'float',
                     type: 'number',
                   },
                   heating_set_point_fahrenheit: {
                     description:
-                      'Temperature to which the thermostat should heat (in °F). See also [Set Points](https://docs.seam.co/latest/capability-guides/thermostats/understanding-thermostat-concepts/set-points).',
+                      'Temperature to which the thermostat should heat (in °F). See also [Set Points](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/set-points).',
                     format: 'float',
                     type: 'number',
                   },
                   hvac_mode_setting: {
                     description:
-                      'Desired [HVAC mode](https://docs.seam.co/latest/capability-guides/thermostats/understanding-thermostat-concepts/hvac-mode) setting, such as `heat`, `cool`, `heat_cool`, or `off`.',
+                      'Desired [HVAC mode](https://docs.seam.co/capability-guides/thermostats/understanding-thermostat-concepts/hvac-mode) setting, such as `heat`, `cool`, `heat_cool`, or `off`.',
                     enum: ['off', 'heat', 'cool', 'heat_cool', 'eco'],
                     type: 'string',
                   },
                   manual_override_allowed: {
                     deprecated: true,
                     description:
-                      "Indicates whether a person at the thermostat can change the thermostat's settings. See [Specifying Manual Override Permissions](https://docs.seam.co/latest/capability-guides/thermostats/creating-and-managing-thermostat-schedules#specifying-manual-override-permissions).",
+                      "Indicates whether a person at the thermostat can change the thermostat's settings. See [Specifying Manual Override Permissions](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-thermostat-schedules#specifying-manual-override-permissions).",
                     type: 'boolean',
                     'x-deprecated':
                       "Use 'thermostat_schedule.is_override_allowed'",
@@ -81064,7 +81064,7 @@ const openapi: OpenAPISpec = {
                   name: {
                     default: null,
                     description:
-                      'User-friendly name to identify the [climate preset](https://docs.seam.co/latest/capability-guides/thermostats/creating-and-managing-climate-presets).',
+                      'User-friendly name to identify the [climate preset](https://docs.seam.co/capability-guides/thermostats/creating-and-managing-climate-presets).',
                     nullable: true,
                     type: 'string',
                   },
@@ -81624,7 +81624,7 @@ const openapi: OpenAPISpec = {
     '/user_identities/add_acs_user': {
       post: {
         description:
-          "Adds a specified [access system user](https://docs.seam.co/latest/capability-guides/access-systems/user-management) to a specified [user identity](https://docs.seam.co/latest/capability-guides/mobile-access/managing-mobile-app-user-accounts-with-user-identities#what-is-a-user-identity).\n\nYou must specify either `user_identity_id` or `user_identity_key` to identify the user identity.\n\nIf `user_identity_key` is provided, but the user identity doesn't exist, a new user identity will be created automatically using information from the ACS user.",
+          "Adds a specified [access system user](https://docs.seam.co/capability-guides/access-systems/user-management) to a specified [user identity](https://docs.seam.co/capability-guides/mobile-access/managing-mobile-app-user-accounts-with-user-identities#what-is-a-user-identity).\n\nYou must specify either `user_identity_id` or `user_identity_key` to identify the user identity.\n\nIf `user_identity_key` is provided, but the user identity doesn't exist, a new user identity will be created automatically using information from the ACS user.",
         operationId: 'userIdentitiesAddAcsUserPost',
         requestBody: {
           content: {
@@ -81685,7 +81685,7 @@ const openapi: OpenAPISpec = {
       },
       put: {
         description:
-          "Adds a specified [access system user](https://docs.seam.co/latest/capability-guides/access-systems/user-management) to a specified [user identity](https://docs.seam.co/latest/capability-guides/mobile-access/managing-mobile-app-user-accounts-with-user-identities#what-is-a-user-identity).\n\nYou must specify either `user_identity_id` or `user_identity_key` to identify the user identity.\n\nIf `user_identity_key` is provided, but the user identity doesn't exist, a new user identity will be created automatically using information from the ACS user.",
+          "Adds a specified [access system user](https://docs.seam.co/capability-guides/access-systems/user-management) to a specified [user identity](https://docs.seam.co/capability-guides/mobile-access/managing-mobile-app-user-accounts-with-user-identities#what-is-a-user-identity).\n\nYou must specify either `user_identity_id` or `user_identity_key` to identify the user identity.\n\nIf `user_identity_key` is provided, but the user identity doesn't exist, a new user identity will be created automatically using information from the ACS user.",
         operationId: 'userIdentitiesAddAcsUserPut',
         requestBody: {
           content: {
@@ -81748,7 +81748,7 @@ const openapi: OpenAPISpec = {
     '/user_identities/create': {
       post: {
         description:
-          'Creates a new [user identity](https://docs.seam.co/latest/capability-guides/mobile-access/managing-mobile-app-user-accounts-with-user-identities#what-is-a-user-identity).',
+          'Creates a new [user identity](https://docs.seam.co/capability-guides/mobile-access/managing-mobile-app-user-accounts-with-user-identities#what-is-a-user-identity).',
         operationId: 'userIdentitiesCreatePost',
         requestBody: {
           content: {
@@ -81831,7 +81831,7 @@ const openapi: OpenAPISpec = {
     '/user_identities/delete': {
       delete: {
         description:
-          'Deletes a specified [user identity](https://docs.seam.co/latest/capability-guides/mobile-access/managing-mobile-app-user-accounts-with-user-identities#what-is-a-user-identity). This deletes the user identity and all associated resources, including any [credentials](https://docs.seam.co/latest/api/acs/credentials), [acs users](https://docs.seam.co/latest/api/acs/users) and [client sessions](https://docs.seam.co/latest/api/client_sessions).',
+          'Deletes a specified [user identity](https://docs.seam.co/capability-guides/mobile-access/managing-mobile-app-user-accounts-with-user-identities#what-is-a-user-identity). This deletes the user identity and all associated resources, including any [credentials](https://docs.seam.co/api/acs/credentials), [acs users](https://docs.seam.co/api/acs/users) and [client sessions](https://docs.seam.co/api/client_sessions).',
         operationId: 'userIdentitiesDeleteDelete',
         parameters: [
           {
@@ -81875,7 +81875,7 @@ const openapi: OpenAPISpec = {
       },
       post: {
         description:
-          'Deletes a specified [user identity](https://docs.seam.co/latest/capability-guides/mobile-access/managing-mobile-app-user-accounts-with-user-identities#what-is-a-user-identity). This deletes the user identity and all associated resources, including any [credentials](https://docs.seam.co/latest/api/acs/credentials), [acs users](https://docs.seam.co/latest/api/acs/users) and [client sessions](https://docs.seam.co/latest/api/client_sessions).',
+          'Deletes a specified [user identity](https://docs.seam.co/capability-guides/mobile-access/managing-mobile-app-user-accounts-with-user-identities#what-is-a-user-identity). This deletes the user identity and all associated resources, including any [credentials](https://docs.seam.co/api/acs/credentials), [acs users](https://docs.seam.co/api/acs/users) and [client sessions](https://docs.seam.co/api/client_sessions).',
         operationId: 'userIdentitiesDeletePost',
         requestBody: {
           content: {
@@ -81927,7 +81927,7 @@ const openapi: OpenAPISpec = {
     '/user_identities/enrollment_automations/delete': {
       delete: {
         description:
-          'Deletes a specified [enrollment automation](https://docs.seam.co/latest/capability-guides/mobile-access/issuing-mobile-credentials-from-an-access-control-system). You must delete all enrollment automations associated with a [user identity](https://docs.seam.co/latest/capability-guides/mobile-access/managing-mobile-app-user-accounts-with-user-identities#what-is-a-user-identity) before [deleting the user identity](https://docs.seam.co/latest/api/user_identities/delete).',
+          'Deletes a specified [enrollment automation](https://docs.seam.co/capability-guides/mobile-access/issuing-mobile-credentials-from-an-access-control-system). You must delete all enrollment automations associated with a [user identity](https://docs.seam.co/capability-guides/mobile-access/managing-mobile-app-user-accounts-with-user-identities#what-is-a-user-identity) before [deleting the user identity](https://docs.seam.co/api/user_identities/delete).',
         operationId: 'userIdentitiesEnrollmentAutomationsDeleteDelete',
         parameters: [
           {
@@ -81973,7 +81973,7 @@ const openapi: OpenAPISpec = {
       },
       post: {
         description:
-          'Deletes a specified [enrollment automation](https://docs.seam.co/latest/capability-guides/mobile-access/issuing-mobile-credentials-from-an-access-control-system). You must delete all enrollment automations associated with a [user identity](https://docs.seam.co/latest/capability-guides/mobile-access/managing-mobile-app-user-accounts-with-user-identities#what-is-a-user-identity) before [deleting the user identity](https://docs.seam.co/latest/api/user_identities/delete).',
+          'Deletes a specified [enrollment automation](https://docs.seam.co/capability-guides/mobile-access/issuing-mobile-credentials-from-an-access-control-system). You must delete all enrollment automations associated with a [user identity](https://docs.seam.co/capability-guides/mobile-access/managing-mobile-app-user-accounts-with-user-identities#what-is-a-user-identity) before [deleting the user identity](https://docs.seam.co/api/user_identities/delete).',
         operationId: 'userIdentitiesEnrollmentAutomationsDeletePost',
         requestBody: {
           content: {
@@ -82026,7 +82026,7 @@ const openapi: OpenAPISpec = {
     '/user_identities/enrollment_automations/get': {
       get: {
         description:
-          'Returns a specified [enrollment automation](https://docs.seam.co/latest/capability-guides/mobile-access/issuing-mobile-credentials-from-an-access-control-system/).',
+          'Returns a specified [enrollment automation](https://docs.seam.co/capability-guides/mobile-access/issuing-mobile-credentials-from-an-access-control-system/).',
         operationId: 'userIdentitiesEnrollmentAutomationsGetGet',
         parameters: [
           {
@@ -82079,7 +82079,7 @@ const openapi: OpenAPISpec = {
       },
       post: {
         description:
-          'Returns a specified [enrollment automation](https://docs.seam.co/latest/capability-guides/mobile-access/issuing-mobile-credentials-from-an-access-control-system/).',
+          'Returns a specified [enrollment automation](https://docs.seam.co/capability-guides/mobile-access/issuing-mobile-credentials-from-an-access-control-system/).',
         operationId: 'userIdentitiesEnrollmentAutomationsGetPost',
         requestBody: {
           content: {
@@ -82139,7 +82139,7 @@ const openapi: OpenAPISpec = {
     '/user_identities/enrollment_automations/launch': {
       post: {
         description:
-          'Sets up a new [enrollment automation](https://docs.seam.co/latest/capability-guides/mobile-access/issuing-mobile-credentials-from-an-access-control-system) for a specified [user identity](https://docs.seam.co/latest/capability-guides/mobile-access/managing-mobile-app-user-accounts-with-user-identities#what-is-a-user-identity) with a specified [credential manager](https://docs.seam.co/latest/capability-guides/mobile-access/issuing-mobile-credentials-from-an-access-control-system).',
+          'Sets up a new [enrollment automation](https://docs.seam.co/capability-guides/mobile-access/issuing-mobile-credentials-from-an-access-control-system) for a specified [user identity](https://docs.seam.co/capability-guides/mobile-access/managing-mobile-app-user-accounts-with-user-identities#what-is-a-user-identity) with a specified [credential manager](https://docs.seam.co/capability-guides/mobile-access/issuing-mobile-credentials-from-an-access-control-system).',
         operationId: 'userIdentitiesEnrollmentAutomationsLaunchPost',
         requestBody: {
           content: {
@@ -82224,7 +82224,7 @@ const openapi: OpenAPISpec = {
     '/user_identities/enrollment_automations/list': {
       get: {
         description:
-          'Returns a list of all [enrollment automations](https://docs.seam.co/latest/capability-guides/mobile-access/issuing-mobile-credentials-from-an-access-control-system) for a specified [user identity](https://docs.seam.co/latest/capability-guides/mobile-access/managing-mobile-app-user-accounts-with-user-identities#what-is-a-user-identity).',
+          'Returns a list of all [enrollment automations](https://docs.seam.co/capability-guides/mobile-access/issuing-mobile-credentials-from-an-access-control-system) for a specified [user identity](https://docs.seam.co/capability-guides/mobile-access/managing-mobile-app-user-accounts-with-user-identities#what-is-a-user-identity).',
         operationId: 'userIdentitiesEnrollmentAutomationsListGet',
         parameters: [
           {
@@ -82280,7 +82280,7 @@ const openapi: OpenAPISpec = {
       },
       post: {
         description:
-          'Returns a list of all [enrollment automations](https://docs.seam.co/latest/capability-guides/mobile-access/issuing-mobile-credentials-from-an-access-control-system) for a specified [user identity](https://docs.seam.co/latest/capability-guides/mobile-access/managing-mobile-app-user-accounts-with-user-identities#what-is-a-user-identity).',
+          'Returns a list of all [enrollment automations](https://docs.seam.co/capability-guides/mobile-access/issuing-mobile-credentials-from-an-access-control-system) for a specified [user identity](https://docs.seam.co/capability-guides/mobile-access/managing-mobile-app-user-accounts-with-user-identities#what-is-a-user-identity).',
         operationId: 'userIdentitiesEnrollmentAutomationsListPost',
         requestBody: {
           content: {
@@ -82343,7 +82343,7 @@ const openapi: OpenAPISpec = {
     '/user_identities/generate_instant_key': {
       post: {
         description:
-          'Generates a new [instant key](https://docs.seam.co/latest/capability-guides/instant-keys) for a specified [user identity](https://docs.seam.co/latest/capability-guides/mobile-access/managing-mobile-app-user-accounts-with-user-identities#what-is-a-user-identity).',
+          'Generates a new [instant key](https://docs.seam.co/capability-guides/instant-keys) for a specified [user identity](https://docs.seam.co/capability-guides/mobile-access/managing-mobile-app-user-accounts-with-user-identities#what-is-a-user-identity).',
         operationId: 'userIdentitiesGenerateInstantKeyPost',
         requestBody: {
           content: {
@@ -82407,7 +82407,7 @@ const openapi: OpenAPISpec = {
     '/user_identities/get': {
       get: {
         description:
-          'Returns a specified [user identity](https://docs.seam.co/latest/capability-guides/mobile-access/managing-mobile-app-user-accounts-with-user-identities#what-is-a-user-identity).',
+          'Returns a specified [user identity](https://docs.seam.co/capability-guides/mobile-access/managing-mobile-app-user-accounts-with-user-identities#what-is-a-user-identity).',
         operationId: 'userIdentitiesGetGet',
         responses: {
           200: {
@@ -82446,7 +82446,7 @@ const openapi: OpenAPISpec = {
       },
       post: {
         description:
-          'Returns a specified [user identity](https://docs.seam.co/latest/capability-guides/mobile-access/managing-mobile-app-user-accounts-with-user-identities#what-is-a-user-identity).',
+          'Returns a specified [user identity](https://docs.seam.co/capability-guides/mobile-access/managing-mobile-app-user-accounts-with-user-identities#what-is-a-user-identity).',
         operationId: 'userIdentitiesGetPost',
         requestBody: {
           content: {
@@ -82514,7 +82514,7 @@ const openapi: OpenAPISpec = {
     '/user_identities/grant_access_to_device': {
       post: {
         description:
-          'Grants a specified [user identity](https://docs.seam.co/latest/capability-guides/mobile-access/managing-mobile-app-user-accounts-with-user-identities#what-is-a-user-identity) access to a specified [device](https://docs.seam.co/latest/core-concepts/devices/).',
+          'Grants a specified [user identity](https://docs.seam.co/capability-guides/mobile-access/managing-mobile-app-user-accounts-with-user-identities#what-is-a-user-identity) access to a specified [device](https://docs.seam.co/core-concepts/devices/).',
         operationId: 'userIdentitiesGrantAccessToDevicePost',
         requestBody: {
           content: {
@@ -82570,7 +82570,7 @@ const openapi: OpenAPISpec = {
       },
       put: {
         description:
-          'Grants a specified [user identity](https://docs.seam.co/latest/capability-guides/mobile-access/managing-mobile-app-user-accounts-with-user-identities#what-is-a-user-identity) access to a specified [device](https://docs.seam.co/latest/core-concepts/devices/).',
+          'Grants a specified [user identity](https://docs.seam.co/capability-guides/mobile-access/managing-mobile-app-user-accounts-with-user-identities#what-is-a-user-identity) access to a specified [device](https://docs.seam.co/core-concepts/devices/).',
         operationId: 'userIdentitiesGrantAccessToDevicePut',
         requestBody: {
           content: {
@@ -82628,7 +82628,7 @@ const openapi: OpenAPISpec = {
     '/user_identities/list': {
       get: {
         description:
-          'Returns a list of all [user identities](https://docs.seam.co/latest/capability-guides/mobile-access/managing-mobile-app-user-accounts-with-user-identities#what-is-a-user-identity).',
+          'Returns a list of all [user identities](https://docs.seam.co/capability-guides/mobile-access/managing-mobile-app-user-accounts-with-user-identities#what-is-a-user-identity).',
         operationId: 'userIdentitiesListGet',
         parameters: [
           {
@@ -82731,7 +82731,7 @@ const openapi: OpenAPISpec = {
       },
       post: {
         description:
-          'Returns a list of all [user identities](https://docs.seam.co/latest/capability-guides/mobile-access/managing-mobile-app-user-accounts-with-user-identities#what-is-a-user-identity).',
+          'Returns a list of all [user identities](https://docs.seam.co/capability-guides/mobile-access/managing-mobile-app-user-accounts-with-user-identities#what-is-a-user-identity).',
         operationId: 'userIdentitiesListPost',
         requestBody: {
           content: {
@@ -82822,7 +82822,7 @@ const openapi: OpenAPISpec = {
     '/user_identities/list_accessible_devices': {
       get: {
         description:
-          'Returns a list of all [devices](https://docs.seam.co/latest/core-concepts/devices) associated with a specified [user identity](https://docs.seam.co/latest/capability-guides/mobile-access/managing-mobile-app-user-accounts-with-user-identities#what-is-a-user-identity). This includes devices derived from the access grants assigned to the user identity and devices directly linked to the user identity.',
+          'Returns a list of all [devices](https://docs.seam.co/core-concepts/devices) associated with a specified [user identity](https://docs.seam.co/capability-guides/mobile-access/managing-mobile-app-user-accounts-with-user-identities#what-is-a-user-identity). This includes devices derived from the access grants assigned to the user identity and devices directly linked to the user identity.',
         operationId: 'userIdentitiesListAccessibleDevicesGet',
         parameters: [
           {
@@ -82880,7 +82880,7 @@ const openapi: OpenAPISpec = {
       },
       post: {
         description:
-          'Returns a list of all [devices](https://docs.seam.co/latest/core-concepts/devices) associated with a specified [user identity](https://docs.seam.co/latest/capability-guides/mobile-access/managing-mobile-app-user-accounts-with-user-identities#what-is-a-user-identity). This includes devices derived from the access grants assigned to the user identity and devices directly linked to the user identity.',
+          'Returns a list of all [devices](https://docs.seam.co/core-concepts/devices) associated with a specified [user identity](https://docs.seam.co/capability-guides/mobile-access/managing-mobile-app-user-accounts-with-user-identities#what-is-a-user-identity). This includes devices derived from the access grants assigned to the user identity and devices directly linked to the user identity.',
         operationId: 'userIdentitiesListAccessibleDevicesPost',
         requestBody: {
           content: {
@@ -82945,7 +82945,7 @@ const openapi: OpenAPISpec = {
     '/user_identities/list_accessible_entrances': {
       get: {
         description:
-          'Returns a list of all [ACS entrances](https://docs.seam.co/latest/api/acs/entrances) accessible to a specified [user identity](https://docs.seam.co/latest/capability-guides/mobile-access/managing-mobile-app-user-accounts-with-user-identities#what-is-a-user-identity). This includes entrances derived from the access grants assigned to the user identity and entrances accessible through ACS users linked to the user identity.',
+          'Returns a list of all [ACS entrances](https://docs.seam.co/api/acs/entrances) accessible to a specified [user identity](https://docs.seam.co/capability-guides/mobile-access/managing-mobile-app-user-accounts-with-user-identities#what-is-a-user-identity). This includes entrances derived from the access grants assigned to the user identity and entrances accessible through ACS users linked to the user identity.',
         operationId: 'userIdentitiesListAccessibleEntrancesGet',
         parameters: [
           {
@@ -82998,7 +82998,7 @@ const openapi: OpenAPISpec = {
       },
       post: {
         description:
-          'Returns a list of all [ACS entrances](https://docs.seam.co/latest/api/acs/entrances) accessible to a specified [user identity](https://docs.seam.co/latest/capability-guides/mobile-access/managing-mobile-app-user-accounts-with-user-identities#what-is-a-user-identity). This includes entrances derived from the access grants assigned to the user identity and entrances accessible through ACS users linked to the user identity.',
+          'Returns a list of all [ACS entrances](https://docs.seam.co/api/acs/entrances) accessible to a specified [user identity](https://docs.seam.co/capability-guides/mobile-access/managing-mobile-app-user-accounts-with-user-identities#what-is-a-user-identity). This includes entrances derived from the access grants assigned to the user identity and entrances accessible through ACS users linked to the user identity.',
         operationId: 'userIdentitiesListAccessibleEntrancesPost',
         requestBody: {
           content: {
@@ -83058,7 +83058,7 @@ const openapi: OpenAPISpec = {
     '/user_identities/list_acs_systems': {
       get: {
         description:
-          'Returns a list of all [access systems](https://docs.seam.co/latest/capability-guides/access-systems) associated with a specified [user identity](https://docs.seam.co/latest/capability-guides/mobile-access/managing-mobile-app-user-accounts-with-user-identities#what-is-a-user-identity).',
+          'Returns a list of all [access systems](https://docs.seam.co/capability-guides/access-systems) associated with a specified [user identity](https://docs.seam.co/capability-guides/mobile-access/managing-mobile-app-user-accounts-with-user-identities#what-is-a-user-identity).',
         operationId: 'userIdentitiesListAcsSystemsGet',
         parameters: [
           {
@@ -83111,7 +83111,7 @@ const openapi: OpenAPISpec = {
       },
       post: {
         description:
-          'Returns a list of all [access systems](https://docs.seam.co/latest/capability-guides/access-systems) associated with a specified [user identity](https://docs.seam.co/latest/capability-guides/mobile-access/managing-mobile-app-user-accounts-with-user-identities#what-is-a-user-identity).',
+          'Returns a list of all [access systems](https://docs.seam.co/capability-guides/access-systems) associated with a specified [user identity](https://docs.seam.co/capability-guides/mobile-access/managing-mobile-app-user-accounts-with-user-identities#what-is-a-user-identity).',
         operationId: 'userIdentitiesListAcsSystemsPost',
         requestBody: {
           content: {
@@ -83171,7 +83171,7 @@ const openapi: OpenAPISpec = {
     '/user_identities/list_acs_users': {
       get: {
         description:
-          'Returns a list of all [access system users](https://docs.seam.co/latest/capability-guides/access-systems/user-management) assigned to a specified [user identity](https://docs.seam.co/latest/capability-guides/mobile-access/managing-mobile-app-user-accounts-with-user-identities#what-is-a-user-identity).',
+          'Returns a list of all [access system users](https://docs.seam.co/capability-guides/access-systems/user-management) assigned to a specified [user identity](https://docs.seam.co/capability-guides/mobile-access/managing-mobile-app-user-accounts-with-user-identities#what-is-a-user-identity).',
         operationId: 'userIdentitiesListAcsUsersGet',
         parameters: [
           {
@@ -83223,7 +83223,7 @@ const openapi: OpenAPISpec = {
       },
       post: {
         description:
-          'Returns a list of all [access system users](https://docs.seam.co/latest/capability-guides/access-systems/user-management) assigned to a specified [user identity](https://docs.seam.co/latest/capability-guides/mobile-access/managing-mobile-app-user-accounts-with-user-identities#what-is-a-user-identity).',
+          'Returns a list of all [access system users](https://docs.seam.co/capability-guides/access-systems/user-management) assigned to a specified [user identity](https://docs.seam.co/capability-guides/mobile-access/managing-mobile-app-user-accounts-with-user-identities#what-is-a-user-identity).',
         operationId: 'userIdentitiesListAcsUsersPost',
         requestBody: {
           content: {
@@ -83282,7 +83282,7 @@ const openapi: OpenAPISpec = {
     '/user_identities/remove_acs_user': {
       delete: {
         description:
-          'Removes a specified [access system user](https://docs.seam.co/latest/capability-guides/access-systems/user-management) from a specified [user identity](https://docs.seam.co/latest/capability-guides/mobile-access/managing-mobile-app-user-accounts-with-user-identities#what-is-a-user-identity).',
+          'Removes a specified [access system user](https://docs.seam.co/capability-guides/access-systems/user-management) from a specified [user identity](https://docs.seam.co/capability-guides/mobile-access/managing-mobile-app-user-accounts-with-user-identities#what-is-a-user-identity).',
         operationId: 'userIdentitiesRemoveAcsUserDelete',
         parameters: [
           {
@@ -83338,7 +83338,7 @@ const openapi: OpenAPISpec = {
       },
       post: {
         description:
-          'Removes a specified [access system user](https://docs.seam.co/latest/capability-guides/access-systems/user-management) from a specified [user identity](https://docs.seam.co/latest/capability-guides/mobile-access/managing-mobile-app-user-accounts-with-user-identities#what-is-a-user-identity).',
+          'Removes a specified [access system user](https://docs.seam.co/capability-guides/access-systems/user-management) from a specified [user identity](https://docs.seam.co/capability-guides/mobile-access/managing-mobile-app-user-accounts-with-user-identities#what-is-a-user-identity).',
         operationId: 'userIdentitiesRemoveAcsUserPost',
         requestBody: {
           content: {
@@ -83396,7 +83396,7 @@ const openapi: OpenAPISpec = {
     '/user_identities/revoke_access_to_device': {
       delete: {
         description:
-          'Revokes access to a specified [device](https://docs.seam.co/latest/core-concepts/devices/) from a specified [user identity](https://docs.seam.co/latest/capability-guides/mobile-access/managing-mobile-app-user-accounts-with-user-identities#what-is-a-user-identity).',
+          'Revokes access to a specified [device](https://docs.seam.co/core-concepts/devices/) from a specified [user identity](https://docs.seam.co/capability-guides/mobile-access/managing-mobile-app-user-accounts-with-user-identities#what-is-a-user-identity).',
         operationId: 'userIdentitiesRevokeAccessToDeviceDelete',
         parameters: [
           {
@@ -83452,7 +83452,7 @@ const openapi: OpenAPISpec = {
       },
       post: {
         description:
-          'Revokes access to a specified [device](https://docs.seam.co/latest/core-concepts/devices/) from a specified [user identity](https://docs.seam.co/latest/capability-guides/mobile-access/managing-mobile-app-user-accounts-with-user-identities#what-is-a-user-identity).',
+          'Revokes access to a specified [device](https://docs.seam.co/core-concepts/devices/) from a specified [user identity](https://docs.seam.co/capability-guides/mobile-access/managing-mobile-app-user-accounts-with-user-identities#what-is-a-user-identity).',
         operationId: 'userIdentitiesRevokeAccessToDevicePost',
         requestBody: {
           content: {
@@ -83510,7 +83510,7 @@ const openapi: OpenAPISpec = {
     '/user_identities/unmanaged/get': {
       get: {
         description:
-          'Returns a specified unmanaged [user identity](https://docs.seam.co/latest/capability-guides/mobile-access/managing-mobile-app-user-accounts-with-user-identities#what-is-a-user-identity) (where is_managed = false).',
+          'Returns a specified unmanaged [user identity](https://docs.seam.co/capability-guides/mobile-access/managing-mobile-app-user-accounts-with-user-identities#what-is-a-user-identity) (where is_managed = false).',
         operationId: 'userIdentitiesUnmanagedGetGet',
         parameters: [
           {
@@ -83701,7 +83701,7 @@ const openapi: OpenAPISpec = {
                         },
                         workspace_id: {
                           description:
-                            'ID of the [workspace](https://docs.seam.co/latest/core-concepts/workspaces) that contains the user identity.',
+                            'ID of the [workspace](https://docs.seam.co/core-concepts/workspaces) that contains the user identity.',
                           format: 'uuid',
                           type: 'string',
                         },
@@ -83748,7 +83748,7 @@ const openapi: OpenAPISpec = {
       },
       post: {
         description:
-          'Returns a specified unmanaged [user identity](https://docs.seam.co/latest/capability-guides/mobile-access/managing-mobile-app-user-accounts-with-user-identities#what-is-a-user-identity) (where is_managed = false).',
+          'Returns a specified unmanaged [user identity](https://docs.seam.co/capability-guides/mobile-access/managing-mobile-app-user-accounts-with-user-identities#what-is-a-user-identity) (where is_managed = false).',
         operationId: 'userIdentitiesUnmanagedGetPost',
         requestBody: {
           content: {
@@ -83944,7 +83944,7 @@ const openapi: OpenAPISpec = {
                         },
                         workspace_id: {
                           description:
-                            'ID of the [workspace](https://docs.seam.co/latest/core-concepts/workspaces) that contains the user identity.',
+                            'ID of the [workspace](https://docs.seam.co/core-concepts/workspaces) that contains the user identity.',
                           format: 'uuid',
                           type: 'string',
                         },
@@ -83993,7 +83993,7 @@ const openapi: OpenAPISpec = {
     '/user_identities/unmanaged/list': {
       get: {
         description:
-          'Returns a list of all unmanaged [user identities](https://docs.seam.co/latest/capability-guides/mobile-access/managing-mobile-app-user-accounts-with-user-identities#what-is-a-user-identity) (where is_managed = false).',
+          'Returns a list of all unmanaged [user identities](https://docs.seam.co/capability-guides/mobile-access/managing-mobile-app-user-accounts-with-user-identities#what-is-a-user-identity) (where is_managed = false).',
         operationId: 'userIdentitiesUnmanagedListGet',
         parameters: [
           {
@@ -84215,7 +84215,7 @@ const openapi: OpenAPISpec = {
                           },
                           workspace_id: {
                             description:
-                              'ID of the [workspace](https://docs.seam.co/latest/core-concepts/workspaces) that contains the user identity.',
+                              'ID of the [workspace](https://docs.seam.co/core-concepts/workspaces) that contains the user identity.',
                             format: 'uuid',
                             type: 'string',
                           },
@@ -84265,7 +84265,7 @@ const openapi: OpenAPISpec = {
       },
       post: {
         description:
-          'Returns a list of all unmanaged [user identities](https://docs.seam.co/latest/capability-guides/mobile-access/managing-mobile-app-user-accounts-with-user-identities#what-is-a-user-identity) (where is_managed = false).',
+          'Returns a list of all unmanaged [user identities](https://docs.seam.co/capability-guides/mobile-access/managing-mobile-app-user-accounts-with-user-identities#what-is-a-user-identity) (where is_managed = false).',
         operationId: 'userIdentitiesUnmanagedListPost',
         requestBody: {
           content: {
@@ -84481,7 +84481,7 @@ const openapi: OpenAPISpec = {
                           },
                           workspace_id: {
                             description:
-                              'ID of the [workspace](https://docs.seam.co/latest/core-concepts/workspaces) that contains the user identity.',
+                              'ID of the [workspace](https://docs.seam.co/core-concepts/workspaces) that contains the user identity.',
                             format: 'uuid',
                             type: 'string',
                           },
@@ -84533,7 +84533,7 @@ const openapi: OpenAPISpec = {
     '/user_identities/unmanaged/update': {
       patch: {
         description:
-          'Updates an unmanaged [user identity](https://docs.seam.co/latest/capability-guides/mobile-access/managing-mobile-app-user-accounts-with-user-identities#what-is-a-user-identity) to make it managed.\n\nThis endpoint can only be used to convert unmanaged user identities to managed ones by setting `is_managed` to `true`. It cannot be used to convert managed user identities back to unmanaged.',
+          'Updates an unmanaged [user identity](https://docs.seam.co/capability-guides/mobile-access/managing-mobile-app-user-accounts-with-user-identities#what-is-a-user-identity) to make it managed.\n\nThis endpoint can only be used to convert unmanaged user identities to managed ones by setting `is_managed` to `true`. It cannot be used to convert managed user identities back to unmanaged.',
         operationId: 'userIdentitiesUnmanagedUpdatePatch',
         requestBody: {
           content: {
@@ -84595,7 +84595,7 @@ const openapi: OpenAPISpec = {
       },
       post: {
         description:
-          'Updates an unmanaged [user identity](https://docs.seam.co/latest/capability-guides/mobile-access/managing-mobile-app-user-accounts-with-user-identities#what-is-a-user-identity) to make it managed.\n\nThis endpoint can only be used to convert unmanaged user identities to managed ones by setting `is_managed` to `true`. It cannot be used to convert managed user identities back to unmanaged.',
+          'Updates an unmanaged [user identity](https://docs.seam.co/capability-guides/mobile-access/managing-mobile-app-user-accounts-with-user-identities#what-is-a-user-identity) to make it managed.\n\nThis endpoint can only be used to convert unmanaged user identities to managed ones by setting `is_managed` to `true`. It cannot be used to convert managed user identities back to unmanaged.',
         operationId: 'userIdentitiesUnmanagedUpdatePost',
         requestBody: {
           content: {
@@ -84659,7 +84659,7 @@ const openapi: OpenAPISpec = {
     '/user_identities/update': {
       patch: {
         description:
-          'Updates a specified [user identity](https://docs.seam.co/latest/capability-guides/mobile-access/managing-mobile-app-user-accounts-with-user-identities#what-is-a-user-identity).',
+          'Updates a specified [user identity](https://docs.seam.co/capability-guides/mobile-access/managing-mobile-app-user-accounts-with-user-identities#what-is-a-user-identity).',
         operationId: 'userIdentitiesUpdatePatch',
         requestBody: {
           content: {
@@ -84733,7 +84733,7 @@ const openapi: OpenAPISpec = {
       },
       post: {
         description:
-          'Updates a specified [user identity](https://docs.seam.co/latest/capability-guides/mobile-access/managing-mobile-app-user-accounts-with-user-identities#what-is-a-user-identity).',
+          'Updates a specified [user identity](https://docs.seam.co/capability-guides/mobile-access/managing-mobile-app-user-accounts-with-user-identities#what-is-a-user-identity).',
         operationId: 'userIdentitiesUpdatePost',
         requestBody: {
           content: {
@@ -84809,7 +84809,7 @@ const openapi: OpenAPISpec = {
     '/webhooks/create': {
       post: {
         description:
-          'Creates a new [webhook](https://docs.seam.co/latest/developer-tools/webhooks).',
+          'Creates a new [webhook](https://docs.seam.co/developer-tools/webhooks).',
         operationId: 'webhooksCreatePost',
         requestBody: {
           content: {
@@ -84871,7 +84871,7 @@ const openapi: OpenAPISpec = {
     '/webhooks/delete': {
       delete: {
         description:
-          'Deletes a specified [webhook](https://docs.seam.co/latest/developer-tools/webhooks).',
+          'Deletes a specified [webhook](https://docs.seam.co/developer-tools/webhooks).',
         operationId: 'webhooksDeleteDelete',
         parameters: [
           {
@@ -84914,7 +84914,7 @@ const openapi: OpenAPISpec = {
       },
       post: {
         description:
-          'Deletes a specified [webhook](https://docs.seam.co/latest/developer-tools/webhooks).',
+          'Deletes a specified [webhook](https://docs.seam.co/developer-tools/webhooks).',
         operationId: 'webhooksDeletePost',
         requestBody: {
           content: {
@@ -84964,7 +84964,7 @@ const openapi: OpenAPISpec = {
     '/webhooks/get': {
       get: {
         description:
-          'Gets a specified [webhook](https://docs.seam.co/latest/developer-tools/webhooks).',
+          'Gets a specified [webhook](https://docs.seam.co/developer-tools/webhooks).',
         operationId: 'webhooksGetGet',
         parameters: [
           {
@@ -85011,7 +85011,7 @@ const openapi: OpenAPISpec = {
       },
       post: {
         description:
-          'Gets a specified [webhook](https://docs.seam.co/latest/developer-tools/webhooks).',
+          'Gets a specified [webhook](https://docs.seam.co/developer-tools/webhooks).',
         operationId: 'webhooksGetPost',
         requestBody: {
           content: {
@@ -85065,7 +85065,7 @@ const openapi: OpenAPISpec = {
     '/webhooks/list': {
       get: {
         description:
-          'Returns a list of all [webhooks](https://docs.seam.co/latest/developer-tools/webhooks).',
+          'Returns a list of all [webhooks](https://docs.seam.co/developer-tools/webhooks).',
         operationId: 'webhooksListGet',
         responses: {
           200: {
@@ -85104,7 +85104,7 @@ const openapi: OpenAPISpec = {
       },
       post: {
         description:
-          'Returns a list of all [webhooks](https://docs.seam.co/latest/developer-tools/webhooks).',
+          'Returns a list of all [webhooks](https://docs.seam.co/developer-tools/webhooks).',
         operationId: 'webhooksListPost',
         responses: {
           200: {
@@ -85145,7 +85145,7 @@ const openapi: OpenAPISpec = {
     '/webhooks/update': {
       post: {
         description:
-          'Updates a specified [webhook](https://docs.seam.co/latest/developer-tools/webhooks).',
+          'Updates a specified [webhook](https://docs.seam.co/developer-tools/webhooks).',
         operationId: 'webhooksUpdatePost',
         requestBody: {
           content: {
@@ -85199,7 +85199,7 @@ const openapi: OpenAPISpec = {
       },
       put: {
         description:
-          'Updates a specified [webhook](https://docs.seam.co/latest/developer-tools/webhooks).',
+          'Updates a specified [webhook](https://docs.seam.co/developer-tools/webhooks).',
         operationId: 'webhooksUpdatePut',
         requestBody: {
           content: {
@@ -85255,7 +85255,7 @@ const openapi: OpenAPISpec = {
     '/workspaces/create': {
       post: {
         description:
-          'Creates a new [workspace](https://docs.seam.co/latest/core-concepts/workspaces).',
+          'Creates a new [workspace](https://docs.seam.co/core-concepts/workspaces).',
         operationId: 'workspacesCreatePost',
         requestBody: {
           content: {
@@ -85275,30 +85275,30 @@ const openapi: OpenAPISpec = {
                   },
                   connect_webview_customization: {
                     description:
-                      '[Connect Webview](https://docs.seam.co/latest/core-concepts/connect-webviews) customizations for the new workspace. See also [Customize the Look and Feel of Your Connect Webviews](https://docs.seam.co/latest/core-concepts/connect-webviews/customizing-connect-webviews#customize-the-look-and-feel-of-your-connect-webviews).',
+                      '[Connect Webview](https://docs.seam.co/core-concepts/connect-webviews) customizations for the new workspace. See also [Customize the Look and Feel of Your Connect Webviews](https://docs.seam.co/core-concepts/connect-webviews/customizing-connect-webviews#customize-the-look-and-feel-of-your-connect-webviews).',
                     properties: {
                       logo_shape: {
                         description:
-                          'Logo shape for [Connect Webviews](https://docs.seam.co/latest/core-concepts/connect-webviews) in the new workspace. See also [Customize the Look and Feel of Your Connect Webviews](https://docs.seam.co/latest/core-concepts/connect-webviews/customizing-connect-webviews#customize-the-look-and-feel-of-your-connect-webviews).',
+                          'Logo shape for [Connect Webviews](https://docs.seam.co/core-concepts/connect-webviews) in the new workspace. See also [Customize the Look and Feel of Your Connect Webviews](https://docs.seam.co/core-concepts/connect-webviews/customizing-connect-webviews#customize-the-look-and-feel-of-your-connect-webviews).',
                         enum: ['circle', 'square'],
                         nullable: true,
                         type: 'string',
                       },
                       primary_button_color: {
                         description:
-                          'Primary button color for [Connect Webviews](https://docs.seam.co/latest/core-concepts/connect-webviews) in the new workspace. See also [Customize the Look and Feel of Your Connect Webviews](https://docs.seam.co/latest/core-concepts/connect-webviews/customizing-connect-webviews#customize-the-look-and-feel-of-your-connect-webviews).',
+                          'Primary button color for [Connect Webviews](https://docs.seam.co/core-concepts/connect-webviews) in the new workspace. See also [Customize the Look and Feel of Your Connect Webviews](https://docs.seam.co/core-concepts/connect-webviews/customizing-connect-webviews#customize-the-look-and-feel-of-your-connect-webviews).',
                         nullable: true,
                         type: 'string',
                       },
                       primary_button_text_color: {
                         description:
-                          'Primary button text color for [Connect Webviews](https://docs.seam.co/latest/core-concepts/connect-webviews) in the new workspace. See also [Customize the Look and Feel of Your Connect Webviews](https://docs.seam.co/latest/core-concepts/connect-webviews/customizing-connect-webviews#customize-the-look-and-feel-of-your-connect-webviews).',
+                          'Primary button text color for [Connect Webviews](https://docs.seam.co/core-concepts/connect-webviews) in the new workspace. See also [Customize the Look and Feel of Your Connect Webviews](https://docs.seam.co/core-concepts/connect-webviews/customizing-connect-webviews#customize-the-look-and-feel-of-your-connect-webviews).',
                         nullable: true,
                         type: 'string',
                       },
                       success_message: {
                         description:
-                          'Success message for [Connect Webviews](https://docs.seam.co/latest/core-concepts/connect-webviews) in the new workspace. See also [Customize the Look and Feel of Your Connect Webviews](https://docs.seam.co/latest/core-concepts/connect-webviews/customizing-connect-webviews#customize-the-look-and-feel-of-your-connect-webviews).',
+                          'Success message for [Connect Webviews](https://docs.seam.co/core-concepts/connect-webviews) in the new workspace. See also [Customize the Look and Feel of Your Connect Webviews](https://docs.seam.co/core-concepts/connect-webviews/customizing-connect-webviews#customize-the-look-and-feel-of-your-connect-webviews).',
                         nullable: true,
                         type: 'string',
                       },
@@ -85308,7 +85308,7 @@ const openapi: OpenAPISpec = {
                   is_sandbox: {
                     default: false,
                     description:
-                      'Indicates whether the new workspace is a [sandbox workspace](https://docs.seam.co/latest/core-concepts/workspaces#sandbox-workspaces).',
+                      'Indicates whether the new workspace is a [sandbox workspace](https://docs.seam.co/core-concepts/workspaces#sandbox-workspaces).',
                     type: 'boolean',
                   },
                   name: {
@@ -86272,7 +86272,7 @@ const openapi: OpenAPISpec = {
     '/workspaces/get': {
       get: {
         description:
-          'Returns the [workspace](https://docs.seam.co/latest/core-concepts/workspaces) associated with the authentication value.',
+          'Returns the [workspace](https://docs.seam.co/core-concepts/workspaces) associated with the authentication value.',
         operationId: 'workspacesGetGet',
         responses: {
           200: {
@@ -86310,7 +86310,7 @@ const openapi: OpenAPISpec = {
       },
       post: {
         description:
-          'Returns the [workspace](https://docs.seam.co/latest/core-concepts/workspaces) associated with the authentication value.',
+          'Returns the [workspace](https://docs.seam.co/core-concepts/workspaces) associated with the authentication value.',
         operationId: 'workspacesGetPost',
         responses: {
           200: {
@@ -86350,7 +86350,7 @@ const openapi: OpenAPISpec = {
     '/workspaces/list': {
       get: {
         description:
-          'Returns a list of [workspaces](https://docs.seam.co/latest/core-concepts/workspaces) associated with the authentication value.',
+          'Returns a list of [workspaces](https://docs.seam.co/core-concepts/workspaces) associated with the authentication value.',
         operationId: 'workspacesListGet',
         responses: {
           200: {
@@ -86392,7 +86392,7 @@ const openapi: OpenAPISpec = {
       },
       post: {
         description:
-          'Returns a list of [workspaces](https://docs.seam.co/latest/core-concepts/workspaces) associated with the authentication value.',
+          'Returns a list of [workspaces](https://docs.seam.co/core-concepts/workspaces) associated with the authentication value.',
         operationId: 'workspacesListPost',
         responses: {
           200: {
@@ -86436,7 +86436,7 @@ const openapi: OpenAPISpec = {
     '/workspaces/reset_sandbox': {
       post: {
         description:
-          'Resets the [sandbox workspace](https://docs.seam.co/latest/core-concepts/workspaces#sandbox-workspaces) associated with the authentication value. Note that this endpoint is only available for sandbox workspaces.',
+          'Resets the [sandbox workspace](https://docs.seam.co/core-concepts/workspaces#sandbox-workspaces) associated with the authentication value. Note that this endpoint is only available for sandbox workspaces.',
         operationId: 'workspacesResetSandboxPost',
         responses: {
           200: {
@@ -86477,7 +86477,7 @@ const openapi: OpenAPISpec = {
     '/workspaces/update': {
       patch: {
         description:
-          'Updates the [workspace](https://docs.seam.co/latest/core-concepts/workspaces) associated with the authentication value.',
+          'Updates the [workspace](https://docs.seam.co/core-concepts/workspaces) associated with the authentication value.',
         operationId: 'workspacesUpdatePatch',
         requestBody: {
           content: {
@@ -86490,30 +86490,30 @@ const openapi: OpenAPISpec = {
                   },
                   connect_webview_customization: {
                     description:
-                      '[Connect Webview](https://docs.seam.co/latest/core-concepts/connect-webviews) customizations for the workspace. See also [Customize the Look and Feel of Your Connect Webviews](https://docs.seam.co/latest/core-concepts/connect-webviews/customizing-connect-webviews#customize-the-look-and-feel-of-your-connect-webviews).',
+                      '[Connect Webview](https://docs.seam.co/core-concepts/connect-webviews) customizations for the workspace. See also [Customize the Look and Feel of Your Connect Webviews](https://docs.seam.co/core-concepts/connect-webviews/customizing-connect-webviews#customize-the-look-and-feel-of-your-connect-webviews).',
                     properties: {
                       logo_shape: {
                         description:
-                          'Logo shape for [Connect Webviews](https://docs.seam.co/latest/core-concepts/connect-webviews) in the workspace. See also [Customize the Look and Feel of Your Connect Webviews](https://docs.seam.co/latest/core-concepts/connect-webviews/customizing-connect-webviews#customize-the-look-and-feel-of-your-connect-webviews).',
+                          'Logo shape for [Connect Webviews](https://docs.seam.co/core-concepts/connect-webviews) in the workspace. See also [Customize the Look and Feel of Your Connect Webviews](https://docs.seam.co/core-concepts/connect-webviews/customizing-connect-webviews#customize-the-look-and-feel-of-your-connect-webviews).',
                         enum: ['circle', 'square'],
                         nullable: true,
                         type: 'string',
                       },
                       primary_button_color: {
                         description:
-                          'Primary button color for [Connect Webviews](https://docs.seam.co/latest/core-concepts/connect-webviews) in the workspace. See also [Customize the Look and Feel of Your Connect Webviews](https://docs.seam.co/latest/core-concepts/connect-webviews/customizing-connect-webviews#customize-the-look-and-feel-of-your-connect-webviews).',
+                          'Primary button color for [Connect Webviews](https://docs.seam.co/core-concepts/connect-webviews) in the workspace. See also [Customize the Look and Feel of Your Connect Webviews](https://docs.seam.co/core-concepts/connect-webviews/customizing-connect-webviews#customize-the-look-and-feel-of-your-connect-webviews).',
                         nullable: true,
                         type: 'string',
                       },
                       primary_button_text_color: {
                         description:
-                          'Primary button text color for [Connect Webviews](https://docs.seam.co/latest/core-concepts/connect-webviews) in the workspace. See also [Customize the Look and Feel of Your Connect Webviews](https://docs.seam.co/latest/core-concepts/connect-webviews/customizing-connect-webviews#customize-the-look-and-feel-of-your-connect-webviews).',
+                          'Primary button text color for [Connect Webviews](https://docs.seam.co/core-concepts/connect-webviews) in the workspace. See also [Customize the Look and Feel of Your Connect Webviews](https://docs.seam.co/core-concepts/connect-webviews/customizing-connect-webviews#customize-the-look-and-feel-of-your-connect-webviews).',
                         nullable: true,
                         type: 'string',
                       },
                       success_message: {
                         description:
-                          'Success message for [Connect Webviews](https://docs.seam.co/latest/core-concepts/connect-webviews) in the workspace. See also [Customize the Look and Feel of Your Connect Webviews](https://docs.seam.co/latest/core-concepts/connect-webviews/customizing-connect-webviews#customize-the-look-and-feel-of-your-connect-webviews).',
+                          'Success message for [Connect Webviews](https://docs.seam.co/core-concepts/connect-webviews) in the workspace. See also [Customize the Look and Feel of Your Connect Webviews](https://docs.seam.co/core-concepts/connect-webviews/customizing-connect-webviews#customize-the-look-and-feel-of-your-connect-webviews).',
                         nullable: true,
                         type: 'string',
                       },
@@ -86559,7 +86559,7 @@ const openapi: OpenAPISpec = {
       },
       post: {
         description:
-          'Updates the [workspace](https://docs.seam.co/latest/core-concepts/workspaces) associated with the authentication value.',
+          'Updates the [workspace](https://docs.seam.co/core-concepts/workspaces) associated with the authentication value.',
         operationId: 'workspacesUpdatePost',
         requestBody: {
           content: {
@@ -86572,30 +86572,30 @@ const openapi: OpenAPISpec = {
                   },
                   connect_webview_customization: {
                     description:
-                      '[Connect Webview](https://docs.seam.co/latest/core-concepts/connect-webviews) customizations for the workspace. See also [Customize the Look and Feel of Your Connect Webviews](https://docs.seam.co/latest/core-concepts/connect-webviews/customizing-connect-webviews#customize-the-look-and-feel-of-your-connect-webviews).',
+                      '[Connect Webview](https://docs.seam.co/core-concepts/connect-webviews) customizations for the workspace. See also [Customize the Look and Feel of Your Connect Webviews](https://docs.seam.co/core-concepts/connect-webviews/customizing-connect-webviews#customize-the-look-and-feel-of-your-connect-webviews).',
                     properties: {
                       logo_shape: {
                         description:
-                          'Logo shape for [Connect Webviews](https://docs.seam.co/latest/core-concepts/connect-webviews) in the workspace. See also [Customize the Look and Feel of Your Connect Webviews](https://docs.seam.co/latest/core-concepts/connect-webviews/customizing-connect-webviews#customize-the-look-and-feel-of-your-connect-webviews).',
+                          'Logo shape for [Connect Webviews](https://docs.seam.co/core-concepts/connect-webviews) in the workspace. See also [Customize the Look and Feel of Your Connect Webviews](https://docs.seam.co/core-concepts/connect-webviews/customizing-connect-webviews#customize-the-look-and-feel-of-your-connect-webviews).',
                         enum: ['circle', 'square'],
                         nullable: true,
                         type: 'string',
                       },
                       primary_button_color: {
                         description:
-                          'Primary button color for [Connect Webviews](https://docs.seam.co/latest/core-concepts/connect-webviews) in the workspace. See also [Customize the Look and Feel of Your Connect Webviews](https://docs.seam.co/latest/core-concepts/connect-webviews/customizing-connect-webviews#customize-the-look-and-feel-of-your-connect-webviews).',
+                          'Primary button color for [Connect Webviews](https://docs.seam.co/core-concepts/connect-webviews) in the workspace. See also [Customize the Look and Feel of Your Connect Webviews](https://docs.seam.co/core-concepts/connect-webviews/customizing-connect-webviews#customize-the-look-and-feel-of-your-connect-webviews).',
                         nullable: true,
                         type: 'string',
                       },
                       primary_button_text_color: {
                         description:
-                          'Primary button text color for [Connect Webviews](https://docs.seam.co/latest/core-concepts/connect-webviews) in the workspace. See also [Customize the Look and Feel of Your Connect Webviews](https://docs.seam.co/latest/core-concepts/connect-webviews/customizing-connect-webviews#customize-the-look-and-feel-of-your-connect-webviews).',
+                          'Primary button text color for [Connect Webviews](https://docs.seam.co/core-concepts/connect-webviews) in the workspace. See also [Customize the Look and Feel of Your Connect Webviews](https://docs.seam.co/core-concepts/connect-webviews/customizing-connect-webviews#customize-the-look-and-feel-of-your-connect-webviews).',
                         nullable: true,
                         type: 'string',
                       },
                       success_message: {
                         description:
-                          'Success message for [Connect Webviews](https://docs.seam.co/latest/core-concepts/connect-webviews) in the workspace. See also [Customize the Look and Feel of Your Connect Webviews](https://docs.seam.co/latest/core-concepts/connect-webviews/customizing-connect-webviews#customize-the-look-and-feel-of-your-connect-webviews).',
+                          'Success message for [Connect Webviews](https://docs.seam.co/core-concepts/connect-webviews) in the workspace. See also [Customize the Look and Feel of Your Connect Webviews](https://docs.seam.co/core-concepts/connect-webviews/customizing-connect-webviews#customize-the-look-and-feel-of-your-connect-webviews).',
                         nullable: true,
                         type: 'string',
                       },


### PR DESCRIPTION
## Summary

Replaces every occurrence of the literal substring `docs.seam.co/latest` with `docs.seam.co` in `description` fields across the TypeScript source (12,073 occurrences in 54 files under `src/`).

This supports the Seam docs GitBook → Mintlify migration: GitBook served the docs at `https://docs.seam.co/latest/…`, while Mintlify serves them at the root `https://docs.seam.co/…`. The docs site 301-redirects old `/latest` URLs, but the canonical references embedded in this package's schema/model/endpoint descriptions should point at the clean URLs directly, since they flow into the generated OpenAPI spec and the public API reference.

URLs remain absolute (`https://docs.seam.co/…`) because these descriptions are consumed in non-docs contexts where a host is required. No paths were remapped — relocated sections are handled by the docs site's redirects.

## Verification

- `grep -rn 'docs.seam.co/latest' src` returns nothing
- `npm run build`, `npm run typecheck`, and `npm run lint` (ESLint + Prettier) all pass
- `npm run blueprint` generates cleanly with zero `/latest` links in the output
- Spot-checked built output (`index.js`, `connect.js`, `lib/`): links read `https://docs.seam.co/<path>`
- Every changed line in the diff contains `docs.seam.co` — no other content was modified

## Follow-up

Once released, the `seamapi/docs` repo will bump `@seamapi/types` and regenerate so the generated API pages become `/latest`-free.

https://claude.ai/code/session_01BYSZHagNcCvzcij5GKXoYr

---
_Generated by [Claude Code](https://claude.ai/code/session_01BYSZHagNcCvzcij5GKXoYr)_